### PR TITLE
Fix #656 #661 #662: Core components implemented for tab flow

### DIFF
--- a/COMET.Web.Common.Tests/Components/Applications/DynamicApplicationBaseTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Applications/DynamicApplicationBaseTestFixture.cs
@@ -1,0 +1,102 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DynamicApplicationBaseTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Applications
+{
+    using COMET.Web.Common.Components.Applications;
+    using COMET.Web.Common.Components.BookEditor;
+    using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using TestContext = Bunit.TestContext;
+
+    [TestFixture]
+    public class DynamicApplicationBaseTestFixture
+    {
+        private Mock<ICustomApplicationBaseViewModel> viewModel;
+        private TestContext context;
+        private Type componentType;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.viewModel = new Mock<ICustomApplicationBaseViewModel>();
+            this.context = new TestContext();
+            this.componentType = typeof(CustomApplicationBase);
+            this.context.Services.AddSingleton(this.viewModel.Object);
+            this.context.Services.AddSingleton(new Mock<IConfigurationService>().Object);
+        }
+
+        [Test]
+        public void VerifyDynamicApplicationBase()
+        {
+            var invalidType = typeof(EditorPopup);
+
+            Assert.That(() => this.context.RenderComponent<DynamicApplicationBase>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+                parameters.Add(p => p.ApplicationBaseType, invalidType);
+            }), Throws.InvalidOperationException.With.Message.Contain("is not an ApplicationBase"));
+
+            var invalidViewModel = new Mock<IOtherCustomApplicationBaseViewModel>();
+
+            Assert.That(() => this.context.RenderComponent<DynamicApplicationBase>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, invalidViewModel.Object);
+                parameters.Add(p => p.ApplicationBaseType, this.componentType);
+            }), Throws.InvalidOperationException.With.Message.Contain("does not matches the required Type"));
+
+            Assert.That(() => this.context.RenderComponent<DynamicApplicationBase>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+                parameters.Add(p => p.ApplicationBaseType, this.componentType);
+            }), Throws.Nothing);
+        }
+    }
+
+    public class CustomApplicationBase : ApplicationBase<ICustomApplicationBaseViewModel>
+    {
+        /// <summary>
+        /// Initializes values of the component and of the ViewModel based on parameters provided from the url
+        /// </summary>
+        /// <param name="parameters">A <see cref="Dictionary{TKey,TValue}" /> for parameters</param>
+        protected override void InitializeValues(Dictionary<string, string> parameters)
+        {
+        }
+    }
+
+    public interface ICustomApplicationBaseViewModel : IApplicationBaseViewModel
+    {
+    }
+
+    public interface IOtherCustomApplicationBaseViewModel : IApplicationBaseViewModel
+    {
+    }
+}

--- a/COMET.Web.Common/Components/Applications/DynamicApplicationBase.razor
+++ b/COMET.Web.Common/Components/Applications/DynamicApplicationBase.razor
@@ -1,0 +1,24 @@
+﻿<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2024 Starion Group S.A. 
+//
+//   Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+//
+//   This file is part of COMET WEB Community Edition
+//   The COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+<CascadingValue Value="this.CurrentThing">
+    <DynamicComponent Type="this.ApplicationBaseType" Parameters="this.parameters"/>
+</CascadingValue>

--- a/COMET.Web.Common/Components/Applications/DynamicApplicationBase.razor.cs
+++ b/COMET.Web.Common/Components/Applications/DynamicApplicationBase.razor.cs
@@ -1,0 +1,96 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DynamicApplicationBase.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//     Annex A and Annex C.
+// 
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+// 
+//         http://www.apache.org/licenses/LICENSE-2.0
+// 
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+// 
+//   </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Applications
+{
+    using System.ComponentModel.DataAnnotations;
+
+    using CDP4Common.CommonData;
+
+    using COMET.Web.Common.Utilities;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component that allows the rendering of any <see cref="ApplicationBase{TViewModel}"/> dynamically
+    /// </summary>
+    public partial class DynamicApplicationBase
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Type"/> of the <see cref="ApplicationBase{TViewModel}"/> to render
+        /// </summary>
+        [Parameter]
+        [Required]
+        public Type ApplicationBaseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IApplicationBaseViewModel"/>
+        /// </summary>
+        [Parameter]
+        [Required]
+        public IApplicationBaseViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional <see cref="Thing" />
+        /// </summary>
+        [Parameter]
+        public Thing CurrentThing { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Dictionary{TKey,TValue}"/> of parameters that have to be passed to the <see cref="DynamicComponent"/>
+        /// </summary>
+        private readonly Dictionary<string, object> parameters = [];
+
+        /// <summary>
+        /// Method invoked when the component has received parameters from its parent in
+        /// the render tree, and the incoming values have been assigned to properties.
+        /// </summary>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            this.ValidateParameters();
+            this.parameters["ParameterizedViewModel"] = this.ViewModel;
+        }
+
+        /// <summary>
+        /// Validates that provided parameters are correct for the current component
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the provided <see cref="ViewModel"/> is not valid for the provided <see cref="ApplicationBaseType"/>
+        /// or if the <see cref="ApplicationBaseType"/> is not a subclass of <see cref="ApplicationBase{TViewModel}"/></exception>
+        private void ValidateParameters()
+        {
+            if (!TypeChecker.IsSubclassOfRawGeneric(this.ApplicationBaseType, typeof(ApplicationBase<>), out var viewModelType))
+            {
+                throw new InvalidOperationException($"The provided {nameof(this.ApplicationBaseType)} is not an ApplicationBase");
+            }
+
+            if (!viewModelType.IsInstanceOfType(this.ViewModel))
+            {
+                throw new InvalidOperationException($"The provided {nameof(this.ViewModel)} does not matches the required Type: Expected {viewModelType.Name}, received {this.ViewModel.GetType().Name}");
+            }
+        }
+    }
+}

--- a/COMET.Web.Common/Components/Applications/SingleThingApplicationBase.razor.cs
+++ b/COMET.Web.Common/Components/Applications/SingleThingApplicationBase.razor.cs
@@ -44,29 +44,22 @@ namespace COMET.Web.Common.Components.Applications
         /// The <typeparamref name="TThing" />
         /// </summary>
         [CascadingParameter]
-        public TThing CurrentThing { get; set; }
+        public Thing CurrentThing { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            if (this.ViewModel != null && this.CurrentThing is TThing tthing)
+            {
+                this.ViewModel.CurrentThing = tthing;
+            }
+
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.CurrentThing)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
-        }
-
-        /// <summary>
-        /// Method invoked when the component has received parameters from its parent in
-        /// the render tree, and the incoming values have been assigned to properties.
-        /// </summary>
-        protected override void OnParametersSet()
-        {
-            this.ViewModel.CurrentThing = this.CurrentThing;
-
-            base.OnParametersSet();
         }
     }
 }

--- a/COMET.Web.Common/Utilities/TypeChecker.cs
+++ b/COMET.Web.Common/Utilities/TypeChecker.cs
@@ -1,0 +1,99 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TypeChecker.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//     Annex A and Annex C.
+// 
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+// 
+//         http://www.apache.org/licenses/LICENSE-2.0
+// 
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+// 
+//   </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Utilities
+{
+    /// <summary>
+    /// The <see cref="TypeChecker" /> provides <see cref="Type" /> check utilities
+    /// </summary>
+    public static class TypeChecker
+    {
+        /// <summary>
+        /// Asserts that the <paramref name="toCheck" /> <see cref="Type" /> is a subclass of a generic <see cref="Type" />
+        /// </summary>
+        /// <param name="toCheck">The <see cref="Type" /> to checks</param>
+        /// <param name="generic">The generic <see cref="Type" /></param>
+        /// <param name="genericTypeArgument">The generic argument of the <paramref name="generic" /> <see cref="Type" /></param>
+        /// <returns>True if the <paramref name="toCheck" /> inherits from the <paramref name="generic" /> one</returns>
+        public static bool IsSubclassOfRawGeneric(Type toCheck, Type generic, out Type genericTypeArgument)
+        {
+            genericTypeArgument = null;
+
+            if (toCheck == null)
+            {
+                return false;
+            }
+
+            while (toCheck != null && toCheck != typeof(object))
+            {
+                var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+
+                if (generic == cur)
+                {
+                    genericTypeArgument = toCheck.GetGenericArguments()[0];
+                    return true;
+                }
+
+                toCheck = toCheck.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Asserts that the <paramref name="toCheck" /> <see cref="Type" /> implements the generic interface
+        /// <paramref name="genericInterfaceType" />
+        /// </summary>
+        /// <param name="toCheck">The <see cref="Type" /> to checks</param>
+        /// <param name="genericInterfaceType">The generic <see cref="Type" /> interface</param>
+        /// <param name="genericTypeArgument">
+        /// The generic argument of the <paramref name="genericInterfaceType" />
+        /// <see cref="Type" />
+        /// </param>
+        /// <returns>True if the <paramref name="toCheck" /> implements from the <paramref name="genericInterfaceType" /> one</returns>
+        public static bool ImplementsGenericInterface(Type toCheck, Type genericInterfaceType, out Type genericTypeArgument)
+        {
+            genericTypeArgument = null;
+
+            if (toCheck == null)
+            {
+                return false;
+            }
+
+            var interfaces = toCheck.GetInterfaces();
+
+            foreach (var iface in interfaces)
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == genericInterfaceType)
+                {
+                    genericTypeArgument = iface.GetGenericArguments()[0];
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
@@ -168,6 +168,26 @@ namespace COMETwebapp.Tests.Components.SubscriptionDashboard
                 Assert.That(this.viewModel.OptionSelector.SelectedOption, Is.Not.Null);
                 Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterType, Is.Not.Null);
             });
+
+            var mockedViewModel = new Mock<ISubscriptionDashboardBodyViewModel>();
+            mockedViewModel.Setup(x => x.CurrentDomain).Returns(this.viewModel.CurrentDomain);
+            mockedViewModel.Setup(x => x.CurrentThing).Returns(this.viewModel.CurrentThing);
+            mockedViewModel.Setup(x => x.DomainOfExpertiseSubscriptionTable).Returns(this.viewModel.DomainOfExpertiseSubscriptionTable);
+            mockedViewModel.Setup(x => x.SubscribedTable).Returns(this.viewModel.SubscribedTable);
+            mockedViewModel.Setup(x => x.OptionSelector).Returns(this.viewModel.OptionSelector);
+            mockedViewModel.Setup(x => x.ParameterTypeSelector).Returns(this.viewModel.ParameterTypeSelector);
+
+            var rendered = this.context.RenderComponent<SubscriptionDashboardBody>(parameters =>
+            {
+                parameters.Add(p => p.CurrentThing, iteration);
+                parameters.Add(p => p.ParameterizedViewModel, mockedViewModel.Object);
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rendered.Instance.ViewModel, Is.EqualTo(mockedViewModel.Object));
+                Assert.That(rendered.Instance.InjectedViewModel, Is.EqualTo(null));
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/Model/ApplicationsTestFixture.cs
+++ b/COMETwebapp.Tests/Model/ApplicationsTestFixture.cs
@@ -36,7 +36,7 @@ namespace COMETwebapp.Tests.Model
         {
             var applications = Applications.ExistingApplications;
 
-            Assert.That(applications, Has.Count.EqualTo(12));
+            Assert.That(applications, Has.Count.EqualTo(13));
 
             foreach (var application in applications)
             {

--- a/COMETwebapp.Tests/Pages/TabsViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/TabsViewModelTestFixture.cs
@@ -1,0 +1,87 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TabsViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Pages
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.ViewModels.Pages;
+
+    using DynamicData;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TabsViewModelTestFixture
+    {
+        private TabsViewModel viewModel;
+        private Mock<ISessionService> sessionService;
+        private Mock<IServiceProvider> serviceProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.serviceProvider = new Mock<IServiceProvider>();
+            this.sessionService = new Mock<ISessionService>();
+            var iterations = new SourceList<Iteration>();
+            iterations.Add(new Iteration());
+            var engineeringModels = new List<EngineeringModel> { new () };
+            this.sessionService.Setup(x => x.OpenIterations).Returns(iterations);
+            this.sessionService.Setup(x => x.OpenEngineeringModels).Returns(engineeringModels);
+            this.serviceProvider.Setup(x => x.GetService(It.IsAny<Type>())).Returns(new Mock<IApplicationBaseViewModel>().Object);
+            this.viewModel = new TabsViewModel(this.sessionService.Object, this.serviceProvider.Object);
+        }
+
+        [Test]
+        public void VerifyViewModelProperties()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableApplications, Is.Not.Empty);
+                Assert.That(this.viewModel.SelectedApplication, Is.Null);
+                Assert.That(this.viewModel.OpenTabs, Has.Count.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void VerifyOnSelectedApplication()
+        {
+            this.viewModel.SelectedApplication = this.viewModel.AvailableApplications.FirstOrDefault(x => x.ThingTypeOfInterest == typeof(Iteration));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.OpenTabs, Has.Count.EqualTo(1));
+                Assert.That(this.viewModel.OpenTabs.Items.First().ObjectOfInterest, Is.EqualTo(this.sessionService.Object.OpenIterations.Items.First()));
+            });
+
+            this.viewModel.SelectedApplication = this.viewModel.AvailableApplications.FirstOrDefault(x => x.ThingTypeOfInterest == null);
+            Assert.That(this.viewModel.OpenTabs, Is.Empty);
+        }
+    }
+}

--- a/COMETwebapp.sln.DotSettings
+++ b/COMETwebapp.sln.DotSettings
@@ -1,4 +1,4 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeAccessorOwnerBody/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -259,6 +259,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=4a98fdf6_002D7d98_002D4f5a_002Dafeb_002Dea44ad98c70c/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Private" Description="Instance fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=f9fce829_002De6f4_002D4cb2_002D80f1_002D5497c44f51df/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Private" Description="Static fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=4AB96A4D2627B246A5C2ECDB728C4A58/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=4AB96A4D2627B246A5C2ECDB728C4A58/AbsolutePath/@EntryValue">C:\CODE\COMET\COMET-WEB-Community-Edition\CommonLibrary.DotSettings</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=4AB96A4D2627B246A5C2ECDB728C4A58/RelativePath/@EntryValue">..\CommonLibrary.DotSettings</s:String>
@@ -268,14 +270,19 @@
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File4AB96A4D2627B246A5C2ECDB728C4A58/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File4AB96A4D2627B246A5C2ECDB728C4A58/DisplayName/@EntryValue">CommonLibraryHeader</s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File4AB96A4D2627B246A5C2ECDB728C4A58/IsOn/@EntryValue">False</s:Boolean>
+	
+	
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File4AB96A4D2627B246A5C2ECDB728C4A58/RelativePriority/@EntryValue">1</s:Double>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileD550F7EA807C0A4C8F7E43AD856774F2/@KeyIndexDefined">True</s:Boolean>
+	
+	
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileD550F7EA807C0A4C8F7E43AD856774F2/RelativePriority/@EntryValue">2</s:Double>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UnitTesting/ExcludedCategoriesList/@EntryValue">Integration</s:String>
 	
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/QuickList/=F0CA621CDF5AB24282D8CDC11C520997/Entry/=40C163D436D8ED48A6D01A0AFEFC5556/EntryName/@EntryValue">Test Fixture</s:String>

--- a/COMETwebapp/Components/BookEditor/BookEditorBody.razor.cs
+++ b/COMETwebapp/Components/BookEditor/BookEditorBody.razor.cs
@@ -24,6 +24,8 @@
 
 namespace COMETwebapp.Components.BookEditor
 {
+    using COMET.Web.Common.Components.Applications;
+
     using ReactiveUI;
 
     /// <summary>
@@ -55,12 +57,11 @@ namespace COMETwebapp.Components.BookEditor
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.EditorPopupViewModel.IsVisible,
                     x => x.ViewModel.ConfirmCancelPopupViewModel.IsVisible)

--- a/COMETwebapp/Components/EngineeringModel/EngineeringModelBody.razor.cs
+++ b/COMETwebapp/Components/EngineeringModel/EngineeringModelBody.razor.cs
@@ -24,15 +24,13 @@
 
 namespace COMETwebapp.Components.EngineeringModel
 {
-    using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Components.Applications;
 
     using COMETwebapp.Components.EngineeringModel.DomainFileStore;
 
     using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
-
-    using ReactiveUI;
 
     /// <summary>
     /// Core component for the Engineering model body application
@@ -69,14 +67,11 @@ namespace COMETwebapp.Components.EngineeringModel
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
-            this.Disposables.Add(this.ViewModel.WhenAnyValue(x => x.IsLoading).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
-
+            base.OnViewModelAssigned();
             this.SelectComponent(this.MapOfComponentsAndParameters.First().Key);
         }
 

--- a/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
+++ b/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
@@ -24,6 +24,7 @@
 
 namespace COMETwebapp.Components.ModelDashboard
 {
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
@@ -61,12 +62,11 @@ namespace COMETwebapp.Components.ModelDashboard
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption,
                     x => x.ViewModel.FiniteStateSelector.SelectedActualFiniteState,

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTable.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTable.razor.cs
@@ -24,6 +24,7 @@
 
 namespace COMETwebapp.Components.ModelEditor
 {
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
 
     using COMETwebapp.Services.Interoperability;
@@ -151,12 +152,11 @@ namespace COMETwebapp.Components.ModelEditor
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnCreationMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnAddingParameterMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -24,6 +24,7 @@
 
 namespace COMETwebapp.Components.ParameterEditor
 {
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
@@ -39,12 +40,11 @@ namespace COMETwebapp.Components.ParameterEditor
     public partial class ParameterEditorBody
     {
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption,
                     x => x.ViewModel.ParameterTypeSelector.SelectedParameterType,

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
@@ -26,10 +26,10 @@ namespace COMETwebapp.Components.SubscriptionDashboard
 {
     using CDP4Common.EngineeringModelData;
 
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
-    using COMETwebapp.Extensions;
     using COMETwebapp.Utilities;
 
     using Microsoft.AspNetCore.Components;
@@ -52,12 +52,11 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         private string DomainOfExpertiseTableTitle => $"Parameters owned by {this.ViewModel.CurrentDomain.Name} domain, subscribed to by other domains";
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption,
                     x => x.ViewModel.ParameterTypeSelector.SelectedParameterType)

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
@@ -24,6 +24,7 @@
 
 namespace COMETwebapp.Components.SystemRepresentation
 {
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
@@ -39,12 +40,11 @@ namespace COMETwebapp.Components.SystemRepresentation
     public partial class SystemRepresentationBody
     {
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption)
                 .Subscribe(_ => this.UpdateUrl()));

--- a/COMETwebapp/Components/Viewer/ViewerBody.razor.cs
+++ b/COMETwebapp/Components/Viewer/ViewerBody.razor.cs
@@ -24,6 +24,7 @@
 
 namespace COMETwebapp.Components.Viewer
 {
+    using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
@@ -71,12 +72,11 @@ namespace COMETwebapp.Components.Viewer
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
+        /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
-        protected override void OnInitialized()
+        protected override void OnViewModelAssigned()
         {
-            base.OnInitialized();
+            base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(x=>x.ViewModel.IsLoading).Subscribe(_=>this.InvokeAsync(this.StateHasChanged)));
 

--- a/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
+++ b/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
@@ -57,6 +57,7 @@ namespace COMETwebapp.Extensions
     using COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileRevisionHandler;
     using COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHandler;
     using COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor;
+    using COMETwebapp.ViewModels.Pages;
 
     /// <summary>
     /// Extension class for the <see cref="IServiceCollection" />
@@ -120,6 +121,7 @@ namespace COMETwebapp.Extensions
             serviceCollection.AddTransient<IFolderHandlerViewModel, FolderHandlerViewModel>();
             serviceCollection.AddTransient<IFileRevisionHandlerViewModel, FileRevisionHandlerViewModel>();
             serviceCollection.AddTransient<IBatchParameterEditorViewModel, BatchParameterEditorViewModel>();
+            serviceCollection.AddTransient<ITabsViewModel, TabsViewModel>();
         }
     }
 }

--- a/COMETwebapp/Model/Applications.cs
+++ b/COMETwebapp/Model/Applications.cs
@@ -26,6 +26,14 @@ namespace COMETwebapp.Model
 {
     using COMET.Web.Common.Model;
 
+    using COMETwebapp.Components.EngineeringModel;
+    using COMETwebapp.Components.ModelDashboard;
+    using COMETwebapp.Components.ModelEditor;
+    using COMETwebapp.Components.ParameterEditor;
+    using COMETwebapp.Components.SubscriptionDashboard;
+    using COMETwebapp.Components.SystemRepresentation;
+    using COMETwebapp.Components.Viewer;
+    using COMETwebapp.Pages.ModelEditor;
     using COMETwebapp.Utilities;
 
     /// <summary>
@@ -34,108 +42,156 @@ namespace COMETwebapp.Model
     public static class Applications
     {
         /// <summary>
-        /// List of <see cref="Application"/> with Name, Color, Icon and Description data
+        /// A collection of <see cref="Application" />
         /// </summary>
-        public static List<Application> ExistingApplications => new()
+        private static List<Application> applications;
+
+        /// <summary>
+        /// List of <see cref="Application" /> with Name, Color, Icon and Description data
+        /// </summary>
+        public static List<Application> ExistingApplications => applications ?? InitializesApplications();
+
+        /// <summary>
+        /// Initializes all <see cref="Application" />
+        /// </summary>
+        /// <returns>The initialized <see cref="Application" /></returns>
+        private static List<Application> InitializesApplications()
         {
-            new Application
-			{
-                Name = "Parameter Editor",
-                Color = "#76b8fc",
-                Icon = "spreadsheet",
-                Description = "Table of element usages with their associated parameters.",
-                Url = WebAppConstantValues.ParameterEditorPage
-            },
-            new Application
-			{
-                Name = "Model Dashboard",
-                Color = "#c3cffd",
-                Icon = "task",
-                Description = "Summarize the model progress.",
-                Url = WebAppConstantValues.ModelDashboardPage
-            },
-            new Application
-			{
-                Name = "Subscription Dashboard",
-                Color = "#76fd98",
-                Icon = "person",
-                Description = "Table of subscribed values.",
-                Url = WebAppConstantValues.SubscriptionDashboardPage
-            },
-            new Application
-			{
-                Name = "System Representation",
-                Color = "#a7f876",
-                Icon = "fork",
-                Description = "Represent relations between elements.",
-                Url = WebAppConstantValues.SystemRepresentationPage
-            },
-            new Application
-			{
-                Name = "Requirement Management",
-                Color = "#fda966",
-                Icon = "link-intact",
-                Description = $"Edit requirements in the model.{Environment.NewLine}Under Development",
-                IsDisabled = true,
-                Url = WebAppConstantValues.RequirementManagementPage
-            },
-            new Application
+            applications =
+            [
+                new TabbedApplication
+                {
+                    Name = "Parameter Editor",
+                    Color = "#76b8fc",
+                    Icon = "spreadsheet",
+                    Description = "Table of element usages with their associated parameters.",
+                    Url = WebAppConstantValues.ParameterEditorPage,
+                    ComponentType = typeof(ParameterEditorBody)
+                },
+
+                new TabbedApplication
+                {
+                    Name = "Model Dashboard",
+                    Color = "#c3cffd",
+                    Icon = "task",
+                    Description = "Summarize the model progress.",
+                    Url = WebAppConstantValues.ModelDashboardPage,
+                    ComponentType = typeof(ModelDashboardBody)
+                },
+
+                new TabbedApplication
+                {
+                    Name = "Subscription Dashboard",
+                    Color = "#76fd98",
+                    Icon = "person",
+                    Description = "Table of subscribed values.",
+                    Url = WebAppConstantValues.SubscriptionDashboardPage,
+                    ComponentType = typeof(SubscriptionDashboardBody)
+                },
+
+                new TabbedApplication
+                {
+                    Name = "System Representation",
+                    Color = "#a7f876",
+                    Icon = "fork",
+                    Description = "Represent relations between elements.",
+                    Url = WebAppConstantValues.SystemRepresentationPage,
+                    ComponentType = typeof(SystemRepresentationBody)
+                },
+
+                new Application
+                {
+                    Name = "Requirement Management",
+                    Color = "#fda966",
+                    Icon = "link-intact",
+                    Description = $"Edit requirements in the model.{Environment.NewLine}Under Development",
+                    IsDisabled = true,
+                    Url = WebAppConstantValues.RequirementManagementPage
+                },
+
+                new Application
+                {
+                    Name = "Budget Editor",
+                    Color = "#fc3a1aad",
+                    Icon = "brush",
+                    Description = $"Create budget tables.{Environment.NewLine}Under Development",
+                    IsDisabled = true,
+                    Url = WebAppConstantValues.BudgetEditorPage
+                },
+
+                new TabbedApplication
+                {
+                    Name = "3D Viewer",
+                    Color = "#76fd98",
+                    Icon = "eye",
+                    Description = "Show 3D Viewer",
+                    Url = WebAppConstantValues.ViewerPage,
+                    ComponentType = typeof(ViewerBody)
+                },
+
+                new Application
+                {
+                    Name = "Reference Data",
+                    Color = "#fc3a1aad",
+                    Icon = "file",
+                    Description = "Visualize reference data",
+                    Url = WebAppConstantValues.ReferenceDataPage
+                },
+
+                new Application
+                {
+                    Name = "Server Administration",
+                    Color = "#fc3a1aad",
+                    Icon = "folder",
+                    Description = "Visualize site directory data",
+                    Url = WebAppConstantValues.SiteDirectoryPage
+                },
+
+                new TabbedApplication
+                {
+                    Name = "Engineering Model",
+                    Color = "#c3cffd",
+                    Icon = "cog",
+                    Description = "Visualize the engineering model data",
+                    Url = WebAppConstantValues.EngineeringModelPage,
+                    ComponentType = typeof(EngineeringModelBody)
+                },
+
+                new TabbedApplication
+                {
+                    Name = "Model Editor",
+                    Color = "#76fd98",
+                    Icon = "box",
+                    Description = "Populate model",
+                    Url = WebAppConstantValues.ModelEditorPage,
+                    ComponentType = typeof(ElementDefinitionTable)
+                },
+
+                new Application
+                {
+                    Name = "Book Editor",
+                    Color = "#76fd98",
+                    Icon = "book",
+                    Description = "Manage books",
+                    Url = WebAppConstantValues.BookEditorPage
+                },
+
+                new Application
+                {
+                    Name = "Tabs",
+                    Url = WebAppConstantValues.TabsPage,
+                    Color = "#76fd98",
+                    Icon = "list",
+                    Description = "Access applications via tabs",
+                }
+            ];
+
+            foreach (var tabbedApplication in applications.OfType<TabbedApplication>())
             {
-                Name = "Budget Editor",
-                Color = "#fc3a1aad",
-                Icon = "brush",
-                Description = $"Create budget tables.{Environment.NewLine}Under Development",
-                IsDisabled = true,
-				Url = WebAppConstantValues.BudgetEditorPage
-            },
-            new Application
-            {
-                Name = "3D Viewer",
-                Color = "#76fd98",
-                Icon = "eye",
-                Description = "Show 3D Viewer",
-                Url = WebAppConstantValues.ViewerPage
-            },
-            new Application
-            {
-                Name = "Reference Data",
-                Color = "#fc3a1aad",
-                Icon = "file",
-                Description = "Visualize reference data",
-                Url = WebAppConstantValues.ReferenceDataPage
-            },
-            new Application
-            {
-                Name = "Server Administration",
-                Color = "#fc3a1aad",
-                Icon = "folder",
-                Description = "Visualize site directory data",
-                Url = WebAppConstantValues.SiteDirectoryPage
-            },
-            new Application
-            {
-                Name = "Engineering Model",
-                Color = "#c3cffd",
-                Icon = "cog",
-                Description = "Visualize the engineering model data",
-                Url = WebAppConstantValues.EngineeringModelPage
-            },
-            new Application
-            {
-                Name = "Model Editor",
-                Color = "#76fd98",
-                Icon = "box",
-                Description = "Populate model",
-                Url = WebAppConstantValues.ModelEditorPage
-            },
-            new Application
-            {
-                Name = "Book Editor",
-                Color = "#76fd98",
-                Icon = "book",
-                Description = "Manage books",
-                Url = WebAppConstantValues.BookEditorPage
+                tabbedApplication.ResolveTypesProperties();
             }
-        };
+
+            return applications;
+        }
     }
 }

--- a/COMETwebapp/Model/TabbedApplication.cs
+++ b/COMETwebapp/Model/TabbedApplication.cs
@@ -1,0 +1,68 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TabbedApplication.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Model
+{
+    using COMET.Web.Common.Components.Applications;
+    using COMET.Web.Common.Model;
+    using COMET.Web.Common.Utilities;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    /// <summary>
+    /// The <see cref="TabbedApplication" /> is an <see cref="Application" /> that provides additional information about req
+    /// </summary>
+    public class TabbedApplication : Application
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Type" /> of the associated component
+        /// </summary>
+        public Type ComponentType { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Type" /> of the ViewModel that is required for the compoenet
+        /// </summary>
+        public Type ViewModelType { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="Type" /> of possible thing of interest
+        /// </summary>
+        public Type ThingTypeOfInterest { get; private set; }
+
+        /// <summary>
+        /// Resolve the <see cref="ViewModelType" /> and <see cref="ThingTypeOfInterest" /> properties
+        /// </summary>
+        public void ResolveTypesProperties()
+        {
+            if (TypeChecker.IsSubclassOfRawGeneric(this.ComponentType, typeof(ApplicationBase<>), out var viewModelType))
+            {
+                this.ViewModelType = viewModelType;
+            }
+
+            if (TypeChecker.ImplementsGenericInterface(this.ViewModelType, typeof(ISingleThingApplicationBaseViewModel<>), out var thingType))
+            {
+                this.ThingTypeOfInterest = thingType;
+            }
+        }
+    }
+}

--- a/COMETwebapp/Model/TabbedApplicationInformation.cs
+++ b/COMETwebapp/Model/TabbedApplicationInformation.cs
@@ -1,0 +1,62 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TabbedApplicationInformation.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Model
+{
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    /// <summary>
+    /// The <see cref="TabbedApplicationInformation" /> provides required information related to an open application
+    /// </summary>
+    public class TabbedApplicationInformation
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TabbedApplicationInformation" /> class.
+        /// </summary>
+        /// <param name="applicationBaseViewModel">The <see cref="IApplicationBaseViewModel" /></param>
+        /// <param name="componentType">The <see cref="Type" /> of the component to use</param>
+        /// <param name="objectOfInterest">An optinal object of interest</param>
+        public TabbedApplicationInformation(IApplicationBaseViewModel applicationBaseViewModel, Type componentType, object objectOfInterest)
+        {
+            this.ApplicationBaseViewModel = applicationBaseViewModel;
+            this.ComponentType = componentType;
+            this.ObjectOfInterest = objectOfInterest;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IApplicationBaseViewModel" />
+        /// </summary>
+        public IApplicationBaseViewModel ApplicationBaseViewModel { get; }
+
+        /// <summary>
+        /// Gets the component <see cref="Type" />
+        /// </summary>
+        public Type ComponentType { get; }
+
+        /// <summary>
+        /// Gets the object of interest
+        /// </summary>
+        public object ObjectOfInterest { get; }
+    }
+}

--- a/COMETwebapp/Pages/Tabs.razor
+++ b/COMETwebapp/Pages/Tabs.razor
@@ -1,0 +1,38 @@
+﻿<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2023 Starion Group S.A.
+//
+//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+//
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@attribute [Route(WebAppConstantValues.TabsPage)]
+@using CDP4Common.CommonData
+@using COMETwebapp.Model
+@using COMETwebapp.Utilities
+@inherits DisposableComponent
+
+<DxComboBox Data="@this.ViewModel.AvailableApplications"
+            TextFieldName="@nameof(TabbedApplication.Name)"
+            @bind-Value="@this.ViewModel.SelectedApplication"/>
+
+
+
+@foreach (var tabbedApplication in this.ViewModel.OpenTabs.Items)
+{
+    <DynamicApplicationBase ViewModel="tabbedApplication.ApplicationBaseViewModel" ApplicationBaseType="tabbedApplication.ComponentType"
+                            CurrentThing="tabbedApplication.ObjectOfInterest as Thing"/>
+}

--- a/COMETwebapp/Pages/Tabs.razor.cs
+++ b/COMETwebapp/Pages/Tabs.razor.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="Tabs.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Pages
+{
+    using COMET.Web.Common.Extensions;
+
+    using COMETwebapp.ViewModels.Pages;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Support class for the <see cref="Tabs" /> page
+    /// </summary>
+    public partial class Tabs
+    {
+        /// <summary>
+        /// Gets or sets the injected <see cref="ITabsViewModel" />
+        /// </summary>
+        [Inject]
+        public ITabsViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Method invoked when the component is ready to start, having received its
+        /// initial parameters from its parent in the render tree.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            this.Disposables.Add(this.ViewModel.OpenTabs.CountChanged.SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+        }
+    }
+}

--- a/COMETwebapp/Utilities/WebAppConstantValues.cs
+++ b/COMETwebapp/Utilities/WebAppConstantValues.cs
@@ -127,8 +127,13 @@ namespace COMETwebapp.Utilities
         public const string ModelEditorPage = "ModelEditor";
 
         /// <summary>
-        /// The page name of the Book Editor
+        /// The page nastringthe Book Editor
         /// </summary>
         public const string BookEditorPage = "BookEditor";
+
+        /// <summary>
+        /// The page that support multi tabs 
+        /// </summary>
+        public const string TabsPage = "Tabs";
     }
 }

--- a/COMETwebapp/ViewModels/Pages/ITabsViewModel.cs
+++ b/COMETwebapp/ViewModels/Pages/ITabsViewModel.cs
@@ -1,0 +1,51 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ITabsViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Pages
+{
+    using COMETwebapp.Model;
+
+    using DynamicData;
+
+    /// <summary>
+    /// The <see cref="ITabsViewModel"/> contains logic and behavior that are required to support multi-tabs application
+    /// </summary>
+    public interface ITabsViewModel
+    {
+        /// <summary>
+        /// Gets the collection of all <see cref="TabbedApplicationInformation" />
+        /// </summary>
+        SourceList<TabbedApplicationInformation> OpenTabs { get; }
+
+        /// <summary>
+        /// Gets the collection of available <see cref="TabbedApplication" />
+        /// </summary>
+        IEnumerable<TabbedApplication> AvailableApplications { get; }
+
+        /// <summary>
+        /// Gets or sets the current selected <see cref="TabbedApplication"/>
+        /// </summary>
+        TabbedApplication SelectedApplication { get; set; }
+    }
+}

--- a/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
+++ b/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
@@ -92,6 +92,8 @@ namespace COMETwebapp.ViewModels.Pages
         /// </summary>
         private void InitializeViewModelBasedOnApplication()
         {
+            this.OpenTabs.Clear();
+            
             if (this.SelectedApplication == null)
             {
                 return;
@@ -110,7 +112,6 @@ namespace COMETwebapp.ViewModels.Pages
                 thingOfInterest = this.sessionService.OpenEngineeringModels.First();
             }
 
-            this.OpenTabs.Clear();
             this.OpenTabs.Add(new TabbedApplicationInformation(viewModel, this.SelectedApplication.ComponentType, thingOfInterest));
         }
     }

--- a/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
+++ b/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
@@ -1,0 +1,117 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TabsViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Pages
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Model;
+
+    using DynamicData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The <see cref="TabsViewModel" /> contains logic and behavior that are required to support multi-tabs application
+    /// </summary>
+    public class TabsViewModel : DisposableObject, ITabsViewModel
+    {
+        /// <summary>
+        /// Gets the injected <see cref="IServiceProvider" />
+        /// </summary>
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Gets the injected <see cref="ISessionService" />
+        /// </summary>
+        private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedApplication" />
+        /// </summary>
+        private TabbedApplication selectedApplication;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TabsViewModel" />
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /></param>
+        /// <param name="serviceProvider">The <see cref="IServiceProvider" /></param>
+        public TabsViewModel(ISessionService sessionService, IServiceProvider serviceProvider)
+        {
+            this.sessionService = sessionService;
+            this.serviceProvider = serviceProvider;
+            this.Disposables.Add(this.WhenAnyValue(x => x.SelectedApplication).Subscribe(_ => this.InitializeViewModelBasedOnApplication()));
+        }
+
+        /// <summary>
+        /// Gets the collection of all <see cref="TabbedApplicationInformation" />
+        /// </summary>
+        public SourceList<TabbedApplicationInformation> OpenTabs { get; } = new();
+
+        /// <summary>
+        /// Gets the collection of available <see cref="TabbedApplication" />
+        /// </summary>
+        public IEnumerable<TabbedApplication> AvailableApplications => Applications.ExistingApplications.OfType<TabbedApplication>();
+
+        /// <summary>
+        /// Gets or sets the current selected <see cref="TabbedApplication" />
+        /// </summary>
+        public TabbedApplication SelectedApplication
+        {
+            get => this.selectedApplication;
+            set => this.RaiseAndSetIfChanged(ref this.selectedApplication, value);
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="TabbedApplicationInformation" /> based on the selected <see cref="TabbedApplication" />
+        /// </summary>
+        private void InitializeViewModelBasedOnApplication()
+        {
+            if (this.SelectedApplication == null)
+            {
+                return;
+            }
+
+            var viewModel = this.serviceProvider.GetService(this.SelectedApplication.ViewModelType) as IApplicationBaseViewModel;
+            object thingOfInterest = default;
+
+            if (this.SelectedApplication.ThingTypeOfInterest == typeof(Iteration))
+            {
+                thingOfInterest = this.sessionService.OpenIterations.Items.First();
+            }
+
+            if (this.SelectedApplication.ThingTypeOfInterest == typeof(EngineeringModel))
+            {
+                thingOfInterest = this.sessionService.OpenEngineeringModels.First();
+            }
+
+            this.OpenTabs.Clear();
+            this.OpenTabs.Add(new TabbedApplicationInformation(viewModel, this.SelectedApplication.ComponentType, thingOfInterest));
+        }
+    }
+}

--- a/CommonLibrary.DotSettings
+++ b/CommonLibrary.DotSettings
@@ -1,12 +1,12 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">--------------------------------------------------------------------------------------------------------------------&#xD;
- &lt;copyright file="${File.FileName}" company="RHEA System S.A."&gt;&#xD;
-    Copyright (c) ${CurrentDate.Year} Starion Group S.A.&#xD;
+ &lt;copyright file="${File.FileName}" company="Starion Group S.A."&gt;&#xD;
+    Copyright (c) 2023-${CurrentDate.Year} Starion Group S.A.&#xD;
 &#xD;
-    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine&#xD;
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua&#xD;
 &#xD;
     This file is part of COMET WEB Community Edition&#xD;
-    The COMET WEB Community Edition is the RHEA Web Application implementation of ECSS-E-TM-10-25&#xD;
+    The COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25&#xD;
     Annex A and Annex C.&#xD;
 &#xD;
     Licensed under the Apache License, Version 2.0 (the "License");&#xD;

--- a/WebAppHeader.DotSettings
+++ b/WebAppHeader.DotSettings
@@ -1,7 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">--------------------------------------------------------------------------------------------------------------------&#xD;
  &lt;copyright file="${File.FileName}" company="Starion Group S.A."&gt;&#xD;
-    Copyright (c) ${CurrentDate.Year} Starion Group S.A.&#xD;
+    Copyright (c) 2023-${CurrentDate.Year} Starion Group S.A.&#xD;
 &#xD;
     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua&#xD;
 &#xD;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #656 #661 #662 

- ApplicationBase components also supports to have the ViewModel set via Parameter
- DynamicApplicationBase component support to render any ApplicationBase with the associated ViewModel
- Tabs page implemented to support the core: For now, possible to select the Application to show via a dropdown
<!-- Thanks for contributing to COMET-WEB! -->

