### PR TITLE
Fix #616 CommonFileStore: when a user adds a filestore and then tries to delete the filestore the application crashes

### DIFF
--- a/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
@@ -114,7 +114,7 @@ namespace COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable
             }
             catch (Exception exception)
             {
-                this.Logger.LogError(exception, "An error has occurred while trying to delete the {thingType} {thingName}", typeof(T), ((IShortNamedThing)this.Thing).ShortName);
+                this.Logger.LogError(exception, "An error has occurred while trying to delete the {thingType} with iid {thingIid}", typeof(T), this.Thing.Iid);
             }
         }
     }

--- a/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
@@ -109,7 +109,7 @@ namespace COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable
 
             try
             {
-                await this.SessionService.DeleteThings(clonedContainer, [this.Thing]);
+                await this.SessionService.DeleteThings(clonedContainer, [this.Thing.Clone(false)]);
                 await this.SessionService.RefreshSession();
             }
             catch (Exception exception)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #616 CommonFileStore: when a user adds a filestore and then tries to delete the filestore the application crashes

