### PR TITLE
Fix #694 [Reference Data] Parameter types - UI problems + #696 Tab text update

### DIFF
--- a/COMETwebapp/Components/Common/SelectedDataItemForm.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDataItemForm.razor.cs
@@ -75,6 +75,11 @@ namespace COMETwebapp.Components.Common
         protected EditContext EditFormContext { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom validation fields names that will be validated immediately
+        /// </summary>
+        protected virtual IEnumerable<string> ImmediateValidationFields { get; } = Enumerable.Empty<string>();
+
+        /// <summary>
         /// Method that is executed when the cancel button is clicked
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -124,6 +129,20 @@ namespace COMETwebapp.Components.Common
             this.EditFormContext = editFormContext;
             this.MapOfValidationMessages.Clear();
             this.EditFormContext.OnFieldChanged += this.OnFieldChangedHandler;
+
+            this.ValidateCustomFields();
+        }
+
+        /// <summary>
+        /// Validate the custom fields contained by the collection <see cref="ImmediateValidationFields" />
+        /// </summary>
+        private void ValidateCustomFields()
+        {
+            foreach (var fieldStr in this.ImmediateValidationFields)
+            {
+                var fieldIdentifier = this.EditFormContext.Field(fieldStr);
+                this.MapOfValidationMessages[fieldIdentifier] = this.EditFormContext.GetValidationMessages(fieldIdentifier);
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor.cs
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor.cs
@@ -26,6 +26,8 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
 {
     using System.ComponentModel.DataAnnotations;
 
+    using CDP4Common.SiteDirectoryData;
+
     using COMETwebapp.Components.Common;
     using COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes;
 
@@ -42,6 +44,17 @@ namespace COMETwebapp.Components.ReferenceData.ParameterTypes
         [Parameter]
         [Required]
         public IParameterTypeTableViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom validation fields names that will be validated immediately
+        /// </summary>
+        protected override IEnumerable<string> ImmediateValidationFields =>
+        [
+            nameof(DerivedQuantityKind.QuantityKindFactor),
+            nameof(EnumerationParameterType.ValueDefinition),
+            nameof(SampledFunctionParameterType.DependentParameterType),
+            nameof(SampledFunctionParameterType.IndependentParameterType)
+        ];
 
         /// <summary>
         /// Method that is executed when there is a valid submit

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
@@ -37,7 +37,7 @@
                               @key="tab"/>
             }
 
-            <TabComponent Text="Open Model"
+            <TabComponent Text="Select Model"
                           Icon="typeof(FeatherPlus)"
                           OnClick="@(() => this.OnOpenTabClick.Invoke())"/>
 

--- a/COMETwebapp/Validators/ReferenceData/ParameterTypes/GenericValidators/ParameterQuantityKindValidator.cs
+++ b/COMETwebapp/Validators/ReferenceData/ParameterTypes/GenericValidators/ParameterQuantityKindValidator.cs
@@ -45,7 +45,7 @@ namespace COMETwebapp.Validators.ReferenceData.ParameterTypes.GenericValidators
             this.Include(new ParameterTypeValidator(validationService));
             this.RuleFor(x => x.DefaultScale).NotEmpty().Validate(validationService, nameof(QuantityKind.DefaultScale));
             this.RuleFor(x => x.QuantityDimensionSymbol).NotEmpty().Validate(validationService, nameof(QuantityKind.QuantityDimensionSymbol));
-            this.RuleFor(x => x.PossibleScale).NotEmpty().Validate(validationService, nameof(QuantityKind.PossibleScale));
+            this.RuleFor(x => x.PossibleScale).Validate(validationService, nameof(QuantityKind.PossibleScale));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #694 [Reference Data] Parameter types - UI problems
Closes #696 Change "tab" text from "open model" to "Select Model"

