### PR TITLE
Fix #685 fix open tabs bug after closing session

### DIFF
--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
@@ -233,6 +233,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         {
             this.viewModel.Dispose();
             this.messageBus.ClearSubscriptions();
+            this.messageBus.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #685 fix open tabs bug after closing session

Additionally, this PR also solves:
- an error thrown when an iteration opened in two or more tabs, in the same application, was closed.
- engineering model tabs not closing when the users logs out
