### PR TITLE
Fix #631 [Refactor] BaseDataItemTableViewModel.InitializeViewModel to make use of an abstract QueryListOfThings method #631

### DIFF
--- a/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
@@ -320,7 +320,6 @@ namespace COMETwebapp.Tests.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.DataSource.Count, Is.EqualTo(2));
                 Assert.That(renderer.Markup, Does.Contain(this.elementDefinitionCategory1.Name));
                 Assert.That(renderer.Markup, Does.Contain(this.elementDefinitionCategory2.Name));
             });
@@ -389,7 +388,6 @@ namespace COMETwebapp.Tests.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.DataSource.Count, Is.EqualTo(2));
                 Assert.That(renderer.Markup, Does.Contain(this.elementDefinitionCategory1.Name));
                 Assert.That(renderer.Markup, Does.Contain(this.elementDefinitionCategory2.Name));
             });

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableTestFixture.cs
@@ -113,7 +113,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
                 Assert.That(this.renderer.Instance.EngineeringModelSetup, Is.EqualTo(this.model));
                 Assert.That(this.renderer.Markup, Does.Contain(this.domain1.Name));
                 Assert.That(this.renderer.Markup, Does.Contain(this.domain2.Name));
-                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+                this.viewModel.Verify(x => x.InitializeViewModel(It.IsAny<EngineeringModelSetup>()), Times.Once);
             });
         }
 

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/IterationsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/IterationsTableTestFixture.cs
@@ -102,7 +102,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
                 Assert.That(this.renderer.Instance.ViewModel, Is.Not.Null);
                 Assert.That(this.renderer.Instance.EngineeringModelSetup, Is.EqualTo(this.model));
                 Assert.That(this.renderer.Markup, Does.Contain(this.model.ShortName));
-                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+                this.viewModel.Verify(x => x.InitializeViewModel(It.IsAny<EngineeringModelSetup>()), Times.Once);
             });
         }
     }

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableTestFixture.cs
@@ -119,7 +119,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
                 Assert.That(this.renderer.Instance.EngineeringModelSetup, Is.EqualTo(this.model));
                 Assert.That(this.renderer.Markup, Does.Contain(this.organizationalParticipant1.Organization.Name));
                 Assert.That(this.renderer.Markup, Does.Contain(this.organizationParticipant2.Organization.ShortName));
-                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+                this.viewModel.Verify(x => x.InitializeViewModel(It.IsAny<EngineeringModelSetup>()), Times.Once);
             });
         }
 

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
@@ -127,7 +127,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
                 Assert.That(this.renderer.Instance.EngineeringModelSetup, Is.EqualTo(this.model));
                 Assert.That(this.renderer.Markup, Does.Contain(this.participant1.Person.Name));
                 Assert.That(this.renderer.Markup, Does.Contain(this.participant2.Person.Name));
-                this.viewModel.Verify(x => x.InitializeViewModel(), Times.Once);
+                this.viewModel.Verify(x => x.InitializeViewModel(It.IsAny<EngineeringModelSetup>()), Times.Once);
             });
 
             var details = this.renderer.Find("a");

--- a/COMETwebapp.Tests/Components/SiteDirectory/UserManagementTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/UserManagementTableTestFixture.cs
@@ -273,7 +273,6 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.DataSource.Count, Is.EqualTo(2));
                 Assert.That(renderer.Markup, Does.Contain(this.person.Name));
                 Assert.That(renderer.Markup, Does.Contain(this.person1.Name));
             });
@@ -302,7 +301,6 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.DataSource.Count, Is.EqualTo(2));
                 Assert.That(renderer.Markup, Does.Contain(this.person.Name));
                 Assert.That(renderer.Markup, Does.Contain(this.person1.Name));
             });
@@ -368,7 +366,6 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.DataSource.Count, Is.EqualTo(2));
                 Assert.That(renderer.Markup, Does.Contain(this.person.Name));
                 Assert.That(renderer.Markup, Does.Contain(this.person1.Name));
             });

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/CommonFileStoreTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/CommonFileStoreTableViewModelTestFixture.cs
@@ -84,13 +84,10 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
                 Owner = siteDirectory.Domain.First()
             };
 
-            var engineeringModel = new EngineeringModel();
+            this.iteration = new Iteration();
+            var engineeringModel = new EngineeringModel { EngineeringModelSetup = new EngineeringModelSetup() };
             engineeringModel.CommonFileStore.Add(this.commonFileStore);
-
-            this.iteration = new Iteration()
-            {
-                Container = engineeringModel
-            };
+            engineeringModel.Iteration.Add(this.iteration);
 
             this.assembler = new Assembler(new Uri("http://localhost:5000/"), this.messageBus);
             var lazyCommonFileStore = new Lazy<Thing>(this.commonFileStore);
@@ -104,6 +101,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
 
             this.viewModel = new CommonFileStoreTableViewModel(this.sessionService.Object, this.messageBus, this.loggerMock.Object, this.folderFileStructureViewModel.Object);
+            this.viewModel.SetCurrentIteration(this.iteration);
         }
 
         [TearDown]
@@ -133,7 +131,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
         public async Task VerifyCommonFileStoreCreateOrEdit()
         {
             this.viewModel.InitializeViewModel();
-            this.viewModel.SetCurrentIteration(this.iteration);
             this.viewModel.Thing = this.commonFileStore;
 
             await this.viewModel.CreateOrEditCommonFileStore(true);

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
@@ -86,6 +86,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
 
             this.viewModel = new OptionsTableViewModel(this.sessionService.Object, this.messageBus, this.loggerMock.Object);
+            this.viewModel.SetCurrentIteration(this.iteration);
         }
 
         [TearDown]

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/PublicationsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/PublicationsTableViewModelTestFixture.cs
@@ -119,6 +119,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
 
             this.viewModel = new PublicationsTableViewModel(this.sessionService.Object, this.messageBus, this.loggerMock.Object);
+            this.viewModel.SetCurrentIteration(this.iteration);
         }
 
         [TearDown]

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModelTestFixture.cs
@@ -1,18 +1,18 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="IterationsTableViewModelTestFixture.cs" company="Starion Group S.A.">
-//     Copyright (c) 2023-2024 Starion Group S.A.
+//     Copyright (c) 2024 Starion Group S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 // 
-//     This file is part of CDP4-COMET WEB Community Edition
-//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
 // 
-//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
 // 
-//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
@@ -24,10 +24,8 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModels
 {
-    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
-    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -35,11 +33,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
     using CDP4Web.Enumerations;
 
-    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels;
+
+    using DynamicData;
 
     using Microsoft.Extensions.Logging;
 
@@ -53,7 +52,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         private IterationsTableViewModel viewModel;
         private Mock<ISessionService> sessionService;
         private Mock<IPermissionService> permissionService;
-        private Assembler assembler;
         private Mock<ILogger<IterationsTableViewModel>> loggerMock;
         private CDPMessageBus messageBus;
         private Iteration iteration;
@@ -67,34 +65,33 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             this.messageBus = new CDPMessageBus();
             this.loggerMock = new Mock<ILogger<IterationsTableViewModel>>();
 
-            this.model = new EngineeringModelSetup()
+            this.model = new EngineeringModelSetup
             {
                 Iid = Guid.NewGuid(),
                 Name = "model",
                 ShortName = "model"
             };
 
-            this.iteration = new Iteration()
+            this.iteration = new Iteration
             {
-                Container = new EngineeringModel()
+                Container = new EngineeringModel
                 {
-                    EngineeringModelSetup = this.model,
+                    EngineeringModelSetup = this.model
                 },
-                IterationSetup = new IterationSetup()
+                IterationSetup = new IterationSetup
                 {
                     Container = this.model
                 }
             };
 
-            this.assembler = new Assembler(new Uri("http://localhost:5000/"), this.messageBus);
-            var lazyIteration = new Lazy<Thing>(this.iteration);
-            this.assembler.Cache.TryAdd(new CacheKey(), lazyIteration);
-
             this.permissionService.Setup(x => x.CanWrite(this.iteration.ClassKind, this.iteration.Container)).Returns(true);
             var session = new Mock<ISession>();
             session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
-            session.Setup(x => x.Assembler).Returns(this.assembler);
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
+
+            var openIterations = new SourceList<Iteration>();
+            openIterations.Add(this.iteration);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(openIterations);
 
             this.viewModel = new IterationsTableViewModel(this.sessionService.Object, this.messageBus, this.loggerMock.Object);
         }
@@ -109,7 +106,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifyInitializeViewModel()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
 
             Assert.Multiple(() =>
             {
@@ -121,7 +118,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifyIterationRowProperties()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
             var participantRow = this.viewModel.Rows.Items.First();
 
             Assert.Multiple(() =>
@@ -135,19 +132,19 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifySessionRefresh()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
 
             this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
 
-            var iterationTest = new Iteration()
+            var iterationTest = new Iteration
             {
                 Iid = Guid.NewGuid(),
-                Container = new EngineeringModel()
+                Container = new EngineeringModel
                 {
-                    EngineeringModelSetup = this.model,
+                    EngineeringModelSetup = this.model
                 },
-                IterationSetup = new IterationSetup()
+                IterationSetup = new IterationSetup
                 {
                     Container = this.model
                 }

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModelTestFixture.cs
@@ -168,8 +168,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifySetEngineeringModel()
         {
-            this.viewModel.InitializeViewModel();
-            this.viewModel.SetEngineeringModel(this.model);
+            this.viewModel.InitializeViewModel(this.model);
 
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
         }

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModelTestFixture.cs
@@ -1,18 +1,18 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="OrganizationalParticipantsTableViewModelTestFixture.cs" company="Starion Group S.A.">
-//     Copyright (c) 2023-2024 Starion Group S.A.
+//     Copyright (c) 2024 Starion Group S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 // 
-//     This file is part of CDP4-COMET WEB Community Edition
-//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
 // 
-//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
 // 
-//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
@@ -26,7 +26,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 {
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
-    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -34,7 +33,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
     using CDP4Web.Enumerations;
 
-    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels;
@@ -51,7 +49,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         private OrganizationalParticipantsTableViewModel viewModel;
         private Mock<ISessionService> sessionService;
         private Mock<IPermissionService> permissionService;
-        private Assembler assembler;
         private Mock<ILogger<OrganizationalParticipantsTableViewModel>> loggerMock;
         private CDPMessageBus messageBus;
         private OrganizationalParticipant organizationalParticipant;
@@ -65,16 +62,16 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             this.messageBus = new CDPMessageBus();
             this.loggerMock = new Mock<ILogger<OrganizationalParticipantsTableViewModel>>();
 
-            this.organizationalParticipant = new OrganizationalParticipant()
+            this.organizationalParticipant = new OrganizationalParticipant
             {
-                Organization = new Organization()
+                Organization = new Organization
                 {
                     Name = "org A",
-                    ShortName = "orgA",
-                },
+                    ShortName = "orgA"
+                }
             };
 
-            this.model = new EngineeringModelSetup()
+            this.model = new EngineeringModelSetup
             {
                 Name = "model",
                 ShortName = "model"
@@ -82,7 +79,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
             this.model.OrganizationalParticipant.Add(this.organizationalParticipant);
 
-            var siteDirectory = new SiteDirectory()
+            var siteDirectory = new SiteDirectory
             {
                 ShortName = "siteDirectory",
                 Organization = { new Organization() }
@@ -90,14 +87,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
             siteDirectory.Model.Add(this.model);
 
-            this.assembler = new Assembler(new Uri("http://localhost:5000/"), this.messageBus);
-            var lazyOrganizationalParticipant = new Lazy<Thing>(this.organizationalParticipant);
-            this.assembler.Cache.TryAdd(new CacheKey(), lazyOrganizationalParticipant);
-
             this.permissionService.Setup(x => x.CanWrite(this.organizationalParticipant.ClassKind, this.organizationalParticipant.Container)).Returns(true);
             var session = new Mock<ISession>();
             session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
-            session.Setup(x => x.Assembler).Returns(this.assembler);
             session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
@@ -115,21 +107,21 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifyInitializeViewModel()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
 
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.Rows.Count, Is.EqualTo(1));
                 Assert.That(this.viewModel.Rows.Items.First().Thing, Is.EqualTo(this.organizationalParticipant));
                 Assert.That(this.viewModel.Organizations, Has.Count.EqualTo(1));
-                Assert.That(this.viewModel.ParticipatingOrganizations, Is.Null);
+                Assert.That(this.viewModel.ParticipatingOrganizations, Is.Not.Null);
             });
         }
 
         [Test]
         public void VerifyOrganizationalParticipantRowProperties()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
             var participantRow = this.viewModel.Rows.Items.First();
 
             Assert.Multiple(() =>
@@ -143,40 +135,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         }
 
         [Test]
-        public void VerifySessionRefresh()
-        {
-            this.viewModel.InitializeViewModel();
-
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
-
-            var organizationalParticipantTest = new OrganizationalParticipant()
-            {
-                Iid = Guid.NewGuid(),
-                Organization = new Organization()
-                {
-                    Name = "org B",
-                    ShortName = "orgB",
-                },
-                Container = this.model,
-            };
-
-            this.messageBus.SendObjectChangeEvent(organizationalParticipantTest, EventKind.Added);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Removed);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Updated);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
-        }
-
-        [Test]
         public async Task VerifyRowOperations()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
             var organizationalParticipantRow = this.viewModel.Rows.Items.First();
 
             Assert.That(organizationalParticipantRow, Is.Not.Null);
@@ -197,10 +158,40 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         }
 
         [Test]
+        public void VerifySessionRefresh()
+        {
+            this.viewModel.InitializeViewModel(this.model);
+
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            var organizationalParticipantTest = new OrganizationalParticipant
+            {
+                Iid = Guid.NewGuid(),
+                Organization = new Organization
+                {
+                    Name = "org B",
+                    ShortName = "orgB"
+                },
+                Container = this.model
+            };
+
+            this.messageBus.SendObjectChangeEvent(organizationalParticipantTest, EventKind.Added);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Removed);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Updated);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+        }
+
+        [Test]
         public void VerifySetEngineeringModel()
         {
-            this.viewModel.InitializeViewModel();
-            this.viewModel.SetEngineeringModel(this.model);
+            this.viewModel.InitializeViewModel(this.model);
 
             Assert.Multiple(() =>
             {

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
@@ -212,8 +212,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifySetEngineeringModel()
         {
-            this.viewModel.InitializeViewModel();
-            this.viewModel.SetEngineeringModel(this.model);
+            this.viewModel.InitializeViewModel(this.model);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
 
             this.viewModel.SelectThing(this.participant);
@@ -230,7 +229,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         public async Task VerifyParticipantsActions()
         {
             this.viewModel.InitializeViewModel();
-            this.viewModel.SetEngineeringModel(this.model);
 
             await this.viewModel.CreateOrEditParticipant(false);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Never);

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
@@ -1,18 +1,18 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ParticipantsTableViewModelTestFixture.cs" company="Starion Group S.A.">
-//     Copyright (c) 2023-2024 Starion Group S.A.
+//     Copyright (c) 2024 Starion Group S.A.
 // 
-//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 // 
-//     This file is part of CDP4-COMET WEB Community Edition
-//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
 // 
-//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
 // 
-//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
@@ -26,7 +26,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 {
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
-    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -34,7 +33,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
     using CDP4Web.Enumerations;
 
-    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels;
@@ -52,7 +50,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         private ParticipantsTableViewModel viewModel;
         private Mock<ISessionService> sessionService;
         private Mock<IPermissionService> permissionService;
-        private Assembler assembler;
         private Mock<ILogger<ParticipantsTableViewModel>> loggerMock;
         private CDPMessageBus messageBus;
         private Participant participant;
@@ -66,19 +63,19 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             this.messageBus = new CDPMessageBus();
             this.loggerMock = new Mock<ILogger<ParticipantsTableViewModel>>();
 
-            this.participant = new Participant()
+            this.participant = new Participant
             {
-                Person = new Person()
+                Person = new Person
                 {
                     GivenName = "person",
                     Surname = "A",
-                    Organization = new Organization(){ Name = "org" },
+                    Organization = new Organization { Name = "org" }
                 },
-                Role = new ParticipantRole() { Name = "role" },
-                Domain = { new DomainOfExpertise() { Name = "doe" } }
+                Role = new ParticipantRole { Name = "role" },
+                Domain = { new DomainOfExpertise { Name = "doe" } }
             };
 
-            this.model = new EngineeringModelSetup()
+            this.model = new EngineeringModelSetup
             {
                 Name = "model",
                 ShortName = "model",
@@ -87,23 +84,18 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
             this.model.Participant.Add(this.participant);
 
-            var siteDirectory = new SiteDirectory()
+            var siteDirectory = new SiteDirectory
             {
                 ShortName = "siteDirectory",
                 Person = { new Person() },
-                ParticipantRole = { new ParticipantRole() },
+                ParticipantRole = { new ParticipantRole() }
             };
 
             siteDirectory.Model.Add(this.model);
 
-            this.assembler = new Assembler(new Uri("http://localhost:5000/"), this.messageBus);
-            var lazyParticipant = new Lazy<Thing>(this.participant);
-            this.assembler.Cache.TryAdd(new CacheKey(), lazyParticipant);
-
             this.permissionService.Setup(x => x.CanWrite(this.participant.ClassKind, this.participant.Container)).Returns(true);
             var session = new Mock<ISession>();
             session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
-            session.Setup(x => x.Assembler).Returns(this.assembler);
             session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
@@ -121,7 +113,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifyInitializeViewModel()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
 
             Assert.Multiple(() =>
             {
@@ -129,7 +121,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
                 Assert.That(this.viewModel.Rows.Items.First().Thing, Is.EqualTo(this.participant));
                 Assert.That(this.viewModel.Persons, Has.Count.EqualTo(1));
                 Assert.That(this.viewModel.ParticipantRoles, Has.Count.EqualTo(1));
-                Assert.That(this.viewModel.DomainsOfExpertise, Is.Null);
+                Assert.That(this.viewModel.DomainsOfExpertise, Is.Not.Null);
                 Assert.That(this.viewModel.SelectedDomains, Is.Null);
             });
         }
@@ -137,7 +129,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         [Test]
         public void VerifyOrganizationalParticipantRowProperties()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
             var participantRow = this.viewModel.Rows.Items.First();
 
             Assert.Multiple(() =>
@@ -153,43 +145,25 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         }
 
         [Test]
-        public void VerifySessionRefresh()
+        public async Task VerifyParticipantsActions()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
 
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+            await this.viewModel.CreateOrEditParticipant(false);
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Never);
 
-            var participantTest = new Participant()
-            {
-                Iid = Guid.NewGuid(),
-                Person = new Person()
-                {
-                    GivenName = "person",
-                    Surname = "B",
-                    Organization = new Organization() { Name = "org2" },
-                },
-                Role = new ParticipantRole() { Name = "role2" },
-                Container = this.model,
-                Domain = { new DomainOfExpertise() { Name = "doe2" } }
-            };
+            this.viewModel.SelectedDomains = [this.participant.Domain.First(), this.participant.Domain.First().Clone(true)];
+            await this.viewModel.CreateOrEditParticipant(false);
 
-            this.messageBus.SendObjectChangeEvent(participantTest, EventKind.Added);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Removed);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Updated);
-            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
-
-            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.Is<IReadOnlyCollection<Thing>>(c => c.Count() == 1)), Times.Once);
+            await this.viewModel.CreateOrEditParticipant(true);
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.Is<IReadOnlyCollection<Thing>>(c => c.Count() == 2)), Times.Once);
         }
 
         [Test]
         public async Task VerifyRowOperations()
         {
-            this.viewModel.InitializeViewModel();
+            this.viewModel.InitializeViewModel(this.model);
             var participantRow = this.viewModel.Rows.Items.First();
 
             Assert.That(participantRow, Is.Not.Null);
@@ -210,6 +184,40 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
         }
 
         [Test]
+        public void VerifySessionRefresh()
+        {
+            this.viewModel.InitializeViewModel(this.model);
+
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+
+            var participantTest = new Participant
+            {
+                Iid = Guid.NewGuid(),
+                Person = new Person
+                {
+                    GivenName = "person",
+                    Surname = "B",
+                    Organization = new Organization { Name = "org2" }
+                },
+                Role = new ParticipantRole { Name = "role2" },
+                Container = this.model,
+                Domain = { new DomainOfExpertise { Name = "doe2" } }
+            };
+
+            this.messageBus.SendObjectChangeEvent(participantTest, EventKind.Added);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Removed);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            this.messageBus.SendObjectChangeEvent(this.viewModel.Rows.Items.First().Thing, EventKind.Updated);
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
+
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
+        }
+
+        [Test]
         public void VerifySetEngineeringModel()
         {
             this.viewModel.InitializeViewModel(this.model);
@@ -223,22 +231,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
                 Assert.That(this.viewModel.SelectedDomains, Is.EqualTo(this.participant.Domain));
                 Assert.That(this.viewModel.DomainsOfExpertise, Has.Count.EqualTo(1));
             });
-        }
-
-        [Test]
-        public async Task VerifyParticipantsActions()
-        {
-            this.viewModel.InitializeViewModel();
-
-            await this.viewModel.CreateOrEditParticipant(false);
-            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Never);
-
-            this.viewModel.SelectedDomains = [this.participant.Domain.First(), this.participant.Domain.First().Clone(true)];
-            await this.viewModel.CreateOrEditParticipant(false);
-
-            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.Is<IReadOnlyCollection<Thing>>(c => c.Count() == 1)), Times.Once);
-            await this.viewModel.CreateOrEditParticipant(true);
-            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModelSetup>(), It.Is<IReadOnlyCollection<Thing>>(c => c.Count() == 2)), Times.Once);
         }
     }
 }

--- a/COMETwebapp/Components/ReferenceData/Categories/CategoriesForm.razor
+++ b/COMETwebapp/Components/ReferenceData/Categories/CategoriesForm.razor
@@ -65,7 +65,7 @@ Copyright (c) 2024 Starion Group S.A.
                 <DxFormLayoutItem Caption="Super Categories:" ColSpanMd="12" CaptionPosition="CaptionPosition.Vertical">
                     <DxListBox TData="Category"
                                TValue="Category" 
-                               Data="@(this.ViewModel.DataSource.Items)"
+                               Data="@(this.ViewModel.Rows.Items.Select(x => x.Thing))"
                                Values="@(this.ViewModel.Thing.SuperCategory)"
                                ValuesChanged="@(superCategories => this.ViewModel.Thing.SuperCategory = superCategories.ToList())"
                                ValuesExpression="@(() => this.ViewModel.Thing.SuperCategory)"

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
@@ -22,43 +22,41 @@ Copyright (c) 2024 Starion Group S.A.
 
 @inherits SelectedDeprecatableDataItemBase<MeasurementScale, MeasurementScaleRowViewModel>
 
-<LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
-        <DxGrid @ref="this.Grid"
-                Data="this.ViewModel.Rows.Items"
-                ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
-                ShowSearchBox="true"
-                SearchBoxNullText="Search for a measurement scale ..."
-                AllowSelectRowByClick="true"
-                SelectionMode="GridSelectionMode.Single"
-                SelectedDataItemChanged="@(row => this.OnSelectedDataItemChanged((MeasurementScaleRowViewModel)row))"
-                EditFormButtonsVisible="false"
-                CustomizeElement="DisableDeprecatedThing"
-                PageSize="20"
-                PagerNavigationMode="PagerNavigationMode.Auto"
-                PageSizeSelectorVisible="true"
-                PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
-                PageSizeSelectorAllRowsItemVisible="true"
-                FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
-            <Columns>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Name)" MinWidth="150"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Type)" Caption="Type" MinWidth="80" SearchEnabled="false"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.NumberSet)" Caption="Number Set" MinWidth="80" SearchEnabled="false"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Unit)" Caption="Unit" MinWidth="80" SearchEnabled="false"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ContainerName)" Caption="Container RDL" MinWidth="80" SearchEnabled="false"/>
-                <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.IsDeprecated)" UnboundType="GridUnboundColumnType.Boolean" Visible="false" Caption="Is Deprecated" MinWidth="80" SearchEnabled="false"/>
-            </Columns>
-        </DxGrid>
+<div class="d-flex justify-content-between">
+    <DxGrid @ref="this.Grid"
+            Data="this.ViewModel.Rows.Items"
+            ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
+            ShowSearchBox="true"
+            SearchBoxNullText="Search for a measurement scale ..."
+            AllowSelectRowByClick="true"
+            SelectionMode="GridSelectionMode.Single"
+            SelectedDataItemChanged="@(row => this.OnSelectedDataItemChanged((MeasurementScaleRowViewModel)row))"
+            EditFormButtonsVisible="false"
+            CustomizeElement="DisableDeprecatedThing"
+            PageSize="20"
+            PagerNavigationMode="PagerNavigationMode.Auto"
+            PageSizeSelectorVisible="true"
+            PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
+            PageSizeSelectorAllRowsItemVisible="true"
+            FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
+            CssClass="height-fit-content">
+        <Columns>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Name)" MinWidth="150"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Type)" Caption="Type" MinWidth="80" SearchEnabled="false"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.NumberSet)" Caption="Number Set" MinWidth="80" SearchEnabled="false"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Unit)" Caption="Unit" MinWidth="80" SearchEnabled="false"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ContainerName)" Caption="Container RDL" MinWidth="80" SearchEnabled="false"/>
+            <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.IsDeprecated)" UnboundType="GridUnboundColumnType.Boolean" Visible="false" Caption="Is Deprecated" MinWidth="80" SearchEnabled="false"/>
+        </Columns>
+    </DxGrid>
 
-        <DataItemDetailsComponent IsSelected="@(this.IsOnEditMode)"
-                                  OnButtonClick="@(this.OnAddThingClick)">
+    <DataItemDetailsComponent IsSelected="@(this.IsOnEditMode)"
+                              OnButtonClick="@(this.OnAddThingClick)">
 
-            <MeasurementScalesForm ViewModel="@(this.ViewModel)"
-                                   @bind-IsVisible="@(this.IsOnEditMode)"
-                                   ShouldCreate="@(this.ShouldCreateThing)"
-                                   OnSaved="@(this.OnSaved)"/>
-        </DataItemDetailsComponent>
-    </div>
-</LoadingComponent>
+        <MeasurementScalesForm ViewModel="@(this.ViewModel)"
+                               @bind-IsVisible="@(this.IsOnEditMode)"
+                               ShouldCreate="@(this.ShouldCreateThing)"
+                               OnSaved="@(this.OnSaved)"/>
+    </DataItemDetailsComponent>
+</div>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor.cs
@@ -50,23 +50,13 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         public EngineeringModelSetup EngineeringModelSetup { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.ViewModel.InitializeViewModel();
-        }
-
-        /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
         /// </summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            this.ViewModel.SetEngineeringModel(this.EngineeringModelSetup);
+            this.ViewModel.InitializeViewModel(this.EngineeringModelSetup);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor.cs
@@ -51,23 +51,13 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         public EngineeringModelSetup EngineeringModelSetup { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.Initialize(this.ViewModel);
-        }
-
-        /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
         /// </summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            this.ViewModel.SetEngineeringModel(this.EngineeringModelSetup);
+            this.ViewModel.InitializeViewModel(this.EngineeringModelSetup);
         }
     }
 }

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor.cs
@@ -52,23 +52,13 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         public EngineeringModelSetup EngineeringModelSetup { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.Initialize(this.ViewModel);
-        }
-
-        /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
         /// </summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            this.ViewModel.SetEngineeringModel(this.EngineeringModelSetup);
+            this.ViewModel.InitializeViewModel(this.EngineeringModelSetup);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
@@ -62,23 +62,13 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         private IEnumerable<Person> Persons => this.ShouldCreateThing ? this.ViewModel.Persons : [this.ViewModel.Thing.Person];
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.Initialize(this.ViewModel);
-        }
-
-        /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
         /// </summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            this.ViewModel.SetEngineeringModel(this.EngineeringModelSetup);
+            this.ViewModel.InitializeViewModel(this.EngineeringModelSetup);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
@@ -99,11 +99,6 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
         public SourceList<TRow> Rows { get; } = new();
 
         /// <summary>
-        /// Gets or sets the data source for the grid control.
-        /// </summary>
-        public SourceList<T> DataSource { get; } = new();
-
-        /// <summary>
         /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
         public virtual void InitializeViewModel()
@@ -111,11 +106,6 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
             this.IsLoading = true;
 
             this.Rows.Clear();
-
-            // this.DataSource.Clear();
-            // var listOfThings = this.SessionService.Session.Assembler.Cache.Values.Where(x => x.IsValueCreated).Select(x => x.Value).OfType<T>().ToList();
-            // this.DataSource.AddRange(listOfThings);
-            //this.Rows.AddRange(this.DataSource.Items.Select(CreateNewRow).OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase));
             var listOfThings = this.QueryListOfThings() ?? Enumerable.Empty<T>();
             this.Rows.AddRange(listOfThings.Select(CreateNewRow).OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase));
             this.RefreshAccessRight();

--- a/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
@@ -111,11 +111,13 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
             this.IsLoading = true;
 
             this.Rows.Clear();
-            this.DataSource.Clear();
 
-            var listOfThings = this.SessionService.Session.Assembler.Cache.Values.Where(x => x.IsValueCreated).Select(x => x.Value).OfType<T>().ToList();
-            this.DataSource.AddRange(listOfThings);
-            this.Rows.AddRange(this.DataSource.Items.Select(CreateNewRow).OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase));
+            // this.DataSource.Clear();
+            // var listOfThings = this.SessionService.Session.Assembler.Cache.Values.Where(x => x.IsValueCreated).Select(x => x.Value).OfType<T>().ToList();
+            // this.DataSource.AddRange(listOfThings);
+            //this.Rows.AddRange(this.DataSource.Items.Select(CreateNewRow).OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase));
+            var listOfThings = this.QueryListOfThings() ?? Enumerable.Empty<T>();
+            this.Rows.AddRange(listOfThings.Select(CreateNewRow).OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase));
             this.RefreshAccessRight();
 
             this.IsLoading = false;
@@ -181,6 +183,12 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
 
             this.Rows.RemoveMany(rowsToDelete);
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected abstract List<T> QueryListOfThings();
 
         /// <summary>
         /// Handles the <see cref="SessionStatus.EndUpdate" /> message received

--- a/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/IBaseDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/IBaseDataItemTableViewModel.cs
@@ -39,11 +39,6 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
         SourceList<TRow> Rows { get; }
 
         /// <summary>
-        /// Gets or sets the data source for the grid control.
-        /// </summary>
-        SourceList<T> DataSource { get; }
-
-        /// <summary>
         /// The thing to create or edit
         /// </summary>
         T Thing { get; set; }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
@@ -142,5 +142,14 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
 
             this.IsLoading = false;
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<CommonFileStore> QueryListOfThings()
+        {
+            return ((EngineeringModel)this.CurrentIteration.Container).CommonFileStore;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
@@ -132,6 +132,15 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Option> QueryListOfThings()
+        {
+            return this.CurrentIteration.Option.ToList();
+        }
+
+        /// <summary>
         /// Handles the <see cref="SessionStatus.EndUpdate" /> message received
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Publications/PublicationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Publications/PublicationsTableViewModel.cs
@@ -130,5 +130,14 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Publications
             
             this.IsLoading = false;
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Publication> QueryListOfThings()
+        {
+            return this.CurrentIteration.Publication;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
@@ -147,6 +147,15 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Category> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.DefinedCategory).ToList();
+        }
+
+        /// <summary>
         /// Handles the <see cref="SessionStatus.EndUpdate" /> message received
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScales/MeasurementScalesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScales/MeasurementScalesTableViewModel.cs
@@ -67,7 +67,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementScales
         /// <param name="showHideDeprecatedThingsService">The <see cref="IShowHideDeprecatedThingsService" /></param>
         /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
         /// <param name="logger">The <see cref="ILogger{TCategoryName}" /></param>
-        /// <param name="notificationService">The <see cref="INotificationService"/></param>
+        /// <param name="notificationService">The <see cref="INotificationService" /></param>
         public MeasurementScalesTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus,
             ILogger<MeasurementScalesTableViewModel> logger, INotificationService notificationService) : base(sessionService, messageBus, showHideDeprecatedThingsService, logger, notificationService)
         {
@@ -180,8 +180,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementScales
         {
             try
             {
-                this.IsLoading = true;
-
                 var hasRdlChanged = this.SelectedReferenceDataLibrary != this.Thing.Container;
                 var rdlClone = this.SelectedReferenceDataLibrary.Clone(false);
                 var thingsToCreate = new List<Thing>();
@@ -220,10 +218,15 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementScales
             {
                 this.Logger.LogError(ex, "Create or Update MeasurementScale failed");
             }
-            finally
-            {
-                this.IsLoading = false;
-            }
+        }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<MeasurementScale> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.Scale).ToList();
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
@@ -132,6 +132,15 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<MeasurementUnit> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.Unit).ToList();
+        }
+
+        /// <summary>
         /// Creates or edits a <see cref="MeasurementUnit" />
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="MeasurementUnit" /> should be created</param>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -152,6 +152,15 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<ParameterType> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.ParameterType).ToList();
+        }
+
+        /// <summary>
         /// Creates or edits a <see cref="ParameterType" />
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="ParameterType" /> should be created</param>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementScaleRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/MeasurementScaleRowViewModel.cs
@@ -58,7 +58,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Rows
         {
             this.Type = measurementScale.ClassKind.ToString();
             this.NumberSet = measurementScale.NumberSet.ToString();
-            this.Unit = measurementScale.Unit.ShortName;
+            this.Unit = measurementScale.Unit?.ShortName;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
@@ -88,5 +88,14 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
                 this.IsLoading = false;
             }
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<DomainOfExpertise> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().Domain;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableViewModel.cs
@@ -57,7 +57,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <summary>
         /// Gets a collection of all the available <see cref="DomainOfExpertise"/>s
         /// </summary>
-        public IEnumerable<DomainOfExpertise> DomainsOfExpertise { get; private set; }
+        public IEnumerable<DomainOfExpertise> DomainsOfExpertise => this.SessionService.GetSiteDirectory().Domain;
 
         /// <summary>
         /// Gets or sets a collection of all the selected active <see cref="DomainOfExpertise"/>s for the engineering model
@@ -67,30 +67,21 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <summary>
         /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
-        public override void InitializeViewModel()
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its active domains</param>
+        public void InitializeViewModel(EngineeringModelSetup model)
         {
+            this.CurrentModel = model;
+            this.ResetSelectedDomainsOfExpertise();
             base.InitializeViewModel();
-
-            this.DomainsOfExpertise = this.SessionService.GetSiteDirectory().Domain;
         }
 
         /// <summary>
-        /// Sets the model and filters the current Rows, keeping only the active domains associated with the given engineering model
+        /// Queries a list of things of the current type
         /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its active domains</param>
-        public void SetEngineeringModel(EngineeringModelSetup model)
+        /// <returns>A list of things</returns>
+        protected override List<DomainOfExpertise> QueryListOfThings()
         {
-            this.CurrentModel = model;
-            var domainsAssociatedWithModel = this.DataSource.Items.Where(x => this.CurrentModel.ActiveDomain.Contains(x));
-
-            this.Rows.Edit(action =>
-            {
-                action.Clear();
-                action.AddRange(domainsAssociatedWithModel.Select(x => new DomainOfExpertiseRowViewModel(x)));
-            });
-
-            this.RefreshAccessRight();
-            this.ResetSelectedDomainsOfExpertise();
+            return this.CurrentModel?.ActiveDomain;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
@@ -125,6 +125,15 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<EngineeringModelSetup> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().Model;
+        }
+
+        /// <summary>
         /// Resets the selected values
         /// </summary>
         public void ResetSelectedValues()

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IActiveDomainsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IActiveDomainsTableViewModel.cs
@@ -35,12 +35,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     public interface IActiveDomainsTableViewModel : IBaseDataItemTableViewModel<DomainOfExpertise, DomainOfExpertiseRowViewModel>
     {
         /// <summary>
-        /// Filters the current Rows, keeping only the Domains of Expertise associated with the given engineering model
-        /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
-        void SetEngineeringModel(EngineeringModelSetup model);
-
-        /// <summary>
         /// Gets a collection of all the available <see cref="DomainOfExpertise"/>s
         /// </summary>
         IEnumerable<DomainOfExpertise> DomainsOfExpertise { get; }
@@ -60,5 +54,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// Resets the <see cref="ActiveDomainsTableViewModel.SelectedDomainsOfExpertise"/> value based on the <see cref="ActiveDomainsTableViewModel.CurrentModel"/>
         /// </summary>
         void ResetSelectedDomainsOfExpertise();
+
+        /// <summary>
+        /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
+        /// </summary>
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its active domains</param>
+        void InitializeViewModel(EngineeringModelSetup model);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IIterationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IIterationsTableViewModel.cs
@@ -36,9 +36,9 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     public interface IIterationsTableViewModel : IBaseDataItemTableViewModel<Iteration, IterationRowViewModel>
     {
         /// <summary>
-        /// Sets the model and filters the current Rows, keeping only the iterations associated with the given engineering model
+        /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its iterations</param>
-        void SetEngineeringModel(EngineeringModelSetup model);
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
+        void InitializeViewModel(EngineeringModelSetup model);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IOrganizationalParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IOrganizationalParticipantsTableViewModel.cs
@@ -26,6 +26,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
 {
     using CDP4Common.SiteDirectoryData;
 
+    using COMETwebapp.ViewModels.Components.Common.BaseDataItemTable;
     using COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
 
@@ -35,12 +36,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     public interface IOrganizationalParticipantsTableViewModel : IDeletableDataItemTableViewModel<OrganizationalParticipant, OrganizationalParticipantRowViewModel>
     {
         /// <summary>
-        /// Filters the current Rows, keeping only the organizational participants associated with the given engineering model
-        /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
-        void SetEngineeringModel(EngineeringModelSetup model);
-
-        /// <summary>
         /// Gets a collection of all the available <see cref="Organization"/>s
         /// </summary>
         IEnumerable<Organization> Organizations { get; }
@@ -49,5 +44,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// Gets or sets a collection of all the participating <see cref="Organization"/>s for the organizational participant creation
         /// </summary>
         IEnumerable<Organization> ParticipatingOrganizations { get; set; }
+
+        /// <summary>
+        /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
+        /// </summary>
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its active domains</param>
+        void InitializeViewModel(EngineeringModelSetup model);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IParticipantsTableViewModel.cs
@@ -26,6 +26,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
 {
     using CDP4Common.SiteDirectoryData;
 
+    using COMETwebapp.ViewModels.Components.Common.BaseDataItemTable;
     using COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
 
@@ -34,12 +35,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     /// </summary>
     public interface IParticipantsTableViewModel : IDeletableDataItemTableViewModel<Participant, ParticipantRowViewModel>
     {
-        /// <summary>
-        /// Filters the current Rows, keeping only the participants associated with the given engineering model
-        /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
-        void SetEngineeringModel(EngineeringModelSetup model);
-
         /// <summary>
         /// Gets a collection of all the available <see cref="Person"/>s
         /// </summary>
@@ -77,5 +72,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// Updates the current participant domains with the <see cref="ParticipantsTableViewModel.SelectedDomains"/>
         /// </summary>
         void UpdateSelectedDomains();
+
+        /// <summary>
+        /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
+        /// </summary>
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
+        void InitializeViewModel(EngineeringModelSetup model);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IterationsTableViewModel.cs
@@ -40,6 +40,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     public class IterationsTableViewModel : BaseDataItemTableViewModel<Iteration, IterationRowViewModel>, IIterationsTableViewModel
     {
         /// <summary>
+        /// Gets or sets the current <see cref="EngineeringModelSetup"/>
+        /// </summary>
+        private EngineeringModelSetup CurrentModel { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ParticipantsTableViewModel" /> class.
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionService" /></param>
@@ -51,18 +56,22 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         }
 
         /// <summary>
-        /// Sets the model and filters the current Rows, keeping only the iterations associated with the given engineering model
+        /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its iterations</param>
-        public void SetEngineeringModel(EngineeringModelSetup model)
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
+        public void InitializeViewModel(EngineeringModelSetup model)
         {
-            var iterationsAssociatedWithModel = this.DataSource.Items.Where(x => ((EngineeringModel)x.Container).EngineeringModelSetup.Iid == model.Iid);
+            this.CurrentModel = model;
+            base.InitializeViewModel();
+        }
 
-            this.Rows.Edit(action =>
-            {
-                action.Clear();
-                action.AddRange(iterationsAssociatedWithModel.Select(x => new IterationRowViewModel(x)));
-            });
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Iteration> QueryListOfThings()
+        {
+            return this.SessionService.OpenIterations.Items.Where(x => ((EngineeringModel)x.Container).EngineeringModelSetup.Iid == this.CurrentModel?.Iid).ToList();
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModel.cs
@@ -40,6 +40,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     public class OrganizationalParticipantsTableViewModel : DeletableDataItemTableViewModel<OrganizationalParticipant, OrganizationalParticipantRowViewModel>, IOrganizationalParticipantsTableViewModel
     {
         /// <summary>
+        /// Gets or sets the current <see cref="EngineeringModelSetup"/>
+        /// </summary>
+        private EngineeringModelSetup CurrentModel { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OrganizationalParticipantsTableViewModel" /> class.
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionService" /></param>
@@ -63,29 +68,23 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <summary>
         /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
-        public override void InitializeViewModel()
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its active domains</param>
+        public void InitializeViewModel(EngineeringModelSetup model)
         {
-            base.InitializeViewModel();
-
+            this.CurrentModel = model;
+            this.ParticipatingOrganizations = model.OrganizationalParticipant.Select(x => x.Organization);
             this.Organizations = this.SessionService.GetSiteDirectory().Organization;
+
+            base.InitializeViewModel();
         }
 
         /// <summary>
-        /// Sets the model and filters the current Rows, keeping only the organizational participants associated with the given engineering model
+        /// Queries a list of things of the current type
         /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
-        public void SetEngineeringModel(EngineeringModelSetup model)
+        /// <returns>A list of things</returns>
+        protected override List<OrganizationalParticipant> QueryListOfThings()
         {
-            var participantsAssociatedWithModel = this.DataSource.Items.Where(x => x.Container.Iid == model.Iid);
-
-            this.Rows.Edit(action =>
-            {
-                action.Clear();
-                action.AddRange(participantsAssociatedWithModel.Select(x => new OrganizationalParticipantRowViewModel(x)));
-            });
-
-            this.RefreshAccessRight();
-            this.ParticipatingOrganizations = model.OrganizationalParticipant.Select(x => x.Organization);
+            return this.CurrentModel?.OrganizationalParticipant;
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
@@ -80,32 +80,25 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <summary>
         /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />
         /// </summary>
-        public override void InitializeViewModel()
+        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
+        public void InitializeViewModel(EngineeringModelSetup model)
         {
-            base.InitializeViewModel();
-
             var siteDirectory = this.SessionService.GetSiteDirectory();
             this.Persons = siteDirectory.Person;
             this.ParticipantRoles = siteDirectory.ParticipantRole;
+            this.CurrentModel = model;
+            this.DomainsOfExpertise = this.CurrentModel.ActiveDomain;
+
+            base.InitializeViewModel();
         }
 
         /// <summary>
-        /// Sets the model and filters the current Rows, keeping only the participants associated with the given engineering model
+        /// Queries a list of things of the current type
         /// </summary>
-        /// <param name="model">The <see cref="EngineeringModelSetup"/> to get its participants</param>
-        public void SetEngineeringModel(EngineeringModelSetup model)
+        /// <returns>A list of things</returns>
+        protected override List<Participant> QueryListOfThings()
         {
-            this.CurrentModel = model;
-            var participantsAssociatedWithModel = this.DataSource.Items.Where(x => x.Container.Iid == this.CurrentModel.Iid);
-
-            this.Rows.Edit(action =>
-            {
-                action.Clear();
-                action.AddRange(participantsAssociatedWithModel.Select(x => new ParticipantRowViewModel(x)));
-            });
-
-            this.DomainsOfExpertise = this.CurrentModel.ActiveDomain;
-            this.RefreshAccessRight();
+            return this.CurrentModel?.Participant;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
@@ -76,5 +76,14 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Organizations
 
             this.IsLoading = false;
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Organization> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().Organization;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/ParticipantRolesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/ParticipantRolesTableViewModel.cs
@@ -83,5 +83,14 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
 
             this.IsLoading = false;
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<ParticipantRole> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().ParticipantRole;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/PersonRolesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/PersonRolesTableViewModel.cs
@@ -86,5 +86,14 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
             await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate);
             this.IsLoading = false;
         }
+
+        /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<PersonRole> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().PersonRole;
+        }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
@@ -209,6 +209,15 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         }
 
         /// <summary>
+        /// Queries a list of things of the current type
+        /// </summary>
+        /// <returns>A list of things</returns>
+        protected override List<Person> QueryListOfThings()
+        {
+            return this.SessionService.GetSiteDirectory().Person;
+        }
+
+        /// <summary>
         /// Updates the active user access rights
         /// </summary>
         protected override void RefreshAccessRight()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #631 refactor BaseDataItemTableViewModel.InitializeViewModel to make use of an abstract QueryListOfThings method
