### PR TITLE
Feat #604 [Reference Data] refactor ParameterTypes page to be inline with measurement scales page

### DIFF
--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
@@ -31,10 +31,10 @@ Copyright (c) 2023-2024 Starion Group S.A.
                     <img src="images/comet-logo-black.png" class="data-item-details-image" alt="Comet Web"/>
                 </div>
                 
-                @if (!string.IsNullOrWhiteSpace(this.ButtonDisplayText))
+                @if (this.OnButtonClick is not null)
                 {
                     <DxButton Text="@(this.ButtonDisplayText)"
-                              Click="@(() => this.OnButtonClick?.Invoke())"
+                              Click="@(() => this.OnButtonClick.Invoke())"
                               IconCssClass="oi oi-plus"
                               RenderStyle="ButtonRenderStyle.Primary"
                               style="width: 200px;"/>

--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.cs
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.cs
@@ -44,13 +44,13 @@ namespace COMETwebapp.Components.Common
         public RenderFragment ChildContent { get; set; }
 
         /// <summary>
-        /// Gets or sets the text to be displayed in the option button. If null or empty, the button will not be displayed
+        /// Gets or sets the text to be displayed in the option button
         /// </summary>
         [Parameter]
-        public string ButtonDisplayText { get; set; } = string.Empty;
+        public string ButtonDisplayText { get; set; } = "Add Item";
 
         /// <summary>
-        /// Gets or sets the action to be executed when the option button is clicked
+        /// Gets or sets the action to be executed when the option button is clicked. If not set, the button will not be displayed
         /// </summary>
         [Parameter]
         public Action OnButtonClick { get; set; }

--- a/COMETwebapp/Components/Common/SelectedDataItemForm.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDataItemForm.razor.cs
@@ -27,6 +27,7 @@ namespace COMETwebapp.Components.Common
     using COMET.Web.Common.Components;
 
     using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Forms;
 
     /// <summary>
     /// Support abstract class for the <see cref="SelectedDataItemForm"/>
@@ -81,6 +82,16 @@ namespace COMETwebapp.Components.Common
         protected virtual async Task OnValidSubmit()
         {
             await this.OnSaved.InvokeAsync();
+        }
+
+        /// <summary>
+        /// Returns the condition to check if the save button should be enabled
+        /// </summary>
+        /// <param name="editFormContext">The <see cref="EditForm"/> context</param>
+        /// <returns>The enabled value</returns>
+        protected bool IsSaveButtonEnabled(EditContext editFormContext)
+        {
+            return editFormContext.Validate() && (editFormContext.IsModified() || !this.ShouldCreate);
         }
     }
 }

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
@@ -160,13 +160,13 @@ Copyright (c) 2024 Starion Group S.A.
             </DxButton>
         }
         
-        <DxButton Id="saveParticipantRoleButton"
+        <DxButton Id="saveMeasurementScaleButton"
                   SubmitFormOnClick="true"
-                  Enabled="editFormContext.Validate() && (editFormContext.IsModified() || !this.ShouldCreate)">
+                  Enabled="@(this.IsSaveButtonEnabled(editFormContext))">
             Save
         </DxButton>
 
-        <DxButton Id="cancelOptionsButton"
+        <DxButton Id="cancelMeasurementScaleButton"
                   Click="@(() => this.OnCancel())"
                   RenderStyle="ButtonRenderStyle.Secondary">
             Cancel

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
@@ -33,8 +33,6 @@ Copyright (c) 2024 Starion Group S.A.
                 AllowSelectRowByClick="true"
                 SelectionMode="GridSelectionMode.Single"
                 SelectedDataItemChanged="@(row => this.OnSelectedDataItemChanged((MeasurementScaleRowViewModel)row))"
-                PopupEditFormCssClass="pw-800"
-                PopupEditFormHeaderText="Measurement Scale"
                 EditFormButtonsVisible="false"
                 CustomizeElement="DisableDeprecatedThing"
                 PageSize="20"
@@ -56,8 +54,7 @@ Copyright (c) 2024 Starion Group S.A.
         </DxGrid>
 
         <DataItemDetailsComponent IsSelected="@(this.IsOnEditMode)"
-                                  OnButtonClick="@(this.OnAddThingClick)"
-                                  ButtonDisplayText="Add Item">
+                                  OnButtonClick="@(this.OnAddThingClick)">
 
             <MeasurementScalesForm ViewModel="@(this.ViewModel)"
                                    @bind-IsVisible="@(this.IsOnEditMode)"

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -197,7 +197,8 @@ Copyright (c) 2024 Starion Group S.A.
         }
 
         <DxButton Id="saveParameterTypeButton"
-                  SubmitFormOnClick="true">
+                  SubmitFormOnClick="true"
+                  Enabled="@(this.IsSaveButtonEnabled(editFormContext))">
             Save
         </DxButton>
 

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor
@@ -20,37 +20,22 @@ Copyright (c) 2023-2024 Starion Group S.A.
     <div class="d-flex justify-content-between">
 
         <DxGrid @ref="this.Grid"
-                Data="this.ViewModel.Rows.Items.OrderBy(x => x.Name)"
+                Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
                 ShowSearchBox="true"
                 SearchBoxNullText="Search for a parameter type..."
                 AllowSelectRowByClick="true"
                 SelectionMode="GridSelectionMode.Single"
                 SelectedDataItemChanged="@(row => this.OnSelectedDataItemChanged((ParameterTypeRowViewModel)row))"
-                PopupEditFormCssClass="pw-800"
-                PopupEditFormHeaderText="Parameter Type"
                 EditFormButtonsVisible="false"
-                EditMode="GridEditMode.PopupEditForm"
                 CustomizeElement="DisableDeprecatedThing"
-                EditModelSaving="@(() => this.OnEditThingSaving())"
-                CustomizeEditModel="this.CustomizeEditThing"
                 PageSize="20"
                 PagerNavigationMode="PagerNavigationMode.Auto"
                 PageSizeSelectorVisible="true"
                 PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
+                FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
                 CssClass="height-fit-content">
-
-            <ToolbarTemplate>
-                <DxToolbar ItemRenderStyleMode="ToolbarRenderStyleMode.Contained">
-                    <DxToolbarItem Text="Add Parameter Type"
-                                   IconCssClass="oi oi-plus"
-                                   Click="() => this.Grid.StartEditNewRowAsync()"
-                                   RenderStyle="ButtonRenderStyle.Primary"
-                                   Enabled="true"/>
-                </DxToolbar>
-            </ToolbarTemplate>
-
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>
@@ -60,20 +45,15 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.ContainerName)" Caption="Container RDL" MinWidth="80" SearchEnabled="false"/>
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.IsDeprecated)" UnboundType="GridUnboundColumnType.Boolean" Visible="false" Caption="Is Deprecated" MinWidth="80" SearchEnabled="false"/>
             </Columns>
-
-            <EditFormTemplate Context="editFormContext">
-                <ParameterTypeForm ViewModel="@(this.ViewModel)"
-                                   IsVisible="true"
-                                   ShouldCreate="true"
-                                   OnSaved="@(() => this.Grid.CancelEditAsync())"
-                                   OnCanceled="@(() => this.Grid.CancelEditAsync())"/>
-            </EditFormTemplate>
         </DxGrid>
 
-        <DataItemDetailsComponent IsSelected="@(this.IsOnEditMode)">
+        <DataItemDetailsComponent IsSelected="@(this.IsOnEditMode)"
+                                  OnButtonClick="@(this.OnAddThingClick)">
+
             <ParameterTypeForm ViewModel="@(this.ViewModel)"
                                @bind-IsVisible="@(this.IsOnEditMode)"
-                               ShouldCreate="false"/>
+                               ShouldCreate="@(this.ShouldCreateThing)"
+                               OnSaved="@(this.OnSaved)" />
         </DataItemDetailsComponent>
     </div>
 </LoadingComponent>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor.cs
@@ -31,8 +31,6 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
     using COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes;
     using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
 
-    using DevExpress.Blazor;
-
     using Microsoft.AspNetCore.Components;
 
     /// <summary>
@@ -57,41 +55,41 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
         }
 
         /// <summary>
-        /// Method that is invoked when the edit/add thing form is being saved
-        /// </summary>
-        /// <returns>A <see cref="Task" /></returns>
-        protected override async Task OnEditThingSaving()
-        {
-            await this.ViewModel.CreateOrEditParameterType(this.ShouldCreateThing);
-        }
-
-        /// <summary>
-        /// Method invoked when creating a new thing
-        /// </summary>
-        /// <param name="e">A <see cref="GridCustomizeEditModelEventArgs" /></param>
-        protected override void CustomizeEditThing(GridCustomizeEditModelEventArgs e)
-        {
-            var dataItem = (ParameterTypeRowViewModel)e.DataItem;
-            this.ShouldCreateThing = e.IsNew;
-            this.IsOnEditMode = !this.ShouldCreateThing;
-
-            if (this.ShouldCreateThing)
-            {
-                this.ViewModel.SelectedParameterType = this.ViewModel.ParameterTypes.First(x => x.ClassKind == ClassKind.BooleanParameterType);
-            }
-
-            this.ViewModel.SelectParameterType(dataItem == null ? new BooleanParameterType() : dataItem.Thing.Clone(true));
-            e.EditModel = this.ViewModel.Thing;
-        }
-
-        /// <summary>
         /// Method invoked every time a row is selected
         /// </summary>
         /// <param name="row">The selected row</param>
         protected override void OnSelectedDataItemChanged(ParameterTypeRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
+            this.ShouldCreateThing = false;
             this.ViewModel.SelectParameterType(row.Thing.Clone(true));
+        }
+
+        /// <summary>
+        /// Method invoked before creating a new thing
+        /// </summary>
+        private void OnAddThingClick()
+        {
+            this.ShouldCreateThing = true;
+            this.IsOnEditMode = true;
+            this.ViewModel.SelectedParameterType = this.ViewModel.ParameterTypes.First(x => x.ClassKind == ClassKind.BooleanParameterType);
+            this.ViewModel.SelectParameterType(new BooleanParameterType());
+            this.InvokeAsync(this.StateHasChanged);
+        }
+
+        /// <summary>
+        /// Method invoked whenever a form is saved
+        /// </summary>
+        private void OnSaved()
+        {
+            if (!this.ShouldCreateThing)
+            {
+                return;
+            }
+
+            this.ShouldCreateThing = false;
+            var createdRow = this.ViewModel.Rows.Items.First(x => x.Thing.Iid == this.ViewModel.Thing.Iid);
+            this.OnSelectedDataItemChanged(createdRow);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #604 [Reference Data] refactor ParameterTypes page to be inline with measurement scales page
