### PR TITLE
Set CompoundParameterTypeEditor to EditMode in the 3DViewer : Fix #385

### DIFF
--- a/COMET.Web.Common/Components/ParameterTypeEditors/ParameterTypeEditorSelector.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/ParameterTypeEditorSelector.razor
@@ -30,7 +30,7 @@
 
         case CompoundParameterType:
             <CompoundParameterTypeEditor ViewModel="this.ViewModel.CreateParameterEditorViewModel<CompoundParameterType>()"
-                             BindValueMode="@this.BindValueMode" />
+                             BindValueMode="@this.BindValueMode" IsOnEditMode=@this.IsOnEditMode />
             break;
 
         case DateParameterType:

--- a/COMET.Web.Common/Components/ParameterTypeEditors/ParameterTypeEditorSelector.razor.cs
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/ParameterTypeEditorSelector.razor.cs
@@ -47,5 +47,11 @@ namespace COMET.Web.Common.Components.ParameterTypeEditors
         /// </summary>
         [Parameter]
         public BindValueMode BindValueMode { get; set; } = BindValueMode.OnLostFocus;
+
+        /// <summary>
+        /// Indicates if confirmation popup is visible
+        /// </summary>
+        [Parameter]
+        public bool IsOnEditMode { get; set; }
     }
 }

--- a/COMETwebapp/Components/Viewer/PropertiesPanel/DetailsComponent.razor
+++ b/COMETwebapp/Components/Viewer/PropertiesPanel/DetailsComponent.razor
@@ -26,8 +26,8 @@ Copyright (c) 2023 RHEA System S.A.
             <p>@this.ViewModel.ParameterType.ShortName - [Scale]</p>
         </div>
         <div id="details-body">
-            <ParameterTypeEditorSelector ViewModel="this.ViewModel.ParameterEditorSelector" 
-                                         BindValueMode="BindValueMode.OnInput"/>
+            <ParameterTypeEditorSelector ViewModel="this.ViewModel.ParameterEditorSelector"
+                                 BindValueMode="BindValueMode.OnInput" IsOnEditMode="true" />
         </div>
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #385 

When editing an element scene in the 3DViewer the CompoundParameterType is now set to edit mode


<!-- Thanks for contributing to COMET-WEB! -->

