### PR TITLE
Fix #628 [Refactor] Viewmodels to make use of this.whenanyvalue in favour of XXXViewModel.Selectxxx() methods

### DIFF
--- a/COMETwebapp.Tests/Components/EngineeringModel/CommonFileStoresTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/CommonFileStoresTableTestFixture.cs
@@ -74,7 +74,7 @@ namespace COMETwebapp.Tests.Components.EngineeringModel
             var rows = new SourceList<CommonFileStoreRowViewModel>();
             rows.Add(new CommonFileStoreRowViewModel(this.commonFileStore));
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new CommonFileStore());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new CommonFileStore());
             
             this.context.ConfigureDevExpressBlazor();
 

--- a/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FileFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FileFormTestFixture.cs
@@ -56,7 +56,7 @@ namespace COMETwebapp.Tests.Components.EngineeringModel.FileStore
         {
             this.context = new TestContext();
             this.viewModel = new Mock<IFileHandlerViewModel>();
-            this.viewModel.Setup(x => x.File).Returns(new File());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new File());
             var domainSelectorViewModel = new Mock<IDomainOfExpertiseSelectorViewModel>();
             this.viewModel.Setup(x => x.DomainOfExpertiseSelectorViewModel).Returns(domainSelectorViewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FolderFileStructureTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FolderFileStructureTestFixture.cs
@@ -88,8 +88,8 @@ namespace COMETwebapp.Tests.Components.EngineeringModel.FileStore
                 }
             ];
 
-            this.fileHandlerViewModel.Setup(x => x.File).Returns(new File());
-            this.folderHandlerViewModel.Setup(x => x.Folder).Returns(new Folder());
+            this.fileHandlerViewModel.Setup(x => x.CurrentThing).Returns(new File());
+            this.folderHandlerViewModel.Setup(x => x.CurrentThing).Returns(new Folder());
 
             this.viewModel.Setup(x => x.Structure).Returns(this.structure);
             this.viewModel.Setup(x => x.FileHandlerViewModel).Returns(this.fileHandlerViewModel.Object);

--- a/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FolderFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/FileStore/FolderFormTestFixture.cs
@@ -58,7 +58,7 @@ namespace COMETwebapp.Tests.Components.EngineeringModel.FileStore
          {
              this.context = new TestContext();
              this.viewModel = new Mock<IFolderHandlerViewModel>();
-             this.viewModel.Setup(x => x.Folder).Returns(new Folder());
+             this.viewModel.Setup(x => x.CurrentThing).Returns(new Folder());
 
              var domainSelectorViewModel = new Mock<IDomainOfExpertiseSelectorViewModel>();
              this.viewModel.Setup(x => x.DomainOfExpertiseSelectorViewModel).Returns(domainSelectorViewModel.Object);

--- a/COMETwebapp.Tests/Components/EngineeringModel/OptionsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/OptionsTableTestFixture.cs
@@ -73,7 +73,7 @@ namespace COMETwebapp.Tests.Components.EngineeringModel
             var rows = new SourceList<OptionRowViewModel>();
             rows.Add(new OptionRowViewModel(this.option){ IsDefault = true});
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new Option());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new Option());
             
             this.context.ConfigureDevExpressBlazor();
 

--- a/COMETwebapp.Tests/Components/EngineeringModel/OptionsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/EngineeringModel/OptionsTableTestFixture.cs
@@ -143,12 +143,7 @@ namespace COMETwebapp.Tests.Components.EngineeringModel
             var grid = this.renderer.FindComponent<DxGrid>();
             await this.renderer.InvokeAsync(() => grid.Instance.SelectedDataItemChanged.InvokeAsync(this.viewModel.Object.Rows.Items.First()));
 
-            Assert.Multiple(() =>
-            {
-                this.viewModel.Verify(x => x.SetCurrentOption(It.IsAny<Option>()));
-                Assert.That(this.renderer.Instance.IsOnEditMode, Is.EqualTo(true));
-            });
-
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.EqualTo(true));
             var form = this.renderer.FindComponent<OptionsForm>();
 
             Assert.Multiple(() =>

--- a/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
@@ -365,7 +365,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
         public async Task VerifyDisplayCategoryDiagram()
         {
             var renderer = this.context.RenderComponent<CategoriesTable>();
-            await renderer.InvokeAsync(() => this.viewModel.SelectCategory(this.elementDefinitionCategory3));
+            await renderer.InvokeAsync(() => this.viewModel.CurrentThing = this.elementDefinitionCategory3);
 
             this.viewModel.CategoryHierarchyDiagramViewModel.SelectedCategory = this.elementDefinitionCategory3;
             this.viewModel.CategoryHierarchyDiagramViewModel.Rows = this.elementDefinitionCategory3.SuperCategory;

--- a/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/CategoriesTableTestFixture.cs
@@ -325,7 +325,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
                 Assert.That(renderer.Markup, Does.Contain(this.elementDefinitionCategory2.Name));
             });
 
-            this.viewModel.Thing = new Category
+            this.viewModel.CurrentThing = new Category
             {
                 Name = "Cat1",
                 ShortName = "TT",
@@ -334,12 +334,12 @@ namespace COMETwebapp.Tests.Components.ReferenceData
             };
 
             this.viewModel.SelectedReferenceDataLibrary = this.siteReferenceDataLibrary;
-            this.viewModel.Thing.PermissibleClass = [ClassKind.ElementDefinition];
+            this.viewModel.CurrentThing.PermissibleClass = [ClassKind.ElementDefinition];
 
             await this.viewModel.CreateCategory(true);
             Assert.That(this.viewModel.Rows.Count, Is.EqualTo(2));
 
-            this.viewModel.Thing = this.viewModel.Thing.Clone(false);
+            this.viewModel.CurrentThing = this.viewModel.CurrentThing.Clone(false);
             await this.viewModel.CreateCategory(false);
 
             Assert.Multiple(() =>
@@ -357,7 +357,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
                 this.logger.Verify(LogLevel.Error, x => !string.IsNullOrWhiteSpace(x.ToString()), Times.Once());
             });
 
-            this.messageBus.SendObjectChangeEvent(this.viewModel.Thing, EventKind.Updated);
+            this.messageBus.SendObjectChangeEvent(this.viewModel.CurrentThing, EventKind.Updated);
             this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate));
         }
 
@@ -407,7 +407,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Thing, Is.InstanceOf(typeof(Category)));
+                Assert.That(this.viewModel.CurrentThing, Is.InstanceOf(typeof(Category)));
             });
 
             await renderer.InvokeAsync(() => grid.Instance.SelectedDataItemChanged.InvokeAsync(firstRow));
@@ -415,7 +415,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(false));
-                Assert.That(this.viewModel.Thing.Original, Is.EqualTo(firstRow.Thing));
+                Assert.That(this.viewModel.CurrentThing.Original, Is.EqualTo(firstRow.Thing));
             });
 
             var editForm = renderer.FindComponent<EditForm>();

--- a/COMETwebapp.Tests/Components/ReferenceData/MeasurementScales/MeasurementScalesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/MeasurementScales/MeasurementScalesTableTestFixture.cs
@@ -100,7 +100,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.MeasurementScales
             this.viewModel.Setup(x => x.ReferenceDataLibraries).Returns([]);
             this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
             this.viewModel.Setup(x => x.MeasurementScaleTypes).Returns(availableMeasurementScaleTypes.Select(x => new ClassKindWrapper(x)));
-            this.viewModel.Setup(x => x.Thing).Returns(new LogarithmicScale());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new LogarithmicScale());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();
@@ -124,7 +124,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.MeasurementScales
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(MeasurementScale)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(MeasurementScale)));
             });
 
             var measurementScalesGrid = renderer.FindComponent<DxGrid>();
@@ -138,7 +138,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.MeasurementScales
             Assert.Multiple(() =>
             {
                 this.viewModel.Verify(x => x.CreateOrEditMeasurementScale(false), Times.Once);
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(LogarithmicScale)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(LogarithmicScale)));
             });
 
             var form = renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/MeasurementUnitsTableTestFixture.cs
@@ -92,7 +92,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
             this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
-            this.viewModel.Setup(x => x.Thing).Returns(new SimpleUnit());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new SimpleUnit());
             this.viewModel.Setup(x => x.MeasurementUnitTypes).Returns([new ClassKindWrapper(ClassKind.SimpleUnit)]);
 
             this.context.Services.AddSingleton(this.viewModel.Object);
@@ -117,7 +117,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(SimpleUnit)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(SimpleUnit)));
             });
 
             var unitsGrid = renderer.FindComponent<DxGrid>();
@@ -131,7 +131,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 this.viewModel.Verify(x => x.CreateOrEditMeasurementUnit(false), Times.Once);
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(SimpleUnit)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(SimpleUnit)));
             });
 
             var form = renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
@@ -54,7 +54,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
 
         private void SetupParameterTypeAndRender(ParameterType parameterType)
         {
-            this.viewModel.Setup(x => x.Thing).Returns(parameterType);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(parameterType);
             this.renderer.Render();
         }
 
@@ -66,7 +66,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
 
             this.viewModel = new Mock<IParameterTypeTableViewModel>();
             this.viewModel.Setup(x => x.ParameterTypes).Returns([new ClassKindWrapper(ClassKind.BooleanParameterType)]);
-            this.viewModel.Setup(x => x.Thing).Returns(new BooleanParameterType());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new BooleanParameterType());
 
             this.renderer = this.context.RenderComponent<ParameterTypeForm>(parameters =>
             {

--- a/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeTableTestFixture.cs
@@ -74,7 +74,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
             this.viewModel.Setup(x => x.ParameterTypes).Returns([new ClassKindWrapper(ClassKind.BooleanParameterType)]);
-            this.viewModel.Setup(x => x.Thing).Returns(new BooleanParameterType());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new BooleanParameterType());
             this.context.Services.AddSingleton(this.viewModel.Object);
         }
 
@@ -108,7 +108,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(ParameterType)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(ParameterType)));
             });
 
             var parameterTypesForm = renderer.FindComponent<ParameterTypeForm>();
@@ -125,7 +125,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
             Assert.Multiple(() =>
             {
                 this.viewModel.Verify(x => x.CreateOrEditParameterType(false), Times.Once);
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(BooleanParameterType)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(BooleanParameterType)));
             });
         }
     }

--- a/COMETwebapp.Tests/Components/SiteDirectory/DomainsOfExpertiseTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/DomainsOfExpertiseTableTestFixture.cs
@@ -87,7 +87,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
             this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
-            this.viewModel.Setup(x => x.Thing).Returns(new DomainOfExpertise());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new DomainOfExpertise());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();
@@ -111,7 +111,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(DomainOfExpertise)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(DomainOfExpertise)));
             });
 
             var domainsGrid = renderer.FindComponent<DxGrid>();
@@ -125,7 +125,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 this.viewModel.Verify(x => x.CreateOrEditDomainOfExpertise(false), Times.Once);
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(DomainOfExpertise)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(DomainOfExpertise)));
             });
 
             var form = renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ActiveDomainsTableTestFixture.cs
@@ -85,7 +85,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             rows.Add(new DomainOfExpertiseRowViewModel(this.domain2));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new DomainOfExpertise());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new DomainOfExpertise());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableTestFixture.cs
@@ -84,7 +84,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             rows.Add(new EngineeringModelRowViewModel(this.engineeringModel2));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new EngineeringModelSetup());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new EngineeringModelSetup());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableTestFixture.cs
@@ -91,7 +91,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             rows.Add(new OrganizationalParticipantRowViewModel(this.organizationParticipant2));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new OrganizationalParticipant());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new OrganizationalParticipant());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();
@@ -140,7 +140,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             Assert.Multiple(() =>
             {
                 Assert.That(this.renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(OrganizationalParticipant)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(OrganizationalParticipant)));
             });
 
             var form = this.renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
@@ -99,7 +99,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             rows.Add(new ParticipantRowViewModel(this.participant2));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(new Participant());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new Participant());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();
@@ -153,7 +153,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             Assert.Multiple(() =>
             {
                 Assert.That(this.renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(Participant)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(Participant)));
             });
 
             var editParticipantButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "editParticipantButton");
@@ -162,7 +162,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             Assert.Multiple(() =>
             {
                 Assert.That(this.renderer.Instance.ShouldCreateThing, Is.EqualTo(false));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(Participant)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(Participant)));
             });
 
             var saveParticipantsButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "saveParticipantsButton");

--- a/COMETwebapp.Tests/Components/SiteDirectory/OrganizationsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/OrganizationsTableTestFixture.cs
@@ -90,7 +90,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
             this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
-            this.viewModel.Setup(x => x.Thing).Returns(new Organization());
+            this.viewModel.Setup(x => x.CurrentThing).Returns(new Organization());
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();
@@ -129,7 +129,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.IsOnEditMode, Is.EqualTo(true));
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(Organization)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(Organization)));
             });
 
             var organizationsGrid = renderer.FindComponent<DxGrid>();
@@ -143,7 +143,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 this.viewModel.Verify(x => x.CreateOrEditOrganization(false), Times.Once);
-                Assert.That(this.viewModel.Object.Thing, Is.InstanceOf(typeof(Organization)));
+                Assert.That(this.viewModel.Object.CurrentThing, Is.InstanceOf(typeof(Organization)));
             });
 
             var form = renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/Components/SiteDirectory/Roles/ParticipantRoleDetailsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/Roles/ParticipantRoleDetailsTestFixture.cs
@@ -67,7 +67,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.Roles
                 Container = new SiteDirectory(){ ShortName = "siteDir" },
             };
 
-            this.viewModel.Setup(x => x.Thing).Returns(this.participantRole);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(this.participantRole);
             this.context.ConfigureDevExpressBlazor();
         }
 

--- a/COMETwebapp.Tests/Components/SiteDirectory/Roles/ParticipantRolesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/Roles/ParticipantRolesTableTestFixture.cs
@@ -74,7 +74,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.Roles
             rows.Add(new ParticipantRoleRowViewModel(this.participantRole1));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(this.participantRole1);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(this.participantRole1);
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/Components/SiteDirectory/Roles/PersonRoleDetailsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/Roles/PersonRoleDetailsTestFixture.cs
@@ -68,7 +68,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.Roles
                 Container = new SiteDirectory(){ ShortName = "siteDir" },
             };
 
-            this.viewModel.Setup(x => x.Thing).Returns(this.personRole);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(this.personRole);
             this.context.ConfigureDevExpressBlazor();
         }
 

--- a/COMETwebapp.Tests/Components/SiteDirectory/Roles/PersonRolesTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/Roles/PersonRolesTableTestFixture.cs
@@ -74,7 +74,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.Roles
             rows.Add(new PersonRoleRowViewModel(this.personRole));
 
             this.viewModel.Setup(x => x.Rows).Returns(rows);
-            this.viewModel.Setup(x => x.Thing).Returns(this.personRole);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(this.personRole);
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/Components/SiteDirectory/UserManagementTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/UserManagementTableTestFixture.cs
@@ -306,7 +306,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
                 Assert.That(renderer.Markup, Does.Contain(this.person1.Name));
             });
 
-            this.viewModel.Thing = new Person
+            this.viewModel.CurrentThing = new Person
             {
                 GivenName = "Test",
                 Surname = "Test",
@@ -318,7 +318,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             };
 
             await this.viewModel.CreateOrEditPerson(true);
-            this.messageBus.SendMessage(new ObjectChangedEvent(this.viewModel.Thing, EventKind.Added));
+            this.messageBus.SendMessage(new ObjectChangedEvent(this.viewModel.CurrentThing, EventKind.Added));
 
             Assert.Multiple(() =>
             {
@@ -338,7 +338,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 Assert.That(renderer.Instance.ShouldCreateThing, Is.EqualTo(true));
-                Assert.That(this.viewModel.Thing, Is.InstanceOf(typeof(Person)));
+                Assert.That(this.viewModel.CurrentThing, Is.InstanceOf(typeof(Person)));
             });
 
             var domainsGrid = renderer.FindComponent<DxGrid>();
@@ -352,7 +352,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             Assert.Multiple(() =>
             {
                 this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Once);
-                Assert.That(this.viewModel.Thing, Is.InstanceOf(typeof(Person)));
+                Assert.That(this.viewModel.CurrentThing, Is.InstanceOf(typeof(Person)));
             });
 
             var form = renderer.FindComponent<DxGrid>();

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/CommonFileStoreTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/CommonFileStoreTableViewModelTestFixture.cs
@@ -132,13 +132,13 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
         public async Task VerifyCommonFileStoreCreateOrEdit()
         {
             this.viewModel.InitializeViewModel();
-            this.viewModel.Thing = this.commonFileStore;
+            this.viewModel.CurrentThing = this.commonFileStore;
 
             await this.viewModel.CreateOrEditCommonFileStore(true);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModel>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Once);
 
             this.sessionService.Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>())).Throws(new Exception());
-            this.viewModel.Thing = new CommonFileStore();
+            this.viewModel.CurrentThing = new CommonFileStore();
             await this.viewModel.CreateOrEditCommonFileStore(false);
             this.loggerMock.Verify(LogLevel.Error, x => !string.IsNullOrWhiteSpace(x.ToString()), Times.Once());
         }

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
@@ -141,7 +141,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
             await this.viewModel.MoveFile(this.commonFileStore.File[0], this.commonFileStore.Folder[0]);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
 
-            this.viewModel.SelectFile(this.commonFileStore.File[0]);
             await this.viewModel.DeleteFile();
             this.sessionService.Verify(x => x.DeleteThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
         }
@@ -153,9 +152,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
 
             var domain = new DomainOfExpertise();
             this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise = domain;
-            Assert.That(this.viewModel.File.Owner, Is.EqualTo(domain));
-
-            this.viewModel.SelectFile(this.commonFileStore.File[0]);
+            Assert.That(this.viewModel.CurrentThing.Owner, Is.EqualTo(domain));
 
             await this.viewModel.CreateOrEditFile(false);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.Is<IReadOnlyCollection<Thing>>(c => !c.OfType<FileStore>().Any()), It.IsAny<IReadOnlyCollection<string>>()), Times.Once);
@@ -172,7 +169,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
                     It.Is<IReadOnlyCollection<string>>(c => c.Contains("/localpath")))
                 , Times.Once);
 
-                Assert.That(this.viewModel.File.LockedBy, Is.Not.Null);
+                Assert.That(this.viewModel.CurrentThing.LockedBy, Is.Not.Null);
             });
         }
     }

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
@@ -138,6 +138,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
         public async Task VerifyMoveAndDeleteFile()
         {
             this.viewModel.InitializeViewModel(this.commonFileStore, this.iteration);
+            this.viewModel.CurrentThing = this.commonFileStore.File[0];
+
             await this.viewModel.MoveFile(this.commonFileStore.File[0], this.commonFileStore.Folder[0]);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
 

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FolderHandlerViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FolderHandlerViewModelTestFixture.cs
@@ -131,6 +131,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
         public async Task VerifyMoveAndDeleteFolder()
         {
             this.viewModel.InitializeViewModel(this.commonFileStore, this.iteration);
+            this.viewModel.CurrentThing = this.commonFileStore.Folder[0];
             await this.viewModel.MoveFolder(this.commonFileStore.Folder[0], this.commonFileStore.Folder[1]);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
 

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FolderHandlerViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FolderHandlerViewModelTestFixture.cs
@@ -134,7 +134,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
             await this.viewModel.MoveFolder(this.commonFileStore.Folder[0], this.commonFileStore.Folder[1]);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
 
-            this.viewModel.SelectFolder(this.commonFileStore.Folder[0]);
             await this.viewModel.DeleteFolder();
             this.sessionService.Verify(x => x.DeleteThings(It.IsAny<FileStore>(), It.IsAny<IReadOnlyCollection<Thing>>()), Times.Once);
         }
@@ -146,9 +145,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
 
             var domain = new DomainOfExpertise();
             this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise = domain;
-            Assert.That(this.viewModel.Folder.Owner, Is.EqualTo(domain));
+            Assert.That(this.viewModel.CurrentThing.Owner, Is.EqualTo(domain));
 
-            this.viewModel.SelectFolder(this.commonFileStore.Folder[0]);
             await this.viewModel.CreateOrEditFolder(false);
             this.sessionService.Verify(x => x.CreateOrUpdateThings(It.IsAny<FileStore>(), It.Is<IReadOnlyCollection<Thing>>(c => !c.OfType<FileStore>().Any())), Times.Once);
 

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
@@ -152,7 +152,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
             this.viewModel.SetCurrentIteration(this.iteration);
             this.viewModel.SetCurrentOption(this.option);
 
-            Assert.That(this.viewModel.Thing.Original, Is.Not.Null);
+            Assert.That(this.viewModel.CurrentThing.Original, Is.Not.Null);
             await this.viewModel.CreateOrEditOption(true);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModel>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Once);
 

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
@@ -150,14 +150,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
         {
             this.viewModel.InitializeViewModel();
             this.viewModel.SetCurrentIteration(this.iteration);
-            this.viewModel.SetCurrentOption(this.option);
 
             Assert.That(this.viewModel.CurrentThing.Original, Is.Not.Null);
             await this.viewModel.CreateOrEditOption(true);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<EngineeringModel>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Once);
 
             this.sessionService.Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>())).Throws(new Exception());
-            this.viewModel.SetCurrentOption(new Option());
             this.viewModel.SelectedIsDefaultValue = true;
 
             await this.viewModel.CreateOrEditOption(false);

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/OptionsTableViewModelTestFixture.cs
@@ -150,6 +150,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel
         {
             this.viewModel.InitializeViewModel();
             this.viewModel.SetCurrentIteration(this.iteration);
+            this.viewModel.CurrentThing = this.option.Clone(true);
 
             Assert.That(this.viewModel.CurrentThing.Original, Is.Not.Null);
             await this.viewModel.CreateOrEditOption(true);

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
@@ -247,6 +247,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             Assert.That(this.viewModel.CurrentThing, Is.TypeOf<LogarithmicScale>());
 
             var measurementScaleToSet = new LogarithmicScale();
+            this.viewModel.CurrentThing = measurementScaleToSet;
 
             Assert.Multiple(() =>
             {

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementScalesTableViewModelTestFixture.cs
@@ -124,7 +124,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
         public void VerifyInitializeViewModel()
         {
             this.viewModel.InitializeViewModel();
-            this.viewModel.Thing.ValueDefinition.Add(new ScaleValueDefinition());
+            this.viewModel.CurrentThing.ValueDefinition.Add(new ScaleValueDefinition());
 
             Assert.Multiple(() =>
             {
@@ -157,18 +157,18 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 ReferenceScaleValue = new ScaleValueDefinition()
             };
 
-            this.viewModel.Thing.ValueDefinition.Add(scaleValueDefinition);
-            this.viewModel.Thing.MappingToReferenceScale.Add(mappingToReferenceScale);
+            this.viewModel.CurrentThing.ValueDefinition.Add(scaleValueDefinition);
+            this.viewModel.CurrentThing.MappingToReferenceScale.Add(mappingToReferenceScale);
             this.viewModel.SelectedReferenceQuantityValue.Value = "value";
             this.viewModel.SelectedReferenceQuantityValue.Scale = new OrdinalScale();
-            Assert.That(((LogarithmicScale)this.viewModel.Thing).ReferenceQuantityValue, Has.Count.EqualTo(0));
+            Assert.That(((LogarithmicScale)this.viewModel.CurrentThing).ReferenceQuantityValue, Has.Count.EqualTo(0));
 
             await this.viewModel.CreateOrEditMeasurementScale(true);
 
             Assert.Multiple(() =>
             {
                 this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Once);
-                Assert.That(((LogarithmicScale)this.viewModel.Thing).ReferenceQuantityValue, Has.Count.EqualTo(1));
+                Assert.That(((LogarithmicScale)this.viewModel.CurrentThing).ReferenceQuantityValue, Has.Count.EqualTo(1));
             });
 
             var exceptionalError = new ExceptionalError(new InvalidDataException("Invalid data"));
@@ -183,10 +183,10 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Exactly(2));
-                Assert.That(((LogarithmicScale)this.viewModel.Thing).ReferenceQuantityValue, Has.Count.EqualTo(0));
+                Assert.That(((LogarithmicScale)this.viewModel.CurrentThing).ReferenceQuantityValue, Has.Count.EqualTo(0));
             });
 
-            ((LogarithmicScale)this.viewModel.Thing).ReferenceQuantityValue.Add(new ScaleReferenceQuantityValue { Value = "val" });
+            ((LogarithmicScale)this.viewModel.CurrentThing).ReferenceQuantityValue.Add(new ScaleReferenceQuantityValue { Value = "val" });
             this.viewModel.SelectedReferenceQuantityValue.Value = "value";
             this.viewModel.SelectedReferenceQuantityValue.Scale = new OrdinalScale();
             await this.viewModel.CreateOrEditMeasurementScale(true);
@@ -194,7 +194,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             Assert.Multiple(() =>
             {
                 this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Exactly(3));
-                Assert.That(((LogarithmicScale)this.viewModel.Thing).ReferenceQuantityValue, Has.Count.EqualTo(1));
+                Assert.That(((LogarithmicScale)this.viewModel.CurrentThing).ReferenceQuantityValue, Has.Count.EqualTo(1));
             });
 
             this.sessionService.Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>())).Throws(new Exception());
@@ -227,33 +227,32 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing, Is.TypeOf<OrdinalScale>());
+                Assert.That(this.viewModel.CurrentThing, Is.TypeOf<OrdinalScale>());
                 Assert.That(this.viewModel.SelectedMeasurementScaleType.ClassKind, Is.EqualTo(ClassKind.OrdinalScale));
             });
 
             this.viewModel.SelectedMeasurementScaleType = new ClassKindWrapper(ClassKind.CyclicRatioScale);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<CyclicRatioScale>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<CyclicRatioScale>());
 
             this.viewModel.SelectedMeasurementScaleType = new ClassKindWrapper(ClassKind.IntervalScale);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<IntervalScale>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<IntervalScale>());
 
             this.viewModel.SelectedMeasurementScaleType = new ClassKindWrapper(ClassKind.RatioScale);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<RatioScale>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<RatioScale>());
 
             this.viewModel.SelectedMeasurementScaleType = new ClassKindWrapper(ClassKind.LogarithmicScale);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<LogarithmicScale>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<LogarithmicScale>());
 
             this.viewModel.SelectedMeasurementScaleType = new ClassKindWrapper(ClassKind.SimpleUnit);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<LogarithmicScale>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<LogarithmicScale>());
 
             var measurementScaleToSet = new LogarithmicScale();
-            this.viewModel.SelectMeasurementScale(measurementScaleToSet);
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing, Is.EqualTo(measurementScaleToSet));
-                Assert.That(this.viewModel.Thing.ValueDefinition, Is.EqualTo(measurementScaleToSet.ValueDefinition));
-                Assert.That(this.viewModel.Thing.MappingToReferenceScale, Is.EqualTo(measurementScaleToSet.MappingToReferenceScale));
+                Assert.That(this.viewModel.CurrentThing, Is.EqualTo(measurementScaleToSet));
+                Assert.That(this.viewModel.CurrentThing.ValueDefinition, Is.EqualTo(measurementScaleToSet.ValueDefinition));
+                Assert.That(this.viewModel.CurrentThing.MappingToReferenceScale, Is.EqualTo(measurementScaleToSet.MappingToReferenceScale));
             });
         }
 

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/MeasurementUnitsTableViewModelTestFixture.cs
@@ -187,21 +187,21 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing, Is.TypeOf<SimpleUnit>());
+                Assert.That(this.viewModel.CurrentThing, Is.TypeOf<SimpleUnit>());
                 Assert.That(this.viewModel.SelectedMeasurementUnitType.ClassKind, Is.EqualTo(ClassKind.SimpleUnit));
             });
 
             this.viewModel.SelectedMeasurementUnitType = new ClassKindWrapper(ClassKind.LinearConversionUnit);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<LinearConversionUnit>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<LinearConversionUnit>());
 
             this.viewModel.SelectedMeasurementUnitType = new ClassKindWrapper(ClassKind.PrefixedUnit);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<PrefixedUnit>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<PrefixedUnit>());
 
             this.viewModel.SelectedMeasurementUnitType = new ClassKindWrapper(ClassKind.Person);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<PrefixedUnit>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<PrefixedUnit>());
 
             this.viewModel.SelectedMeasurementUnitType = new ClassKindWrapper(ClassKind.DerivedUnit);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<DerivedUnit>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<DerivedUnit>());
 
             var unitFactor = new UnitFactor()
             {
@@ -209,7 +209,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Exponent = "exp"
             };
 
-            ((DerivedUnit)this.viewModel.Thing).UnitFactor.Add(unitFactor);
+            ((DerivedUnit)this.viewModel.CurrentThing).UnitFactor.Add(unitFactor);
             await this.viewModel.CreateOrEditMeasurementUnit(true);
 
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -133,7 +133,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Assert.That(this.viewModel.MeasurementScales.Count(), Is.EqualTo(1));
             });
 
-            this.viewModel.Thing = new SpecializedQuantityKind
+            this.viewModel.CurrentThing = new SpecializedQuantityKind
             {
                 General = new SimpleQuantityKind()
             };
@@ -156,12 +156,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Exactly(2));
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.CompoundParameterType);
-            this.viewModel.Thing = this.viewModel.Thing.Clone(false);
+            this.viewModel.CurrentThing = this.viewModel.CurrentThing.Clone(false);
             await this.viewModel.CreateOrEditParameterType(true);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Exactly(3));
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.DerivedQuantityKind);
-            this.viewModel.Thing = this.viewModel.Thing.Clone(true);
+            this.viewModel.CurrentThing = this.viewModel.CurrentThing.Clone(true);
             await this.viewModel.CreateOrEditParameterType(false);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()), Times.Exactly(4));
 
@@ -195,42 +195,42 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing, Is.TypeOf<BooleanParameterType>());
+                Assert.That(this.viewModel.CurrentThing, Is.TypeOf<BooleanParameterType>());
                 Assert.That(this.viewModel.SelectedParameterType.ClassKind, Is.EqualTo(ClassKind.BooleanParameterType));
             });
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.CompoundParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<CompoundParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<CompoundParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.DateParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<DateParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<DateParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.DateTimeParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<DateTimeParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<DateTimeParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.DerivedQuantityKind);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<DerivedQuantityKind>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<DerivedQuantityKind>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.EnumerationParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<EnumerationParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<EnumerationParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.SampledFunctionParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<SampledFunctionParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<SampledFunctionParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.SimpleQuantityKind);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<SimpleQuantityKind>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<SimpleQuantityKind>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.SpecializedQuantityKind);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<SpecializedQuantityKind>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<SpecializedQuantityKind>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.TextParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<TextParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<TextParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.TimeOfDayParameterType);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<TimeOfDayParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<TimeOfDayParameterType>());
 
             this.viewModel.SelectedParameterType = new ClassKindWrapper(ClassKind.DomainOfExpertise);
-            Assert.That(this.viewModel.Thing, Is.TypeOf<TimeOfDayParameterType>());
+            Assert.That(this.viewModel.CurrentThing, Is.TypeOf<TimeOfDayParameterType>());
 
             var parameterTypeToSet = new BooleanParameterType
             {
@@ -241,7 +241,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing, Is.EqualTo(parameterTypeToSet));
+                Assert.That(this.viewModel.CurrentThing, Is.EqualTo(parameterTypeToSet));
                 Assert.That(this.viewModel.SelectedReferenceDataLibrary, Is.EqualTo(parameterTypeToSet.Container));
             });
         }

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -237,8 +237,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Container = new SiteReferenceDataLibrary()
             };
 
-            this.viewModel.SelectParameterType(parameterTypeToSet);
-
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.CurrentThing, Is.EqualTo(parameterTypeToSet));

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -237,6 +237,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Container = new SiteReferenceDataLibrary()
             };
 
+            this.viewModel.CurrentThing = parameterTypeToSet;
+
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.CurrentThing, Is.EqualTo(parameterTypeToSet));

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModelTestFixture.cs
@@ -190,7 +190,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.IsOnDeletionMode, Is.EqualTo(true));
-                Assert.That(this.viewModel.Thing, Is.EqualTo(modelRow.Thing));
+                Assert.That(this.viewModel.CurrentThing, Is.EqualTo(modelRow.Thing));
             });
 
             this.viewModel.OnCancelPopupButtonClick();

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/OrganizationalParticipantsTableViewModelTestFixture.cs
@@ -148,7 +148,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.IsOnDeletionMode, Is.EqualTo(true));
-                Assert.That(this.viewModel.Thing, Is.EqualTo(organizationalParticipantRow.Thing));
+                Assert.That(this.viewModel.CurrentThing, Is.EqualTo(organizationalParticipantRow.Thing));
             });
 
             this.viewModel.OnCancelPopupButtonClick();

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
@@ -174,7 +174,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.IsOnDeletionMode, Is.EqualTo(true));
-                Assert.That(this.viewModel.Thing, Is.EqualTo(participantRow.Thing));
+                Assert.That(this.viewModel.CurrentThing, Is.EqualTo(participantRow.Thing));
             });
 
             this.viewModel.OnCancelPopupButtonClick();
@@ -228,7 +228,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Thing.Iid, Is.EqualTo(this.participant.Iid));
+                Assert.That(this.viewModel.CurrentThing.Iid, Is.EqualTo(this.participant.Iid));
                 Assert.That(this.viewModel.SelectedDomains, Is.EqualTo(this.participant.Domain));
                 Assert.That(this.viewModel.DomainsOfExpertise, Has.Count.EqualTo(1));
             });

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModelTestFixture.cs
@@ -224,8 +224,6 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory.EngineeringModel
             this.viewModel.InitializeViewModel(this.model);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
 
-            this.viewModel.SelectThing(this.participant);
-
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.CurrentThing.Iid, Is.EqualTo(this.participant.Iid));

--- a/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
@@ -71,7 +71,11 @@ namespace COMETwebapp.Components.Common
             this.ViewModel = viewModel;
             this.ViewModel.InitializeViewModel();
 
-            this.Disposables.Add(this.ViewModel.WhenAnyValue(x => x.IsLoading).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+            this.Disposables.Add(this.ViewModel.WhenAnyValue(
+                    x => x.IsLoading,
+                    x => x.CurrentThing)
+                .SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+
             this.Disposables.Add(this.ViewModel.Rows.CountChanged.SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.ViewModel.Rows.Connect().AutoRefresh().SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
         }

--- a/COMETwebapp/Components/Common/SelectedDeprecatableDataItemBase.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDeprecatableDataItemBase.razor.cs
@@ -119,7 +119,7 @@ namespace COMETwebapp.Components.Common
             }
 
             this.ShouldCreateThing = false;
-            var createdRow = this.ViewModel.Rows.Items.FirstOrDefault(x => x.Thing.Iid == this.ViewModel.Thing.Iid);
+            var createdRow = this.ViewModel.Rows.Items.FirstOrDefault(x => x.Thing.Iid == this.ViewModel.CurrentThing.Iid);
 
             if (createdRow is null)
             {

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresForm.razor
@@ -16,11 +16,11 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.Name"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Owner:" ColSpanMd="10">
             <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)"

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor.cs
@@ -71,7 +71,7 @@ namespace COMETwebapp.Components.EngineeringModel
             base.CustomizeEditThing(e);
 
             var dataItem = (CommonFileStoreRowViewModel)e.DataItem;
-            this.ViewModel.SelectCommonFileStore(dataItem == null ? new CommonFileStore() : dataItem.Thing.Clone(true));
+            this.ViewModel.CurrentThing = dataItem == null ? new CommonFileStore() : dataItem.Thing.Clone(true);
             e.EditModel = this.ViewModel.CurrentThing;
             this.IsOnEditMode = false;
         }
@@ -83,7 +83,7 @@ namespace COMETwebapp.Components.EngineeringModel
         protected override void OnSelectedDataItemChanged(CommonFileStoreRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
-            this.ViewModel.SelectCommonFileStore(row.Thing);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor.cs
@@ -72,7 +72,7 @@ namespace COMETwebapp.Components.EngineeringModel
 
             var dataItem = (CommonFileStoreRowViewModel)e.DataItem;
             this.ViewModel.SelectCommonFileStore(dataItem == null ? new CommonFileStore() : dataItem.Thing.Clone(true));
-            e.EditModel = this.ViewModel.Thing;
+            e.EditModel = this.ViewModel.CurrentThing;
             this.IsOnEditMode = false;
         }
 

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
@@ -17,13 +17,13 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @using COMETwebapp.Extensions
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.File)" OnValidSubmit="@(async () => await this.OnValidSubmit())">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(async () => await this.OnValidSubmit())">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Is Locked:" ColSpanMd="6">
             <DxCheckBox @bind-Checked="@this.ViewModel.IsLocked" />
         </DxFormLayoutItem>
-        <DxFormLayoutItem Caption="@($"Locked By: {this.ViewModel.File.LockedBy?.Name}")" ColSpanMd="6"/>
+        <DxFormLayoutItem Caption="@($"Locked By: {this.ViewModel.CurrentThing.LockedBy?.Name}")" ColSpanMd="6"/>
         <DxFormLayoutItem Caption="Owner:" ColSpanMd="10">
             <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)"
                                        DisplayText="@(string.Empty)"
@@ -75,7 +75,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 </EditForm>
 
 <DxPopup @bind-Visible="@this.IsDeletePopupVisible" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
-    You are about to delete the File: @(this.ViewModel.File.CurrentFileRevision?.Name)
+    You are about to delete the File: @(this.ViewModel.CurrentThing.CurrentFileRevision?.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(() => this.IsDeletePopupVisible = false)" />
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFilePopupButton" />

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FolderFileStructure.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FolderFileStructure.razor.cs
@@ -100,7 +100,7 @@ namespace COMETwebapp.Components.EngineeringModel.FileStore
                 return;
             }
 
-            this.ViewModel.FolderHandlerViewModel.SelectFolder(row == null ? new Folder() : (Folder)row.Thing);
+            this.ViewModel.FolderHandlerViewModel.CurrentThing = row == null ? new Folder() : (Folder)row.Thing.Clone(true);
             this.ShouldCreateFolder = row == null;
             this.IsFolderFormVisibile = true;
         }
@@ -116,7 +116,7 @@ namespace COMETwebapp.Components.EngineeringModel.FileStore
                 return;
             }
 
-            this.ViewModel.FileHandlerViewModel.SelectFile(row == null ? new File() : (File)row.Thing);
+            this.ViewModel.FileHandlerViewModel.CurrentThing = row == null ? new File() : (File)row.Thing.Clone(true);
             this.ShouldCreateFile = row == null;
             this.IsFileFormVisibile = true;
         }

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
@@ -17,11 +17,11 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @using COMETwebapp.Extensions
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Folder)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Folder.Name" />
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name" />
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Owner:" ColSpanMd="10">
             <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)"
@@ -35,7 +35,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 <DxComboBox Data="@this.ViewModel.Folders"
                             TextFieldName="@nameof(Folder.Name)"
                             NullText="root"
-                            @bind-Value="@this.ViewModel.Folder.ContainingFolder"
+                            @bind-Value="@this.ViewModel.CurrentThing.ContainingFolder"
                             CssClass="cw-480">
                     <ItemTemplate Context="itemTemplateContext">
                         @itemTemplateContext.GetFolderPath()
@@ -67,7 +67,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 </EditForm>
 
 <DxPopup @bind-Visible="@this.IsDeletePopupVisible" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
-    You are about to delete the Folder: @(this.ViewModel.Folder.Name)
+    You are about to delete the Folder: @(this.ViewModel.CurrentThing.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(() => this.IsDeletePopupVisible = false)" />
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFolderPopupButton" />

--- a/COMETwebapp/Components/EngineeringModel/OptionsForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/OptionsForm.razor
@@ -16,14 +16,14 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.ShortName"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.ShortName"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.Name"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Is Default:" ColSpanMd="6">
             <DxCheckBox @bind-Checked="@this.ViewModel.SelectedIsDefaultValue"/>

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
@@ -66,7 +66,7 @@ namespace COMETwebapp.Components.EngineeringModel
             base.CustomizeEditThing(e);
 
             var dataItem = (OptionRowViewModel)e.DataItem;
-            this.ViewModel.CurrentThing = dataItem == null ? new Option() : dataItem.Thing.Clone(true);
+            this.ViewModel.CurrentThing = dataItem == null ? new Option().Clone(true) : dataItem.Thing.Clone(true);
             e.EditModel = this.ViewModel.CurrentThing;
             this.IsOnEditMode = false;
         }

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
@@ -67,7 +67,7 @@ namespace COMETwebapp.Components.EngineeringModel
 
             var dataItem = (OptionRowViewModel)e.DataItem;
             this.ViewModel.SetCurrentOption(dataItem == null ? new Option() : dataItem.Thing);
-            e.EditModel = this.ViewModel.Thing;
+            e.EditModel = this.ViewModel.CurrentThing;
             this.IsOnEditMode = false;
         }
 

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor.cs
@@ -66,7 +66,7 @@ namespace COMETwebapp.Components.EngineeringModel
             base.CustomizeEditThing(e);
 
             var dataItem = (OptionRowViewModel)e.DataItem;
-            this.ViewModel.SetCurrentOption(dataItem == null ? new Option() : dataItem.Thing);
+            this.ViewModel.CurrentThing = dataItem == null ? new Option() : dataItem.Thing.Clone(true);
             e.EditModel = this.ViewModel.CurrentThing;
             this.IsOnEditMode = false;
         }
@@ -78,7 +78,7 @@ namespace COMETwebapp.Components.EngineeringModel
         protected override void OnSelectedDataItemChanged(OptionRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
-            this.ViewModel.SetCurrentOption(row.Thing);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ReferenceData/Categories/CategoriesForm.razor
+++ b/COMETwebapp/Components/ReferenceData/Categories/CategoriesForm.razor
@@ -23,22 +23,22 @@ Copyright (c) 2024 Starion Group S.A.
 @using CDP4Common.CommonData
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator/>
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutTabPages>
             <DxFormLayoutTabPage Caption="Basic">
                 <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Abstract:" ColSpanMd="6">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsAbstract)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsAbstract)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="10">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsDeprecated)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsDeprecated)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Library:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.ReferenceDataLibraries)"
@@ -52,9 +52,9 @@ Copyright (c) 2024 Starion Group S.A.
                     <DxListBox Data="@(this.ViewModel.PermissibleClasses)"
                                TData="ClassKindWrapper"
                                TValue="ClassKind"
-                               Values="@(this.ViewModel.Thing.PermissibleClass)"
-                               ValuesChanged="@(permissibleClasses => this.ViewModel.Thing.PermissibleClass = permissibleClasses.ToList())"
-                               ValuesExpression="@(() => this.ViewModel.Thing.PermissibleClass)"
+                               Values="@(this.ViewModel.CurrentThing.PermissibleClass)"
+                               ValuesChanged="@(permissibleClasses => this.ViewModel.CurrentThing.PermissibleClass = permissibleClasses.ToList())"
+                               ValuesExpression="@(() => this.ViewModel.CurrentThing.PermissibleClass)"
                                SelectionMode="ListBoxSelectionMode.Multiple"
                                TextFieldName="@nameof(ClassKindWrapper.ClassKindName)"
                                ValueFieldName="@nameof(ClassKindWrapper.ClassKind)"
@@ -66,9 +66,9 @@ Copyright (c) 2024 Starion Group S.A.
                     <DxListBox TData="Category"
                                TValue="Category" 
                                Data="@(this.ViewModel.Rows.Items.Select(x => x.Thing))"
-                               Values="@(this.ViewModel.Thing.SuperCategory)"
-                               ValuesChanged="@(superCategories => this.ViewModel.Thing.SuperCategory = superCategories.ToList())"
-                               ValuesExpression="@(() => this.ViewModel.Thing.SuperCategory)"
+                               Values="@(this.ViewModel.CurrentThing.SuperCategory)"
+                               ValuesChanged="@(superCategories => this.ViewModel.CurrentThing.SuperCategory = superCategories.ToList())"
+                               ValuesExpression="@(() => this.ViewModel.CurrentThing.SuperCategory)"
                                SelectionMode="ListBoxSelectionMode.Multiple"
                                TextFieldName="@nameof(Category.Name)"
                                ShowCheckboxes="true"/>

--- a/COMETwebapp/Components/ReferenceData/Categories/CategoriesTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/Categories/CategoriesTable.razor.cs
@@ -61,7 +61,7 @@ namespace COMETwebapp.Components.ReferenceData.Categories
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.SelectCategory(row.Thing.Clone(true));
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace COMETwebapp.Components.ReferenceData.Categories
         {
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
-            this.ViewModel.SelectCategory(new Category());
+            this.ViewModel.CurrentThing = new Category();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
@@ -22,7 +22,7 @@ Copyright (c) 2024 Starion Group S.A.
 @using COMETwebapp.Wrappers
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator/>
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutTabPages>
@@ -38,10 +38,10 @@ Copyright (c) 2024 Starion Group S.A.
                 }
 
                 <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Library:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.ReferenceDataLibraries)"
@@ -53,41 +53,41 @@ Copyright (c) 2024 Starion Group S.A.
                 <DxFormLayoutItem Caption="Unit:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.MeasurementUnits)"
                                 TextFieldName="@nameof(MeasurementUnit.ShortName)"
-                                @bind-Value="@(this.ViewModel.Thing.Unit)"
+                                @bind-Value="@(this.ViewModel.CurrentThing.Unit)"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Number set:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.NumberSetKinds)"
-                                @bind-Value="@(this.ViewModel.Thing.NumberSet)"
+                                @bind-Value="@(this.ViewModel.CurrentThing.NumberSet)"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Maximum Permissible Value:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.MaximumPermissibleValue)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.MaximumPermissibleValue)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Minimum Permissible Value:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.MinimumPermissibleValue)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.MinimumPermissibleValue)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Positive Value Connotation:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.PositiveValueConnotation)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.PositiveValueConnotation)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Negative Value Connotation:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.NegativeValueConnotation)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.NegativeValueConnotation)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Minimum Inclusive:" ColSpanMd="10">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsMinimumInclusive)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsMinimumInclusive)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Maximum Inclusive:" ColSpanMd="10">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsMaximumInclusive)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsMaximumInclusive)"/>
                 </DxFormLayoutItem>
 
-                @if (this.ViewModel.Thing is CyclicRatioScale ciclicRatioScale)
+                @if (this.ViewModel.CurrentThing is CyclicRatioScale ciclicRatioScale)
                 {
                     <DxFormLayoutItem Caption="Modulus:" ColSpanMd="10">
                         <DxTextBox @bind-Text="@(ciclicRatioScale.Modulus)"/>
                     </DxFormLayoutItem>
                 }
 
-                @if (this.ViewModel.Thing is OrdinalScale ordinalScale)
+                @if (this.ViewModel.CurrentThing is OrdinalScale ordinalScale)
                 {
                     <DxFormLayoutItem Caption="Use Shortname Values:" ColSpanMd="10">
                         <DxCheckBox @bind-Checked="@(ordinalScale.UseShortNameValues)"/>
@@ -95,11 +95,11 @@ Copyright (c) 2024 Starion Group S.A.
                 }
 
                 <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="10">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsDeprecated)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsDeprecated)"/>
                 </DxFormLayoutItem>
             </DxFormLayoutTabPage>
 
-            @if (this.ViewModel.Thing is LogarithmicScale logarithmicScale)
+            @if (this.ViewModel.CurrentThing is LogarithmicScale logarithmicScale)
             {
                 <DxFormLayoutTabPage Id="LogarithmTab" Caption="Logarithm">
                     <DxFormLayoutItem Caption="Logarithmic Base:" ColSpanMd="10">
@@ -138,11 +138,11 @@ Copyright (c) 2024 Starion Group S.A.
             }
 
             <DxFormLayoutTabPage Caption="Value Definition">
-                <ScaleValueDefinitionsTable @bind-MeasurementScale="@(this.ViewModel.Thing)"/>
+                <ScaleValueDefinitionsTable @bind-MeasurementScale="@(this.ViewModel.CurrentThing)"/>
             </DxFormLayoutTabPage>
             <DxFormLayoutTabPage Caption="Mappings">
-                <MappingToReferenceScalesTable @bind-MeasurementScale="@(this.ViewModel.Thing)"
-                                               DependentScaleValueDefinitions="@(this.ViewModel.Thing.ValueDefinition)"
+                <MappingToReferenceScalesTable @bind-MeasurementScale="@(this.ViewModel.CurrentThing)"
+                                               DependentScaleValueDefinitions="@(this.ViewModel.CurrentThing.ValueDefinition)"
                                                ReferenceScaleValueDefinitions="@(this.ViewModel.ReferenceScaleValueDefinitions)"/>
             </DxFormLayoutTabPage>
         </DxFormLayoutTabPages>

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor.cs
@@ -62,7 +62,7 @@ namespace COMETwebapp.Components.ReferenceData.MeasurementScales
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.SelectMeasurementScale(row.Thing.Clone(true));
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace COMETwebapp.Components.ReferenceData.MeasurementScales
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
             this.ViewModel.SelectedMeasurementScaleType = this.ViewModel.MeasurementScaleTypes.First(x => x.ClassKind == ClassKind.CyclicRatioScale);
-            this.ViewModel.SelectMeasurementScale(new CyclicRatioScale());
+            this.ViewModel.CurrentThing = new CyclicRatioScale();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsForm.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsForm.razor
@@ -22,7 +22,7 @@ Copyright (c) 2024 Starion Group S.A.
 @using COMETwebapp.Wrappers
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator/>
 
     <DxFormLayout CssClass="w-100">
@@ -38,11 +38,11 @@ Copyright (c) 2024 Starion Group S.A.
         }
 
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"
                        ReadOnly="@(this.ShouldNameAndShortNameBeReadOnly)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"
                        ReadOnly="@(this.ShouldNameAndShortNameBeReadOnly)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Library:" ColSpanMd="10">
@@ -53,7 +53,7 @@ Copyright (c) 2024 Starion Group S.A.
         </DxFormLayoutItem>
 
 
-        @if (this.ViewModel.Thing is ConversionBasedUnit conversionBasedUnit)
+        @if (this.ViewModel.CurrentThing is ConversionBasedUnit conversionBasedUnit)
         {
             <DxFormLayoutItem Caption="Reference Unit:" ColSpanMd="10">
                 <DxComboBox Data="@(this.ViewModel.ReferenceUnits)"
@@ -63,14 +63,14 @@ Copyright (c) 2024 Starion Group S.A.
             </DxFormLayoutItem>
         }
 
-        @if (this.ViewModel.Thing is LinearConversionUnit linearConvertionUnit)
+        @if (this.ViewModel.CurrentThing is LinearConversionUnit linearConvertionUnit)
         {
             <DxFormLayoutItem Caption="Conversion Factor:" ColSpanMd="10">
                 <DxTextBox @bind-Text="@(linearConvertionUnit.ConversionFactor)"/>
             </DxFormLayoutItem>
         }
 
-        @if (this.ViewModel.Thing is PrefixedUnit prefixedUnit)
+        @if (this.ViewModel.CurrentThing is PrefixedUnit prefixedUnit)
         {
             <DxFormLayoutItem Caption="Prefix:" ColSpanMd="10">
                 <DxComboBox Data="@(this.ViewModel.Prefixes)"
@@ -81,10 +81,10 @@ Copyright (c) 2024 Starion Group S.A.
         }
 
         <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsDeprecated)"/>
+            <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsDeprecated)"/>
         </DxFormLayoutItem>
 
-        @if (this.ViewModel.Thing is DerivedUnit derivedUnit)
+        @if (this.ViewModel.CurrentThing is DerivedUnit derivedUnit)
         {
             <DxFormLayoutItem Caption="Unit Factors:"
                               ColSpanMd="12"

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsForm.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsForm.razor.cs
@@ -48,7 +48,7 @@ namespace COMETwebapp.Components.ReferenceData.MeasurementUnits
         /// <summary>
         /// Condition to check if the shortname and name fields should be readonly
         /// </summary>
-        private bool ShouldNameAndShortNameBeReadOnly => this.ViewModel.Thing is PrefixedUnit;
+        private bool ShouldNameAndShortNameBeReadOnly => this.ViewModel.CurrentThing is PrefixedUnit;
 
         /// <summary>
         /// Method that is executed when there is a valid submit

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTable.razor.cs
@@ -62,7 +62,7 @@ namespace COMETwebapp.Components.ReferenceData.MeasurementUnits
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.SelectMeasurementUnit(row.Thing.Clone(true));
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace COMETwebapp.Components.ReferenceData.MeasurementUnits
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
             this.ViewModel.SelectedMeasurementUnitType = this.ViewModel.MeasurementUnitTypes.First(x => x.ClassKind == ClassKind.SimpleUnit);
-            this.ViewModel.SelectMeasurementUnit(new SimpleUnit());
+            this.ViewModel.CurrentThing = new SimpleUnit();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -22,7 +22,7 @@ Copyright (c) 2024 Starion Group S.A.
 @using COMETwebapp.Wrappers
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator/>
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutTabPages>
@@ -38,13 +38,13 @@ Copyright (c) 2024 Starion Group S.A.
                 }
 
                 <DxFormLayoutItem Caption="Shortname:" ColSpanMd="12">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Name:" ColSpanMd="12">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Symbol:" ColSpanMd="12">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.Symbol)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Symbol)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Library:" ColSpanMd="12">
                     <DxComboBox Data="@(this.ViewModel.ReferenceDataLibraries)"
@@ -54,14 +54,14 @@ Copyright (c) 2024 Starion Group S.A.
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
 
-                @if (this.ViewModel.Thing is EnumerationParameterType enumerationParameterType)
+                @if (this.ViewModel.CurrentThing is EnumerationParameterType enumerationParameterType)
                 {
                     <DxFormLayoutItem Caption="Multi select:" ColSpanMd="12" Id="multiSelect">
                         <DxCheckBox @bind-Checked="@enumerationParameterType.AllowMultiSelect"/>
                     </DxFormLayoutItem>
                 }
 
-                @if (this.ViewModel.Thing is CompoundParameterType compoundParameterType)
+                @if (this.ViewModel.CurrentThing is CompoundParameterType compoundParameterType)
                 {
                     <DxFormLayoutItem Caption="Components:" ColSpanMd="12" CaptionPosition="CaptionPosition.Vertical">
                         <ComponentsTable @bind-Thing="compoundParameterType"
@@ -73,14 +73,14 @@ Copyright (c) 2024 Starion Group S.A.
                     </DxFormLayoutItem>
                 }
 
-                @if (this.ViewModel.Thing is ArrayParameterType arrayParameterType)
+                @if (this.ViewModel.CurrentThing is ArrayParameterType arrayParameterType)
                 {
                     <DxFormLayoutItem Caption="Is a Tensor:" ColSpanMd="12" Id="isTensor">
                         <DxCheckBox @bind-Checked="@arrayParameterType.IsTensor"/>
                     </DxFormLayoutItem>
                 }
 
-                @if (this.ViewModel.Thing is SpecializedQuantityKind specializedQuantityKindParameterType)
+                @if (this.ViewModel.CurrentThing is SpecializedQuantityKind specializedQuantityKindParameterType)
                 {
                     <DxFormLayoutItem Caption="General:" ColSpanMd="12">
                         <DxComboBox Data="@(this.ViewModel.ExistingParameterTypes.OfType<QuantityKind>())"
@@ -105,7 +105,7 @@ Copyright (c) 2024 Starion Group S.A.
                     }
                 }
 
-                @if (this.ViewModel.Thing is QuantityKind quantityKindParameterType)
+                @if (this.ViewModel.CurrentThing is QuantityKind quantityKindParameterType)
                 {
                     @if (quantityKindParameterType is SpecializedQuantityKind { General: not null } or not SpecializedQuantityKind)
                     {
@@ -143,7 +143,7 @@ Copyright (c) 2024 Starion Group S.A.
                     </DxFormLayoutItem>
                 }
 
-                @if (this.ViewModel.Thing is SampledFunctionParameterType sampledFunctionParameterType)
+                @if (this.ViewModel.CurrentThing is SampledFunctionParameterType sampledFunctionParameterType)
                 {
                     <DxFormLayoutItem Caption="Degree of Interpolation:" ColSpanMd="12">
                         <DxSpinEdit @bind-Value="@(sampledFunctionParameterType.DegreeOfInterpolation)"/>
@@ -163,18 +163,18 @@ Copyright (c) 2024 Starion Group S.A.
                 }
 
                 <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="12">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsDeprecated)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsDeprecated)"/>
                 </DxFormLayoutItem>
             </DxFormLayoutTabPage>
 
-            @if (this.ViewModel.Thing is EnumerationParameterType enumerationParameter)
+            @if (this.ViewModel.CurrentThing is EnumerationParameterType enumerationParameter)
             {
                 <DxFormLayoutTabPage Caption="Values">
                     <EnumerationValueDefinitionsTable @bind-Thing="enumerationParameter" />
                 </DxFormLayoutTabPage>
             }
 
-            @if (this.ViewModel.Thing is DerivedQuantityKind derivedQuantityKindParameterType)
+            @if (this.ViewModel.CurrentThing is DerivedQuantityKind derivedQuantityKindParameterType)
             {
                 <DxFormLayoutTabPage Caption="Factors">
                     <QuantityKindFactorsTable @bind-Thing="@(derivedQuantityKindParameterType)"

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor.cs
@@ -62,7 +62,7 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.SelectParameterType(row.Thing.Clone(true));
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
             this.ViewModel.SelectedParameterType = this.ViewModel.ParameterTypes.First(x => x.ClassKind == ClassKind.BooleanParameterType);
-            this.ViewModel.SelectParameterType(new BooleanParameterType());
+            this.ViewModel.CurrentThing = new BooleanParameterType();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseForm.razor
+++ b/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseForm.razor
@@ -17,17 +17,17 @@ Copyright (c) 2023-2024 Starion Group S.A.
 
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.ShortName"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.ShortName"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.Name"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@this.ViewModel.Thing.IsDeprecated"/>
+            <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
         </DxFormLayoutItem>
     </DxFormLayout>
     <FormButtons SaveButtonEnabled="@(this.IsSaveButtonEnabled(editFormContext))"

--- a/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseTable.razor.cs
@@ -61,7 +61,7 @@ namespace COMETwebapp.Components.SiteDirectory
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.Thing = row.Thing.Clone(true);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace COMETwebapp.Components.SiteDirectory
         {
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
-            this.ViewModel.Thing = new DomainOfExpertise();
+            this.ViewModel.CurrentThing = new DomainOfExpertise();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
@@ -65,10 +65,10 @@ Copyright (c) 2023-2024 Starion Group S.A.
 
                         <DxFormLayoutTabPage Caption="Basic">
                             <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-                                <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+                                <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-                                <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+                                <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Source Model:" ColSpanMd="10">
                                 <DxComboBox Data="@this.ViewModel.EngineeringModels"
@@ -79,12 +79,12 @@ Copyright (c) 2023-2024 Starion Group S.A.
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Model Kind:" ColSpanMd="10">
                                 <DxComboBox Data="@this.ViewModel.ModelKinds"
-                                            @bind-Value="@this.ViewModel.Thing.Kind"
+                                            @bind-Value="@this.ViewModel.CurrentThing.Kind"
                                             CssClass="cw-480"/>
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Study Phase:" ColSpanMd="10">
                                 <DxComboBox Data="@this.ViewModel.StudyPhases"
-                                            @bind-Value="@this.ViewModel.Thing.StudyPhase"
+                                            @bind-Value="@this.ViewModel.CurrentThing.StudyPhase"
                                             CssClass="cw-480"/>
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Site RDL:" ColSpanMd="10">

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor.cs
@@ -99,9 +99,9 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         {
             base.CustomizeEditThing(e);
 
-            this.ViewModel.Thing = new EngineeringModelSetup();
+            this.ViewModel.CurrentThing = new EngineeringModelSetup();
             this.ViewModel.ResetSelectedValues();
-            e.EditModel = this.ViewModel.Thing;
+            e.EditModel = this.ViewModel.CurrentThing;
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         protected override void OnSelectedDataItemChanged(EngineeringModelRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
-            this.ViewModel.Thing = row.Thing;
+            this.ViewModel.CurrentThing = row.Thing;
             this.parameters[nameof(EngineeringModelSetup)] = row.Thing;
         }
 

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor.cs
@@ -74,13 +74,13 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
 
             if (dataItem == null)
             {
-                this.ViewModel.Thing = new OrganizationalParticipant();
-                e.EditModel = this.ViewModel.Thing;
+                this.ViewModel.CurrentThing = new OrganizationalParticipant();
+                e.EditModel = this.ViewModel.CurrentThing;
                 return;
             }
 
             e.EditModel = dataItem;
-            this.ViewModel.Thing = dataItem.Thing.Clone(true);
+            this.ViewModel.CurrentThing = dataItem.Thing.Clone(true);
         }
     }
 }

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
@@ -68,14 +68,14 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 <DxFormLayoutItem Caption="Person:" ColSpanMd="10">
                     <DxComboBox Data="@this.Persons"
                                 TextFieldName="@nameof(Person.Name)"
-                                @bind-Value="@this.ViewModel.Thing.Person"
+                                @bind-Value="@this.ViewModel.CurrentThing.Person"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 
                 <DxFormLayoutItem Caption="Participant Role:" ColSpanMd="10">
                     <DxComboBox Data="@this.ViewModel.ParticipantRoles"
                                 TextFieldName="@nameof(ParticipantRole.Name)"
-                                @bind-Value="@this.ViewModel.Thing.Role"
+                                @bind-Value="@this.ViewModel.CurrentThing.Role"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 
@@ -91,7 +91,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 </DxFormLayoutItem>
 
                 <DxFormLayoutItem Caption="Active:" ColSpanMd="6">
-                    <DxCheckBox @bind-Checked="@this.ViewModel.Thing.IsActive" />
+                    <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsActive" />
                 </DxFormLayoutItem>
 
             </DxFormLayout>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
@@ -59,7 +59,7 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
         /// <summary>
         /// Gets the available persons. If the user is editing an existing participant, only the selected person should be retrieved
         /// </summary>
-        private IEnumerable<Person> Persons => this.ShouldCreateThing ? this.ViewModel.Persons : [this.ViewModel.Thing.Person];
+        private IEnumerable<Person> Persons => this.ShouldCreateThing ? this.ViewModel.Persons : [this.ViewModel.CurrentThing.Person];
 
         /// <summary>
         /// Method invoked when the component has received parameters from its parent in
@@ -94,12 +94,12 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
             if (dataItem == null)
             {
                 this.ViewModel.SelectThing(new Participant());
-                e.EditModel = this.ViewModel.Thing;
+                e.EditModel = this.ViewModel.CurrentThing;
                 return;
             }
 
             this.ViewModel.SelectThing(dataItem.Thing);
-            e.EditModel = this.ViewModel.Thing;
+            e.EditModel = this.ViewModel.CurrentThing;
         }
 
         /// <summary>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor.cs
@@ -93,12 +93,12 @@ namespace COMETwebapp.Components.SiteDirectory.EngineeringModel
 
             if (dataItem == null)
             {
-                this.ViewModel.SelectThing(new Participant());
+                this.ViewModel.CurrentThing = new Participant();
                 e.EditModel = this.ViewModel.CurrentThing;
                 return;
             }
 
-            this.ViewModel.SelectThing(dataItem.Thing);
+            this.ViewModel.CurrentThing = dataItem.Thing;
             e.EditModel = this.ViewModel.CurrentThing;
         }
 

--- a/COMETwebapp/Components/SiteDirectory/OrganizationsForm.razor
+++ b/COMETwebapp/Components/SiteDirectory/OrganizationsForm.razor
@@ -16,17 +16,17 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.ShortName"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.ShortName"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.Thing.Name"/>
+            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@this.ViewModel.Thing.IsDeprecated"/>
+            <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
         </DxFormLayoutItem>
     </DxFormLayout>
     <FormButtons SaveButtonEnabled="@(this.IsSaveButtonEnabled(editFormContext))"

--- a/COMETwebapp/Components/SiteDirectory/OrganizationsTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/OrganizationsTable.razor.cs
@@ -61,7 +61,7 @@ namespace COMETwebapp.Components.SiteDirectory
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.Thing = row.Thing.Clone(true);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace COMETwebapp.Components.SiteDirectory
         {
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
-            this.ViewModel.Thing = new Organization();
+            this.ViewModel.CurrentThing = new Organization();
             this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRoleDetails.razor
+++ b/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRoleDetails.razor
@@ -16,23 +16,23 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits DisposableComponent
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="12">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="12">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@this.ViewModel.Thing.IsDeprecated"/>
+            <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
         </DxFormLayoutItem>
 
         <DxFormLayoutGroup Caption="Permissions"
                            CssClass="overflow-auto max-height-50vh pb-3">
 
-            @foreach (var permission in this.ViewModel.Thing.ParticipantPermission.OrderBy(x => x.ObjectClass.ToString()))
+            @foreach (var permission in this.ViewModel.CurrentThing.ParticipantPermission.OrderBy(x => x.ObjectClass.ToString()))
             {
                 <DxFormLayoutItem @key="permission.ObjectClass.ToString()" 
                                   Caption="@(permission.ObjectClass.ToString())"

--- a/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRolesTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRolesTable.razor.cs
@@ -72,8 +72,8 @@ namespace COMETwebapp.Components.SiteDirectory.Roles
         {
             base.CustomizeEditThing(e);
 
-            this.ViewModel.Thing = new ParticipantRole();
-            e.EditModel = this.ViewModel.Thing;
+            this.ViewModel.CurrentThing = new ParticipantRole();
+            e.EditModel = this.ViewModel.CurrentThing;
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace COMETwebapp.Components.SiteDirectory.Roles
         protected override void OnSelectedDataItemChanged(ParticipantRoleRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
-            this.ViewModel.Thing = row.Thing.Clone(true);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
     }
 }

--- a/COMETwebapp/Components/SiteDirectory/Roles/PersonRoleDetails.razor
+++ b/COMETwebapp/Components/SiteDirectory/Roles/PersonRoleDetails.razor
@@ -16,23 +16,23 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits DisposableComponent
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutItem Caption="Shortname:" ColSpanMd="12">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Name:" ColSpanMd="12">
-            <DxTextBox @bind-Text="@(this.ViewModel.Thing.Name)"/>
+            <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Name)"/>
         </DxFormLayoutItem>
         <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@this.ViewModel.Thing.IsDeprecated"/>
+            <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
         </DxFormLayoutItem>
 
         <DxFormLayoutGroup Caption="Permissions"
                            CssClass="overflow-auto max-height-50vh pb-3">
 
-            @foreach (var permission in this.ViewModel.Thing.PersonPermission.OrderBy(x => x.ObjectClass.ToString()))
+            @foreach (var permission in this.ViewModel.CurrentThing.PersonPermission.OrderBy(x => x.ObjectClass.ToString()))
             {
                 <DxFormLayoutItem @key="permission.ObjectClass.ToString()" 
                                   Caption="@(permission.ObjectClass.ToString())"

--- a/COMETwebapp/Components/SiteDirectory/Roles/PersonRolesTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/Roles/PersonRolesTable.razor.cs
@@ -72,8 +72,8 @@ namespace COMETwebapp.Components.SiteDirectory.Roles
         {
             base.CustomizeEditThing(e);
 
-            this.ViewModel.Thing = new PersonRole();
-            e.EditModel = this.ViewModel.Thing;
+            this.ViewModel.CurrentThing = new PersonRole();
+            e.EditModel = this.ViewModel.CurrentThing;
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace COMETwebapp.Components.SiteDirectory.Roles
         protected override void OnSelectedDataItemChanged(PersonRoleRowViewModel row)
         {
             base.OnSelectedDataItemChanged(row);
-            this.ViewModel.Thing = row.Thing.Clone(true);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
     }
 }

--- a/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementForm.razor
+++ b/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementForm.razor
@@ -17,33 +17,33 @@ Copyright (c) 2023-2024 Starion Group S.A.
 
 @inherits SelectedDataItemForm
 
-<EditForm Context="editFormContext" Model="@(this.ViewModel.Thing)" OnValidSubmit="@(this.OnValidSubmit)">
+<EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator/>
     <DxFormLayout CssClass="w-100">
         <DxFormLayoutTabPages>
             <DxFormLayoutTabPage Caption="Basic">
                 <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.ShortName)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.ShortName)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Given Name:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.GivenName)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.GivenName)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Surname:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.Surname)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.Surname)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Organizational Unit:" ColSpanMd="10">
-                    <DxTextBox @bind-Text="@(this.ViewModel.Thing.OrganizationalUnit)"/>
+                    <DxTextBox @bind-Text="@(this.ViewModel.CurrentThing.OrganizationalUnit)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Organization:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.AvailableOrganizations)"
                                 TextFieldName="@nameof(Organization.Name)"
-                                @bind-Value="@(this.ViewModel.Thing.Organization)"
+                                @bind-Value="@(this.ViewModel.CurrentThing.Organization)"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Person Role:" ColSpanMd="10">
                     <DxComboBox Data="@(this.ViewModel.AvailablePersonRoles)"
                                 TextFieldName="@nameof(PersonRole.Name)"
-                                @bind-Value="@(this.ViewModel.Thing.Role)"
+                                @bind-Value="@(this.ViewModel.CurrentThing.Role)"
                                 CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Default Domain:" ColSpanMd="10">
@@ -52,10 +52,10 @@ Copyright (c) 2023-2024 Starion Group S.A.
                                                CssClass="cw-480"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Active:" ColSpanMd="6">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsActive)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsActive)"/>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-                    <DxCheckBox @bind-Checked="@(this.ViewModel.Thing.IsDeprecated)"/>
+                    <DxCheckBox @bind-Checked="@(this.ViewModel.CurrentThing.IsDeprecated)"/>
                 </DxFormLayoutItem>
             </DxFormLayoutTabPage>
             <DxFormLayoutTabPage Caption="E-Mail">

--- a/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor.cs
@@ -89,7 +89,7 @@ namespace COMETwebapp.Components.SiteDirectory.UserManagement
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
             this.ViewModel.SelectPerson(row.Thing.Clone(true));
-            this.ViewModel.Thing = row.Thing.Clone(true);
+            this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor.cs
+++ b/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor.cs
@@ -1,26 +1,26 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="UserManagementTable.razor.cs" company="Starion Group S.A.">
-//    Copyright (c) 2023-2024 Starion Group S.A.
-//
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
-//
-//    This file is part of CDP4-COMET WEB Community Edition
-//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//
-//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Affero General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or (at your option) any later version.
-//
-//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  <copyright file="UserManagementTable.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
-//
+// 
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace COMETwebapp.Components.SiteDirectory.UserManagement
 {
@@ -88,7 +88,6 @@ namespace COMETwebapp.Components.SiteDirectory.UserManagement
         {
             base.OnSelectedDataItemChanged(row);
             this.ShouldCreateThing = false;
-            this.ViewModel.SelectPerson(row.Thing.Clone(true));
             this.ViewModel.CurrentThing = row.Thing.Clone(true);
         }
 
@@ -99,7 +98,7 @@ namespace COMETwebapp.Components.SiteDirectory.UserManagement
         {
             this.ShouldCreateThing = true;
             this.IsOnEditMode = true;
-            this.ViewModel.SelectPerson(new Person() { IsActive = true });
+            this.ViewModel.CurrentThing = new Person { IsActive = true };
             this.InvokeAsync(this.StateHasChanged);
         }
 

--- a/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/BaseDataItemTableViewModel.cs
@@ -44,7 +44,7 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
     /// <summary>
     /// View model that provides the basic functionalities for a base data item
     /// </summary>
-    public abstract class BaseDataItemTableViewModel<T, TRow> : ApplicationBaseViewModel, IBaseDataItemTableViewModel<T, TRow> where T : Thing where TRow : BaseDataItemRowViewModel<T>
+    public abstract class BaseDataItemTableViewModel<T, TRow> : SingleThingApplicationBaseViewModel<T>, IBaseDataItemTableViewModel<T, TRow> where T : Thing where TRow : BaseDataItemRowViewModel<T>
     {
         /// <summary>
         /// A collection of <see cref="Type" /> used to create <see cref="ObjectChangedEvent" /> subscriptions
@@ -81,11 +81,6 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
             this.InitializeSubscriptions(ObjectChangedTypesOfInterest);
             this.RegisterViewModelWithReusableRows(this);
         }
-
-        /// <summary>
-        /// The thing to create or edit
-        /// </summary>
-        public T Thing { get; set; }
 
         /// <summary>
         /// A reactive collection of things
@@ -175,6 +170,12 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
         protected abstract List<T> QueryListOfThings();
 
         /// <summary>
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnThingChanged() => Task.CompletedTask;
+
+        /// <summary>
         /// Gets the message for the success notification
         /// </summary>
         /// <param name="created">The value to check if the thing was created</param>
@@ -183,8 +184,8 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
         {
             var notificationDescription = new NotificationDescription()
             {
-                OnSuccess = $"The {typeof(T).Name} {this.Thing.GetShortNameOrName()} was {(created ? "added" : "updated")}",
-                OnError = $"Error while {(created ? "adding" : "updating")} the {typeof(T).Name} {this.Thing.GetShortNameOrName()}"
+                OnSuccess = $"The {typeof(T).Name} {this.CurrentThing.GetShortNameOrName()} was {(created ? "added" : "updated")}",
+                OnError = $"Error while {(created ? "adding" : "updating")} the {typeof(T).Name} {this.CurrentThing.GetShortNameOrName()}"
             };
 
             return notificationDescription;

--- a/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/IBaseDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/BaseDataItemTable/IBaseDataItemTableViewModel.cs
@@ -41,7 +41,7 @@ namespace COMETwebapp.ViewModels.Components.Common.BaseDataItemTable
         /// <summary>
         /// The thing to create or edit
         /// </summary>
-        T Thing { get; set; }
+        T CurrentThing { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="BaseDataItemTableViewModel{T,TRow}" />

--- a/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/DeletableDataItemTable/DeletableDataItemTableViewModel.cs
@@ -98,7 +98,7 @@ namespace COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable
         /// <param name="thingRow"> The row to delete </param>
         public void OnDeleteButtonClick(TRow thingRow)
         {
-            this.Thing = thingRow.Thing;
+            this.CurrentThing = thingRow.Thing;
             this.PopupDialog = $"You are about to delete the {typeof(T).Name}: {thingRow.Name}";
             this.IsOnDeletionMode = true;
         }
@@ -109,15 +109,15 @@ namespace COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable
         /// <returns>A <see cref="Task" /></returns>
         public async Task DeleteThing()
         {
-            var clonedContainer = this.Thing.Container.Clone(false);
+            var clonedContainer = this.CurrentThing.Container.Clone(false);
 
             try
             {
-                await this.SessionService.DeleteThingsWithNotification(clonedContainer, [this.Thing.Clone(false)], this.GetDeletionNotificationDescription());
+                await this.SessionService.DeleteThingsWithNotification(clonedContainer, [this.CurrentThing.Clone(false)], this.GetDeletionNotificationDescription());
             }
             catch (Exception exception)
             {
-                this.Logger.LogError(exception, "An error has occurred while trying to delete the {thingType} with iid {thingIid}", typeof(T), this.Thing.Iid);
+                this.Logger.LogError(exception, "An error has occurred while trying to delete the {thingType} with iid {thingIid}", typeof(T), this.CurrentThing.Iid);
             }
         }
 
@@ -129,8 +129,8 @@ namespace COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable
         {
             var notificationDescription = new NotificationDescription()
             {
-                OnSuccess = $"The {typeof(T).Name} {this.Thing.GetShortNameOrName()} was deleted!",
-                OnError = $"Error while deleting The {typeof(T).Name} {this.Thing.GetShortNameOrName()}"
+                OnSuccess = $"The {typeof(T).Name} {this.CurrentThing.GetShortNameOrName()} was deleted!",
+                OnError = $"Error while deleting The {typeof(T).Name} {this.CurrentThing.GetShortNameOrName()}"
             };
 
             return notificationDescription;

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
@@ -55,11 +55,11 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
             : base(sessionService, messageBus, logger)
         {
             this.FolderFileStructureViewModel = folderFileStructureViewModel;
-            this.Thing = new CommonFileStore();
+            this.CurrentThing = new CommonFileStore();
 
             this.DomainOfExpertiseSelectorViewModel = new DomainOfExpertiseSelectorViewModel(sessionService, messageBus)
             {
-                OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.Thing.Owner = selectedOwner; })
+                OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.CurrentThing.Owner = selectedOwner; })
             };
         }
 
@@ -99,7 +99,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
         /// <param name="commonFileStore">The common file store to be set</param>
         public void SelectCommonFileStore(CommonFileStore commonFileStore)
         {
-            this.Thing = commonFileStore.Clone(true);
+            this.CurrentThing = commonFileStore.Clone(true);
             this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(commonFileStore.Iid == Guid.Empty, commonFileStore.Owner);
         }
 
@@ -108,7 +108,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
         /// </summary>
         public void LoadFileStructure()
         {
-            this.FolderFileStructureViewModel.InitializeViewModel(this.Thing, this.CurrentIteration);
+            this.FolderFileStructureViewModel.InitializeViewModel(this.CurrentThing, this.CurrentIteration);
         }
 
         /// <summary>
@@ -125,11 +125,11 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
 
             if (shouldCreate)
             {
-                engineeringModelClone.CommonFileStore.Add(this.Thing);
+                engineeringModelClone.CommonFileStore.Add(this.CurrentThing);
                 thingsToCreate.Add(engineeringModelClone);
             }
 
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
 
             try
             {

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable;
@@ -94,16 +95,6 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
         }
 
         /// <summary>
-        /// Selects the current <see cref="CommonFileStore" />
-        /// </summary>
-        /// <param name="commonFileStore">The common file store to be set</param>
-        public void SelectCommonFileStore(CommonFileStore commonFileStore)
-        {
-            this.CurrentThing = commonFileStore.Clone(true);
-            this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(commonFileStore.Iid == Guid.Empty, commonFileStore.Owner);
-        }
-
-        /// <summary>
         /// Loads the file structure handled by the <see cref="FolderFileStructureViewModel" />
         /// </summary>
         public void LoadFileStructure()
@@ -141,6 +132,21 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
             }
 
             this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has
+        /// changed
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
+        {
+            await base.OnThingChanged();
+
+            if (this.DomainOfExpertiseSelectorViewModel is not null)
+            {
+                await this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(this.CurrentThing.Iid == Guid.Empty, this.CurrentThing.Owner);
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/ICommonFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/ICommonFileStoreTableViewModel.cs
@@ -69,11 +69,5 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
         /// Loads the file structure handled by the <see cref="CommonFileStoreTableViewModel.FolderFileStructureViewModel" />
         /// </summary>
         void LoadFileStructure();
-
-        /// <summary>
-        /// Selects the current <see cref="CommonFileStore" />
-        /// </summary>
-        /// <param name="commonFileStore">The common file store to be set</param>
-        void SelectCommonFileStore(CommonFileStore commonFileStore);
     }
 }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/FileHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/FileHandlerViewModel.cs
@@ -58,6 +58,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileHandl
         public FileHandlerViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ILogger<FileHandlerViewModel> logger, IFileRevisionHandlerViewModel fileRevisionHandlerViewModel)
             : base(sessionService, messageBus)
         {
+            this.CurrentThing = new File();
             this.logger = logger;
             this.FileRevisionHandlerViewModel = fileRevisionHandlerViewModel;
 
@@ -228,9 +229,13 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileHandl
         {
             this.IsLocked = this.CurrentThing.LockedBy is not null;
             this.SelectedFileRevisions = this.CurrentThing.FileRevision;
-            this.FileRevisionHandlerViewModel.InitializeViewModel(this.CurrentThing, this.CurrentFileStore);
             this.SelectedFolder = null;
-            await this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(this.CurrentThing.Iid == Guid.Empty, this.CurrentThing.Owner);
+            this.FileRevisionHandlerViewModel?.InitializeViewModel(this.CurrentThing, this.CurrentFileStore);
+
+            if (this.DomainOfExpertiseSelectorViewModel is not null)
+            {
+                await this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(this.CurrentThing.Iid == Guid.Empty, this.CurrentThing.Owner);
+            }
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/IFileHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/IFileHandlerViewModel.cs
@@ -47,7 +47,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileHandl
         /// <summary>
         /// Gets or sets the file to be created/edited
         /// </summary>
-        File File { get; set; }
+        File CurrentThing { get; set; }
 
         /// <summary>
         /// Gets or sets the condition to check if the file or folder to be created is locked
@@ -98,12 +98,6 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileHandl
         /// <param name="shouldCreate"></param>
         /// <returns>A <see cref="Task"/></returns>
         Task CreateOrEditFile(bool shouldCreate);
-
-        /// <summary>
-        /// Selects the current <see cref="FileHandlerViewModel.File"/>
-        /// </summary>
-        /// <param name="file">The file to be set</param>
-        void SelectFile(File file);
 
         /// <summary>
         /// Deletes the current file

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderFileStructureViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderFileStructureViewModel.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore
     using CDP4Common.EngineeringModelData;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.ViewModels.Components.Applications;
@@ -89,6 +90,15 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore
         }
 
         /// <summary>
+        /// Handles the <see cref="SessionStatus.EndUpdate" /> message received
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnEndUpdate()
+        {
+            await this.OnSessionRefreshed();
+        }
+
+        /// <summary>
         /// Handles the refresh of the current <see cref="ISession" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -114,7 +124,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore
                 parentNode.Content.Add(nodeToUpdate);
             }
 
-            foreach (var nodeToDelete in this.DeletedThings.Select(deletedThing => flatListOfNodes.First(x => x.Thing?.Iid == deletedThing?.Iid)))
+            foreach (var nodeToDelete in this.DeletedThings.Select(deletedThing => flatListOfNodes.FirstOrDefault(x => x.Thing?.Iid == deletedThing?.Iid)))
             {
                 rootNode.RemoveChildNode(nodeToDelete);
             }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/FolderHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/FolderHandlerViewModel.cs
@@ -48,6 +48,8 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHan
         /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
         public FolderHandlerViewModel(ISessionService sessionService, ICDPMessageBus messageBus) : base(sessionService, messageBus)
         {
+            this.CurrentThing = new Folder();
+
             this.DomainOfExpertiseSelectorViewModel = new DomainOfExpertiseSelectorViewModel(sessionService, messageBus)
             {
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner =>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/IFolderHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/IFolderHandlerViewModel.cs
@@ -25,7 +25,6 @@
 namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHandler
 {
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.SiteDirectoryData;
 
     using COMET.Web.Common.ViewModels.Components.Applications;
     using COMET.Web.Common.ViewModels.Components.Selectors;
@@ -60,7 +59,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHan
         /// <summary>
         /// Creates or edits a folder
         /// </summary>
-        /// <param name="shouldCreate">the value to check if the <see cref="FolderHandlerViewModel.CurrentThing"/> should be created or edited</param>
+        /// <param name="shouldCreate">the value to check if the <see cref="CurrentThing"/> should be created or edited</param>
         /// <returns>A <see cref="Task"/></returns>
         Task CreateOrEditFolder(bool shouldCreate);
 

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/IFolderHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/IFolderHandlerViewModel.cs
@@ -45,10 +45,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHan
         /// <summary>
         /// Gets or sets the folder to be created/edited
         /// </summary>
-        Folder Folder { get; set; }
+        Folder CurrentThing { get; set; }
 
         /// <summary>
-        /// Gets a collection of the available <see cref="Folder"/>s
+        /// Gets a collection of the available <see cref="CurrentThing"/>s
         /// </summary>
         IEnumerable<Folder> Folders { get; }
 
@@ -58,15 +58,9 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHan
         IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
 
         /// <summary>
-        /// Selects the current <see cref="Folder"/>
-        /// </summary>
-        /// <param name="folder">The folder to be set</param>
-        public void SelectFolder(Folder folder);
-
-        /// <summary>
         /// Creates or edits a folder
         /// </summary>
-        /// <param name="shouldCreate">the value to check if the <see cref="FolderHandlerViewModel.Folder"/> should be created or edited</param>
+        /// <param name="shouldCreate">the value to check if the <see cref="FolderHandlerViewModel.CurrentThing"/> should be created or edited</param>
         /// <returns>A <see cref="Task"/></returns>
         Task CreateOrEditFolder(bool shouldCreate);
 

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Options/IOptionsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Options/IOptionsTableViewModel.cs
@@ -51,11 +51,5 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         /// Gets or sets the value to check if the option to create is the default option for the <see cref="OptionsTableViewModel.CurrentIteration"/>
         /// </summary>
         bool SelectedIsDefaultValue { get; set; }
-
-        /// <summary>
-        /// Sets the current option value
-        /// </summary>
-        /// <param name="option">The option to be set</param>
-        void SetCurrentOption(Option option);
     }
 }

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
     using CDP4Dal.Events;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable;
     using COMETwebapp.ViewModels.Components.EngineeringModel.Rows;
@@ -82,13 +83,13 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         }
 
         /// <summary>
-        /// Sets the current option value
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
         /// </summary>
-        /// <param name="option">The option to be set</param>
-        public void SetCurrentOption(Option option)
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
         {
-            this.SelectedIsDefaultValue = option.IsDefault;
-            this.CurrentThing = option.Clone(true);
+            await base.OnThingChanged();
+            this.SelectedIsDefaultValue = this.CurrentThing.IsDefault;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
@@ -1,26 +1,26 @@
 // --------------------------------------------------------------------------------------------------------------------
-// <copyright file="OptionsTableViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2023-2024 Starion Group S.A.
-//
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Antoine Théate, João Rua
-//
-//    This file is part of CDP4-COMET WEB Community Edition
-//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//
-//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Affero General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or (at your option) any later version.
-//
-//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  <copyright file="OptionsTableViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
-//
+// 
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
 {
@@ -43,11 +43,6 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
     public class OptionsTableViewModel : DeletableDataItemTableViewModel<Option, OptionRowViewModel>, IOptionsTableViewModel
     {
         /// <summary>
-        /// Gets or sets the current <see cref="Iteration"/>
-        /// </summary>
-        private Iteration CurrentIteration { get; set; }
-
-        /// <summary>
         /// A collection of <see cref="Type" /> used to create <see cref="ObjectChangedEvent" /> subscriptions
         /// </summary>
         private static readonly IEnumerable<Type> ObjectChangedTypesOfInterest = new List<Type>
@@ -59,8 +54,8 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         /// Initializes a new instance of the <see cref="ParameterTypeTableViewModel" /> class.
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionService" /></param>
-        /// <param name="messageBus">The <see cref="ICDPMessageBus"/></param>
-        /// <param name="logger">The <see cref="ILogger{TCategoryName}"/></param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
+        /// <param name="logger">The <see cref="ILogger{TCategoryName}" /></param>
         public OptionsTableViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ILogger<OptionsTableViewModel> logger)
             : base(sessionService, messageBus, logger)
         {
@@ -69,12 +64,17 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         }
 
         /// <summary>
-        /// Gets or sets the value to check if the option to create is the default option for the <see cref="CurrentIteration"/>
+        /// Gets or sets the current <see cref="Iteration" />
+        /// </summary>
+        private Iteration CurrentIteration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value to check if the option to create is the default option for the <see cref="CurrentIteration" />
         /// </summary>
         public bool SelectedIsDefaultValue { get; set; }
 
         /// <summary>
-        /// Sets the <see cref="CurrentIteration"/> value
+        /// Sets the <see cref="CurrentIteration" /> value
         /// </summary>
         /// <param name="iteration">The iteration to be set</param>
         public void SetCurrentIteration(Iteration iteration)
@@ -83,20 +83,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         }
 
         /// <summary>
-        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
+        /// Creates or edits a <see cref="Option" />
         /// </summary>
+        /// <param name="shouldCreate">The value to check if a new <see cref="Option" /> should be created</param>
         /// <returns>A <see cref="Task" /></returns>
-        protected override async Task OnThingChanged()
-        {
-            await base.OnThingChanged();
-            this.SelectedIsDefaultValue = this.CurrentThing.IsDefault;
-        }
-
-        /// <summary>
-        /// Creates or edits a <see cref="Option"/>
-        /// </summary>
-        /// <param name="shouldCreate">The value to check if a new <see cref="Option"/> should be created</param>
-        /// <returns>A <see cref="Task"/></returns>
         public async Task CreateOrEditOption(bool shouldCreate)
         {
             this.IsLoading = true;
@@ -128,8 +118,23 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
             {
                 this.Logger.LogError(ex, "An error has occurred while creating or editing an Option");
             }
-            
+
             this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has
+        /// changed
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
+        {
+            await base.OnThingChanged();
+
+            if (this.CurrentThing.Original is Option originalOption)
+            {
+                this.SelectedIsDefaultValue = originalOption.IsDefault;
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/Options/OptionsTableViewModel.cs
@@ -63,7 +63,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         public OptionsTableViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ILogger<OptionsTableViewModel> logger)
             : base(sessionService, messageBus, logger)
         {
-            this.Thing = new Option();
+            this.CurrentThing = new Option();
             this.InitializeSubscriptions(ObjectChangedTypesOfInterest);
         }
 
@@ -88,7 +88,7 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
         public void SetCurrentOption(Option option)
         {
             this.SelectedIsDefaultValue = option.IsDefault;
-            this.Thing = option.Clone(true);
+            this.CurrentThing = option.Clone(true);
         }
 
         /// <summary>
@@ -102,22 +102,22 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.Options
 
             var iterationClone = this.CurrentIteration.Clone(false);
             var thingsToCreate = new List<Thing>();
-            var originalOption = (Option)this.Thing.Original;
+            var originalOption = (Option)this.CurrentThing.Original;
 
             iterationClone.DefaultOption = this.SelectedIsDefaultValue switch
             {
-                true when !originalOption.IsDefault => this.Thing,
+                true when !originalOption.IsDefault => this.CurrentThing,
                 false when originalOption.IsDefault => null,
                 _ => iterationClone.DefaultOption
             };
 
             if (shouldCreate)
             {
-                iterationClone.Option.Add(this.Thing);
+                iterationClone.Option.Add(this.CurrentThing);
             }
 
             thingsToCreate.Add(iterationClone);
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
 
             try
             {

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
@@ -98,22 +98,22 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
             {
                 this.IsLoading = true;
 
-                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.Thing.Container;
+                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.CurrentThing.Container;
                 var rdlClone = this.SelectedReferenceDataLibrary.Clone(false);
                 var thingsToCreate = new List<Thing>();
 
                 if (shouldCreate || hasRdlChanged)
                 {
-                    rdlClone.DefinedCategory.Add(this.Thing);
+                    rdlClone.DefinedCategory.Add(this.CurrentThing);
                     thingsToCreate.Add(rdlClone);
                 }
 
-                thingsToCreate.Add(this.Thing);
+                thingsToCreate.Add(this.CurrentThing);
                 await this.SessionService.CreateOrUpdateThingsWithNotification(rdlClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
                 
-                if (this.Thing.Original is not null)
+                if (this.CurrentThing.Original is not null)
                 {
-                    this.Thing = (Category)this.Thing.Original.Clone(true);
+                    this.CurrentThing = (Category)this.CurrentThing.Original.Clone(true);
                 }
             }
             catch (Exception ex)
@@ -132,7 +132,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
         /// <param name="selectedCategory">The selected <see cref="CategoryRowViewModel" /></param>
         public void SelectCategory(Category selectedCategory)
         {
-            this.Thing = selectedCategory;
+            this.CurrentThing = selectedCategory;
             this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)selectedCategory.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
 
             if (selectedCategory.Iid == Guid.Empty)

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Categories/CategoriesTableViewModel.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
     using CDP4Dal.Events;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
@@ -62,7 +63,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
         /// <summary>
         /// Available <see cref="ReferenceDataLibrary" />s
         /// </summary>
-        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; set; }
+        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; set; } = [];
 
         /// <summary>
         /// Available <see cref="ClassKind" />s
@@ -127,22 +128,22 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
         }
 
         /// <summary>
-        /// Sets the selected <see cref="Category" />
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
         /// </summary>
-        /// <param name="selectedCategory">The selected <see cref="CategoryRowViewModel" /></param>
-        public void SelectCategory(Category selectedCategory)
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
         {
-            this.CurrentThing = selectedCategory;
-            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)selectedCategory.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
+            await base.OnThingChanged();
+            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)this.CurrentThing.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
 
-            if (selectedCategory.Iid == Guid.Empty)
+            if (this.CurrentThing.Iid == Guid.Empty)
             {
                 return;
             }
 
-            this.CategoryHierarchyDiagramViewModel.SelectedCategory = selectedCategory;
-            this.CategoryHierarchyDiagramViewModel.Rows = selectedCategory.SuperCategory;
-            this.CategoryHierarchyDiagramViewModel.SubCategories = ((Category)selectedCategory.Original).AllDerivedCategories();
+            this.CategoryHierarchyDiagramViewModel.SelectedCategory = this.CurrentThing;
+            this.CategoryHierarchyDiagramViewModel.Rows = this.CurrentThing.SuperCategory;
+            this.CategoryHierarchyDiagramViewModel.SubCategories = ((Category)this.CurrentThing.Original).AllDerivedCategories();
             this.CategoryHierarchyDiagramViewModel.SetupDiagram();
         }
 

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Categories/ICategoriesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Categories/ICategoriesTableViewModel.cs
@@ -62,11 +62,5 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.Categories
         /// <param name="shouldCreate">The value to check if a new <see cref="Category" /> should be created</param>
         /// <returns>A <see cref="Task" /></returns>
         Task CreateCategory(bool shouldCreate);
-
-        /// <summary>
-        /// set the selected <see cref="CategoryRowViewModel" />
-        /// </summary>
-        /// <param name="selectedCategory">The selected <see cref="CategoryRowViewModel" /></param>
-        void SelectCategory(Category selectedCategory);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScales/IMeasurementScalesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementScales/IMeasurementScalesTableViewModel.cs
@@ -91,12 +91,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementScales
         ScaleReferenceQuantityValue SelectedReferenceQuantityValue { get; set; }
 
         /// <summary>
-        /// Selects the current <see cref="MeasurementScale" />
-        /// </summary>
-        /// <param name="measurementScale">The measurement scale to be set</param>
-        void SelectMeasurementScale(MeasurementScale measurementScale);
-
-        /// <summary>
         /// Creates or edits a <see cref="MeasurementScale" />
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="MeasurementScale" /> should be created</param>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/IMeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/IMeasurementUnitsTableViewModel.cs
@@ -72,11 +72,5 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         /// <param name="shouldCreate">The value to check if a new <see cref="MeasurementUnit"/> should be created</param>
         /// <returns>A <see cref="Task"/></returns>
         Task CreateOrEditMeasurementUnit(bool shouldCreate);
-
-        /// <summary>
-        /// Sets the current <see cref="MeasurementUnit"/>
-        /// </summary>
-        /// <param name="measurementUnit">The <see cref="MeasurementUnit"/> to be set</param>
-        void SelectMeasurementUnit(MeasurementUnit measurementUnit);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
@@ -70,7 +71,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         /// <summary>
         /// Gets the available <see cref="ReferenceDataLibrary" />s
         /// </summary>
-        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; }
+        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; } = [];
 
         /// <summary>
         /// Gets the available <see cref="MeasurementUnit" />s from the same rdl as the <see cref="SelectedReferenceDataLibrary" />
@@ -106,16 +107,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         }
 
         /// <summary>
-        /// Sets the current <see cref="MeasurementUnit" />
-        /// </summary>
-        /// <param name="measurementUnit">The <see cref="MeasurementUnit" /> to be set</param>
-        public void SelectMeasurementUnit(MeasurementUnit measurementUnit)
-        {
-            this.CurrentThing = measurementUnit;
-            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)measurementUnit.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
-        }
-
-        /// <summary>
         /// Initializes the <see cref="MeasurementUnitsTableViewModel" />
         /// </summary>
         public override void InitializeViewModel()
@@ -129,6 +120,16 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
             this.SelectedMeasurementUnitType = this.MeasurementUnitTypes.First();
 
             this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
+        {
+            await base.OnThingChanged();
+            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)this.CurrentThing.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTableViewModel.cs
@@ -111,7 +111,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         /// <param name="measurementUnit">The <see cref="MeasurementUnit" /> to be set</param>
         public void SelectMeasurementUnit(MeasurementUnit measurementUnit)
         {
-            this.Thing = measurementUnit;
+            this.CurrentThing = measurementUnit;
             this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)measurementUnit.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
         }
 
@@ -151,19 +151,19 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
             {
                 this.IsLoading = true;
 
-                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.Thing.Container;
+                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.CurrentThing.Container;
                 var rdlClone = this.SelectedReferenceDataLibrary.Clone(false);
                 var thingsToCreate = new List<Thing>();
 
                 if (shouldCreate || hasRdlChanged)
                 {
-                    rdlClone.Unit.Add(this.Thing);
+                    rdlClone.Unit.Add(this.CurrentThing);
                     thingsToCreate.Add(rdlClone);
                 }
 
-                thingsToCreate.Add(this.Thing);
+                thingsToCreate.Add(this.CurrentThing);
 
-                if (this.Thing is DerivedUnit derivedUnit)
+                if (this.CurrentThing is DerivedUnit derivedUnit)
                 {
                     thingsToCreate.AddRange(derivedUnit.UnitFactor);
                 }
@@ -186,13 +186,13 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits
         /// <param name="newKind">The new kind to which the <see cref="SelectedMeasurementUnitType" /> will be set</param>
         private void SelectMeasurementUnitType(ClassKindWrapper newKind)
         {
-            this.Thing = newKind.ClassKind switch
+            this.CurrentThing = newKind.ClassKind switch
             {
                 ClassKind.SimpleUnit => new SimpleUnit(),
                 ClassKind.DerivedUnit => new DerivedUnit(),
                 ClassKind.LinearConversionUnit => new LinearConversionUnit(),
                 ClassKind.PrefixedUnit => new PrefixedUnit(),
-                _ => this.Thing
+                _ => this.CurrentThing
             };
         }
     }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
@@ -71,11 +71,5 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// <param name="shouldCreate">The value to check if a new <see cref="ParameterType" /> should be created</param>
         /// <returns>A <see cref="Task" /></returns>
         Task CreateOrEditParameterType(bool shouldCreate);
-
-        /// <summary>
-        /// Selects the current <see cref="ParameterType" />
-        /// </summary>
-        /// <param name="parameterType">The parameter type to be set</param>
-        void SelectParameterType(ParameterType parameterType);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -32,6 +32,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
@@ -84,7 +85,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// <summary>
         /// Gets the available <see cref="ReferenceDataLibrary" />s
         /// </summary>
-        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; }
+        public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; } = [];
 
         /// <summary>
         /// Gets the possible available <see cref="MeasurementScale" />s
@@ -120,16 +121,6 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         }
 
         /// <summary>
-        /// Selects the current <see cref="ParameterType" />
-        /// </summary>
-        /// <param name="parameterType">The parameter type to be set</param>
-        public void SelectParameterType(ParameterType parameterType)
-        {
-            this.CurrentThing = parameterType;
-            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)parameterType.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
-        }
-
-        /// <summary>
         /// Initializes the current view model
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -148,6 +139,16 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
                 .SelectMany(x => x.ParameterType)
                 .Distinct()
                 .OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
+        {
+            await base.OnThingChanged();
+            this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)this.CurrentThing.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -78,7 +78,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         public ParameterTypeTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, ILogger<ParameterTypeTableViewModel> logger) 
             : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new BooleanParameterType();
+            this.CurrentThing = new BooleanParameterType();
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// <param name="parameterType">The parameter type to be set</param>
         public void SelectParameterType(ParameterType parameterType)
         {
-            this.Thing = parameterType;
+            this.CurrentThing = parameterType;
             this.SelectedReferenceDataLibrary = (ReferenceDataLibrary)parameterType.Container ?? this.ReferenceDataLibraries.FirstOrDefault();
         }
 
@@ -170,17 +170,17 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
             {
                 this.IsLoading = true;
 
-                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.Thing.Container;
+                var hasRdlChanged = this.SelectedReferenceDataLibrary != this.CurrentThing.Container;
                 var rdlClone = this.SelectedReferenceDataLibrary.Clone(false);
                 var thingsToCreate = new List<Thing>();
 
                 if (shouldCreate || hasRdlChanged)
                 {
-                    rdlClone.ParameterType.Add(this.Thing);
+                    rdlClone.ParameterType.Add(this.CurrentThing);
                     thingsToCreate.Add(rdlClone);
                 }
 
-                switch (this.Thing)
+                switch (this.CurrentThing)
                 {
                     case EnumerationParameterType enumerationParameterType:
                         thingsToCreate.AddRange(enumerationParameterType.ValueDefinition);
@@ -197,13 +197,13 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
                         break;
                 }
 
-                thingsToCreate.Add(this.Thing);
+                thingsToCreate.Add(this.CurrentThing);
 
                 await this.SessionService.CreateOrUpdateThingsWithNotification(rdlClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
 
-                if (this.Thing.Original is not null)
+                if (this.CurrentThing.Original is not null)
                 {
-                    this.Thing = (ParameterType)this.Thing.Original.Clone(true);
+                    this.CurrentThing = (ParameterType)this.CurrentThing.Original.Clone(true);
                 }
             }
             catch (Exception ex)
@@ -222,7 +222,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// <param name="newKind">The new kind to which the <see cref="SelectedParameterType" /> will be set</param>
         private void SelectParameterType(ClassKindWrapper newKind)
         {
-            this.Thing = newKind.ClassKind switch
+            this.CurrentThing = newKind.ClassKind switch
             {
                 ClassKind.BooleanParameterType => new BooleanParameterType(),
                 ClassKind.CompoundParameterType => new CompoundParameterType(),
@@ -235,10 +235,10 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
                 ClassKind.SpecializedQuantityKind => new SpecializedQuantityKind(),
                 ClassKind.TextParameterType => new TextParameterType(),
                 ClassKind.TimeOfDayParameterType => new TimeOfDayParameterType(),
-                _ => this.Thing
+                _ => this.CurrentThing
             };
 
-            if (this.Thing is SpecializedQuantityKind specializedQuantityKindParameterType)
+            if (this.CurrentThing is SpecializedQuantityKind specializedQuantityKindParameterType)
             {
                 specializedQuantityKindParameterType.General = this.ExistingParameterTypes.OfType<QuantityKind>().FirstOrDefault();
             }
@@ -254,7 +254,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
                 .OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase)
                 .Select(x => new MeasurementScaleRowViewModel(x)) ?? Enumerable.Empty<MeasurementScaleRowViewModel>();
 
-            if (this.Thing is not SpecializedQuantityKind specializedQuantity || specializedQuantity.General is null)
+            if (this.CurrentThing is not SpecializedQuantityKind specializedQuantity || specializedQuantity.General is null)
             {
                 return allMeasurementScales;
             }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
@@ -53,7 +53,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
         public DomainsOfExpertiseTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, ILogger<DomainsOfExpertiseTableViewModel> logger)
             : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new DomainOfExpertise();
+            this.CurrentThing = new DomainOfExpertise();
         }
 
         /// <summary>
@@ -72,11 +72,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
 
                 if (shouldCreate)
                 {
-                    siteDirectoryClone.Domain.Add(this.Thing);
+                    siteDirectoryClone.Domain.Add(this.CurrentThing);
                     thingsToUpdateOrCreate.Add(siteDirectoryClone);
                 }
 
-                thingsToUpdateOrCreate.Add(this.Thing);
+                thingsToUpdateOrCreate.Add(this.CurrentThing);
                 await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToUpdateOrCreate, this.GetNotificationDescription(shouldCreate));
             }
             catch (Exception ex)

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
@@ -36,8 +36,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     using COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
 
-    using ReactiveUI;
-
     /// <summary>
     /// View model used to manage <see cref="DomainOfExpertise" />
     /// </summary>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
@@ -52,7 +52,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         public EngineeringModelsTableViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ILogger<EngineeringModelsTableViewModel> logger) 
             : base(sessionService, messageBus, logger)
         {
-            this.Thing = new EngineeringModelSetup();
+            this.CurrentThing = new EngineeringModelSetup();
         }
 
         /// <summary>
@@ -150,28 +150,28 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// </summary>
         public void SetupEngineeringModelWithSelectedValues()
         {
-            this.Thing.ActiveDomain = this.SelectedActiveDomains?.ToList();
-            this.Thing.SourceEngineeringModelSetupIid = this.SelectedSourceModel?.Iid;
-            this.Thing.OrganizationalParticipant.Clear();
-            this.Thing.RequiredRdl.Clear();
+            this.CurrentThing.ActiveDomain = this.SelectedActiveDomains?.ToList();
+            this.CurrentThing.SourceEngineeringModelSetupIid = this.SelectedSourceModel?.Iid;
+            this.CurrentThing.OrganizationalParticipant.Clear();
+            this.CurrentThing.RequiredRdl.Clear();
 
             if (this.SelectedOrganizations != null)
             {
-                this.Thing.OrganizationalParticipant.AddRange(this.SelectedOrganizations.Select(org => new OrganizationalParticipant()
+                this.CurrentThing.OrganizationalParticipant.AddRange(this.SelectedOrganizations.Select(org => new OrganizationalParticipant()
                 {
                     Organization = org
                 }));
 
-                this.Thing.DefaultOrganizationalParticipant = this.Thing.OrganizationalParticipant.FirstOrDefault(x => x.Organization == this.SelectedModelAdminOrganization);
+                this.CurrentThing.DefaultOrganizationalParticipant = this.CurrentThing.OrganizationalParticipant.FirstOrDefault(x => x.Organization == this.SelectedModelAdminOrganization);
             }
 
             if (this.SelectedSiteRdl != null)
             {
-                this.Thing.RequiredRdl.Add(new ModelReferenceDataLibrary()
+                this.CurrentThing.RequiredRdl.Add(new ModelReferenceDataLibrary()
                 {
                     RequiredRdl = this.SelectedSiteRdl,
-                    Name = $"{this.Thing.Name} Model RDL",
-                    ShortName = $"{this.Thing.ShortName}MRDL"
+                    Name = $"{this.CurrentThing.Name} Model RDL",
+                    ShortName = $"{this.CurrentThing.ShortName}MRDL"
                 });
             }
         }
@@ -186,21 +186,21 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
 
             var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
             var thingsToCreate = new List<Thing>();
-            this.Thing.EngineeringModelIid = Guid.NewGuid();
+            this.CurrentThing.EngineeringModelIid = Guid.NewGuid();
 
-            if (this.Thing.OrganizationalParticipant.Count > 0)
+            if (this.CurrentThing.OrganizationalParticipant.Count > 0)
             {
-                thingsToCreate.AddRange(this.Thing.OrganizationalParticipant);
+                thingsToCreate.AddRange(this.CurrentThing.OrganizationalParticipant);
             }
 
-            if (this.Thing.RequiredRdl.Count > 0)
+            if (this.CurrentThing.RequiredRdl.Count > 0)
             {
-                thingsToCreate.AddRange(this.Thing.RequiredRdl);
+                thingsToCreate.AddRange(this.CurrentThing.RequiredRdl);
             }
             
-            siteDirectoryClone.Model.Add(this.Thing);
+            siteDirectoryClone.Model.Add(this.CurrentThing);
             thingsToCreate.Add(siteDirectoryClone);
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
 
             await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate, this.GetNotificationDescription(true));
 

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/IParticipantsTableViewModel.cs
@@ -56,12 +56,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         IEnumerable<DomainOfExpertise> SelectedDomains { get; set; }
 
         /// <summary>
-        /// Selects the current participant
-        /// </summary>
-        /// <param name="participant">The <see cref="Participant"/> to select</param>
-        void SelectThing(Participant participant);
-
-        /// <summary>
         /// Creates or edits the current participant
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="Participant"/> should be created</param>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.ViewModels.Components.Common.BaseDataItemTable;
     using COMETwebapp.ViewModels.Components.Common.DeletableDataItemTable;
@@ -102,12 +103,12 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         }
 
         /// <summary>
-        /// Selects the current participant
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
         /// </summary>
-        /// <param name="participant">The <see cref="Participant"/> to select</param>
-        public void SelectThing(Participant participant)
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
         {
-            this.CurrentThing = participant.Clone(false);
+            await base.OnThingChanged();
             this.SelectedDomains = this.CurrentThing.Domain;
         }
 

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/ParticipantsTableViewModel.cs
@@ -54,7 +54,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         public ParticipantsTableViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ILogger<ParticipantsTableViewModel> logger) 
             : base(sessionService, messageBus, logger)
         {
-            this.Thing = new Participant();
+            this.CurrentThing = new Participant();
         }
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <param name="participant">The <see cref="Participant"/> to select</param>
         public void SelectThing(Participant participant)
         {
-            this.Thing = participant.Clone(false);
-            this.SelectedDomains = this.Thing.Domain;
+            this.CurrentThing = participant.Clone(false);
+            this.SelectedDomains = this.CurrentThing.Domain;
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// </summary>
         public void UpdateSelectedDomains()
         {
-            this.Thing.Domain = this.SelectedDomains.ToList();
+            this.CurrentThing.Domain = this.SelectedDomains.ToList();
         }
 
         /// <summary>
@@ -134,15 +134,15 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
                 var thingsToCreate = new List<Thing>();
 
                 this.UpdateSelectedDomains();
-                this.Thing.SelectedDomain = this.SelectedDomains.FirstOrDefault();
+                this.CurrentThing.SelectedDomain = this.SelectedDomains.FirstOrDefault();
 
                 if (shouldCreate)
                 {
-                    modelClone.Participant.Add(this.Thing);
+                    modelClone.Participant.Add(this.CurrentThing);
                     thingsToCreate.Add(modelClone);
                 }
 
-                thingsToCreate.Add(this.Thing);
+                thingsToCreate.Add(this.CurrentThing);
                 await this.SessionService.CreateOrUpdateThingsWithNotification(modelClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
             }
             catch (Exception ex)

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
@@ -51,7 +51,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Organizations
         public OrganizationsTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, ILogger<OrganizationsTableViewModel> logger)
             : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new Organization();
+            this.CurrentThing = new Organization();
         }
 
         /// <summary>
@@ -68,11 +68,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Organizations
 
             if (shouldCreate)
             {
-                siteDirectoryClone.Organization.Add(this.Thing);
+                siteDirectoryClone.Organization.Add(this.CurrentThing);
                 thingsToCreate.Add(siteDirectoryClone);
             }
 
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
             await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
 
             this.IsLoading = false;

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Organizations/OrganizationsTableViewModel.cs
@@ -34,7 +34,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Organizations
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
-    using Microsoft.AspNetCore.Http.HttpResults;
 
     /// <summary>
     /// View model used to manage <see cref="Organization" />

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/ParticipantRolesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/ParticipantRolesTableViewModel.cs
@@ -50,7 +50,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
         public ParticipantRolesTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, ILogger<ParticipantRolesTableViewModel> logger)
             : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new ParticipantRole();
+            this.CurrentThing = new ParticipantRole();
         }
 
         /// <summary>
@@ -70,15 +70,15 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
             var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
             var thingsToCreate = new List<Thing>();
 
-            thingsToCreate.AddRange(this.Thing.ParticipantPermission);
+            thingsToCreate.AddRange(this.CurrentThing.ParticipantPermission);
 
             if (shouldCreate)
             {
-                siteDirectoryClone.ParticipantRole.Add(this.Thing);
+                siteDirectoryClone.ParticipantRole.Add(this.CurrentThing);
                 thingsToCreate.Add(siteDirectoryClone);
             }
 
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
             await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
 
             this.IsLoading = false;

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/PersonRolesTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/Roles/PersonRolesTableViewModel.cs
@@ -50,7 +50,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
         public PersonRolesTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, ILogger<PersonRolesTableViewModel> logger)
             : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new PersonRole();
+            this.CurrentThing = new PersonRole();
         }
 
         /// <summary>
@@ -74,15 +74,15 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.Roles
             var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
             var thingsToCreate = new List<Thing>();
 
-            thingsToCreate.AddRange(this.Thing.PersonPermission);
+            thingsToCreate.AddRange(this.CurrentThing.PersonPermission);
 
             if (shouldCreate)
             {
-                siteDirectoryClone.PersonRole.Add(this.Thing);
+                siteDirectoryClone.PersonRole.Add(this.CurrentThing);
                 thingsToCreate.Add(siteDirectoryClone);
             }
 
-            thingsToCreate.Add(this.Thing);
+            thingsToCreate.Add(this.CurrentThing);
             await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
             this.IsLoading = false;
         }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/IUserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/IUserManagementTableViewModel.cs
@@ -96,11 +96,5 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         /// <param name="shouldCreate">Value to check if the current Person should be created</param>
         /// <returns>A <see cref="Task" /></returns>
         Task CreateOrEditPerson(bool shouldCreate);
-
-        /// <summary>
-        /// Selects the current <see cref="Person" />
-        /// </summary>
-        /// <param name="person">The person to be set</param>
-        void SelectPerson(Person person);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
@@ -56,13 +56,13 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         public UserManagementTableViewModel(ISessionService sessionService, IShowHideDeprecatedThingsService showHideDeprecatedThingsService, ICDPMessageBus messageBus, 
             ILogger<UserManagementTableViewModel> logger) : base(sessionService, messageBus, showHideDeprecatedThingsService, logger)
         {
-            this.Thing = new Person();
+            this.CurrentThing = new Person();
 
             this.DomainOfExpertiseSelectorViewModel = new DomainOfExpertiseSelectorViewModel(sessionService, messageBus)
             {
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner =>
                 {
-                    this.Thing.DefaultDomain = selectedOwner;
+                    this.CurrentThing.DefaultDomain = selectedOwner;
                 })
             };
         }
@@ -133,7 +133,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         /// <param name="person">The person to be set</param>
         public void SelectPerson(Person person)
         {
-            this.Thing = person;
+            this.CurrentThing = person;
             this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(person.Iid == Guid.Empty, person.DefaultDomain);
         }
 
@@ -152,35 +152,35 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
 
                 if (!string.IsNullOrWhiteSpace(this.EmailAddress.Value))
                 {
-                    this.Thing.EmailAddress.Add(this.EmailAddress);
+                    this.CurrentThing.EmailAddress.Add(this.EmailAddress);
                     thingsToCreate.Add(this.EmailAddress);
                 }
 
                 if (!string.IsNullOrWhiteSpace(this.TelephoneNumber.Value))
                 {
-                    this.Thing.TelephoneNumber.Add(this.TelephoneNumber);
+                    this.CurrentThing.TelephoneNumber.Add(this.TelephoneNumber);
                     thingsToCreate.Add(this.TelephoneNumber);
                 }
 
                 if (this.IsDefaultEmail)
                 {
-                    this.Thing.DefaultEmailAddress = this.EmailAddress;
+                    this.CurrentThing.DefaultEmailAddress = this.EmailAddress;
                 }
 
                 if (this.IsDefaultTelephoneNumber)
                 {
-                    this.Thing.DefaultTelephoneNumber = this.TelephoneNumber;
+                    this.CurrentThing.DefaultTelephoneNumber = this.TelephoneNumber;
                 }
 
                 var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
 
                 if (shouldCreate)
                 {
-                    siteDirectoryClone.Person.Add(this.Thing);
+                    siteDirectoryClone.Person.Add(this.CurrentThing);
                     thingsToCreate.Add(siteDirectoryClone);
                 }
 
-                thingsToCreate.Add(this.Thing);
+                thingsToCreate.Add(this.CurrentThing);
                 await this.SessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));
                 this.ResetFields();
             }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
@@ -39,7 +40,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
     using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
-    using Microsoft.AspNetCore.Http.HttpResults;
 
     /// <summary>
     /// View model used to manage <see cref="Person" />
@@ -128,13 +128,17 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         }
 
         /// <summary>
-        /// Selects the current <see cref="Person" />
+        /// Update this view model properties when the <see cref="SingleThingApplicationBaseViewModel{TThing}.CurrentThing" /> has changed
         /// </summary>
-        /// <param name="person">The person to be set</param>
-        public void SelectPerson(Person person)
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
         {
-            this.CurrentThing = person;
-            this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(person.Iid == Guid.Empty, person.DefaultDomain);
+            await base.OnThingChanged();
+
+            if (this.DomainOfExpertiseSelectorViewModel is not null)
+            {
+                await this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(this.CurrentThing.Iid == Guid.Empty, this.CurrentThing.DefaultDomain);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #628 [Refactor] Viewmodels to make use of this.whenanyvalue in favour of XXXViewModel.Selectxxx() methods

