### PR TITLE
Feat #697 From a tab, allow a user to open a new tab by only selecting the view of interest

### DIFF
--- a/COMET.Web.Common.Tests/Components/IndexComponentTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/IndexComponentTestFixture.cs
@@ -24,6 +24,7 @@
 
 namespace COMET.Web.Common.Tests.Components
 {
+    using System.Collections.ObjectModel;
     using System.Reflection;
 
     using Bunit;
@@ -70,6 +71,7 @@ namespace COMET.Web.Common.Tests.Components
         private TestAuthorizationContext authorization;
         private SourceList<Iteration> sourceList;
         private Mock<IRegistrationService> registrationService;
+        private readonly Guid modelId = Guid.NewGuid();
 
         [SetUp]
         public void Setup()
@@ -82,6 +84,7 @@ namespace COMET.Web.Common.Tests.Components
             this.serverConnectionService.Setup(x => x.ServerConfiguration).Returns(serverConfiguration);
             this.sourceList = new SourceList<Iteration>();
             this.sessionService.Setup(x => x.OpenIterations).Returns(this.sourceList);
+            this.sessionService.Setup(x => x.OpenEngineeringModels).Returns([]);
 
             this.authenticationService = new Mock<IAuthenticationService>();
 
@@ -157,7 +160,7 @@ namespace COMET.Web.Common.Tests.Components
 
             var engineeringModelSetup = new EngineeringModelSetup
             {
-                Iid = Guid.NewGuid(),
+                Iid = this.modelId,
                 IterationSetup =
                 {
                     new IterationSetup
@@ -165,6 +168,12 @@ namespace COMET.Web.Common.Tests.Components
                         IterationIid = Guid.NewGuid()
                     }
                 }
+            };
+
+            var engineeringModel = new EngineeringModel
+            {
+                Iid = this.modelId,
+                EngineeringModelSetup = engineeringModelSetup
             };
 
             var queries = new Dictionary<string, string>
@@ -183,6 +192,7 @@ namespace COMET.Web.Common.Tests.Components
             Assert.That(openModel.Instance.ViewModel.SelectedEngineeringModel, Is.Null);
 
             this.sessionService.Setup(x => x.GetParticipantModels()).Returns(new List<EngineeringModelSetup> { engineeringModelSetup });
+            this.sessionService.Setup(x => x.OpenEngineeringModels).Returns(new ReadOnlyCollection<EngineeringModel>([engineeringModel]));
 
             renderer = this.context.RenderComponent<IndexComponent>(parameters =>
                 parameters.Add(p => p.Redirect, url));

--- a/COMET.Web.Common/ViewModels/Components/OpenModelViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/OpenModelViewModel.cs
@@ -214,7 +214,7 @@ namespace COMET.Web.Common.ViewModels.Components
         /// <param name="domainId">The <see cref="Guid" /> of the <see cref="DomainOfExpertise" /> to select</param>
         public void PreSelectIteration(Guid modelId, Guid iterationId, Guid domainId)
         {
-            this.selectedEngineeringModel = this.AvailableEngineeringModelSetups.FirstOrDefault(x => x.Iid == modelId);
+            this.selectedEngineeringModel = this.sessionService.OpenEngineeringModels.FirstOrDefault(x => x.Iid == modelId)?.EngineeringModelSetup;
             var iterationSetup = this.SelectedEngineeringModel?.IterationSetup.Find(x => x.IterationIid == iterationId);
 
             if (iterationSetup != null)

--- a/COMETwebapp.Tests/Pages/TabsTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/TabsTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.Tests.Pages
 
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Services.StringTableService;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Components;
@@ -103,6 +104,7 @@ namespace COMETwebapp.Tests.Pages
             this.context.Services.AddSingleton(new Mock<IOpenTabViewModel>().Object);
             this.context.Services.AddSingleton(new Mock<IOpenModelViewModel>().Object);
             this.context.Services.AddSingleton(new Mock<IStringTableService>().Object);
+            this.context.Services.AddSingleton(new Mock<ISessionService>().Object);
 
             this.renderer = this.context.RenderComponent<Tabs>();
         }

--- a/COMETwebapp/Components/Tabs/OpenTab.razor
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor
@@ -49,7 +49,8 @@
                         Data="@(this.ViewModel.EngineeringModelSetups)"
                         TextFieldName="@nameof(EngineeringModelSetup.Name)"
                         @bind-Value="@(this.ViewModel.SelectedEngineeringModel)"
-                        NullText="Select an Engineering Model"/>
+                        NullText="Select an Engineering Model"
+                        Enabled="@(this.ModelId == Guid.Empty)" />
         </DxFormLayoutItem>
 
         <DxFormLayoutItem Caption="Domain" ColSpanLg="12">
@@ -57,7 +58,8 @@
                         Data="@(this.ViewModel.AvailablesDomainOfExpertises)"
                         TextFieldName="@nameof(DomainOfExpertise.Name)"
                         @bind-Value="@(this.ViewModel.SelectedDomainOfExpertise)"
-                        NullText="Select a Domain of Expertise">
+                        NullText="Select a Domain of Expertise"
+                        Enabled="@(this.DomainId == Guid.Empty)">
                 <ItemTemplate Context="ctx">
                     @if (this.ViewModel.IsCurrentModelOpened)
                     {
@@ -79,7 +81,8 @@
                             TextFieldName="@nameof(IterationData.IterationName)"
                             @bind-Value="@(this.ViewModel.SelectedIterationSetup)"
                             NullText="Select an Iteration"
-                            ReadOnly="@(this.ViewModel.IsCurrentModelOpened)"/>
+                            ReadOnly="@(this.ViewModel.IsCurrentModelOpened)"
+                            Enabled="@(this.IterationId == Guid.Empty)" />
             </DxFormLayoutItem>
         }
 

--- a/COMETwebapp/Components/Tabs/TabComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabComponent.razor
@@ -30,7 +30,8 @@
     {
         <DxButton RenderStyle="ButtonRenderStyle.None"
                   Click="@(() => this.OnCustomOptionIconClick?.Invoke())"
-                  CssClass="ps-1 pe-0">
+                  CssClass="ps-1 pe-0"
+                  Id="tab-custom-option-button">
             <DynamicComponent Type="@(this.CustomOptionIcon)"
                               Parameters="IconConfiguration"/>
         </DxButton>
@@ -38,7 +39,8 @@
 
     <DxButton RenderStyle="ButtonRenderStyle.None"
               Click="@(() => this.OnIconClick?.Invoke())"
-              CssClass="px-1">
+              CssClass="px-1"
+              Id="tab-button">
         <DynamicComponent Type="@(this.Icon)"
                           Parameters="IconConfiguration"/>
     </DxButton>

--- a/COMETwebapp/Components/Tabs/TabComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabComponent.razor
@@ -25,6 +25,16 @@
      @onclick="@(() => this.OnClick?.Invoke())">
 
     <span>@(this.Text)</span>
+    
+    @if (this.CustomOptionIcon is not null)
+    {
+        <DxButton RenderStyle="ButtonRenderStyle.None"
+                  Click="@(() => this.OnCustomOptionIconClick?.Invoke())"
+                  CssClass="ps-1 pe-0">
+            <DynamicComponent Type="@(this.CustomOptionIcon)"
+                              Parameters="IconConfiguration"/>
+        </DxButton>
+    }
 
     <DxButton RenderStyle="ButtonRenderStyle.None"
               Click="@(() => this.OnIconClick?.Invoke())"
@@ -32,5 +42,4 @@
         <DynamicComponent Type="@(this.Icon)"
                           Parameters="IconConfiguration"/>
     </DxButton>
-
 </div>

--- a/COMETwebapp/Components/Tabs/TabComponent.razor.cs
+++ b/COMETwebapp/Components/Tabs/TabComponent.razor.cs
@@ -40,10 +40,16 @@ namespace COMETwebapp.Components.Tabs
         public string Text { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon to be displayed
+        /// Gets or sets the icon to be displayed on the right side of a tab
         /// </summary>
         [Parameter]
         public Type Icon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon to be displayed as an option icon from a tab
+        /// </summary>
+        [Parameter]
+        public Type CustomOptionIcon { get; set; }
 
         /// <summary>
         /// Gets or sets the action to be executed when the tab is clicked
@@ -56,6 +62,12 @@ namespace COMETwebapp.Components.Tabs
         /// </summary>
         [Parameter]
         public Action OnIconClick { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action to be executed when the custom option icon button is clicked
+        /// </summary>
+        [Parameter]
+        public Action OnCustomOptionIconClick { get; set; }
 
         /// <summary>
         /// Gets or sets the condition to check if this tab is the current one

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
@@ -31,8 +31,10 @@
             {
                 <TabComponent Text="@(GetTabText(tab.ObjectOfInterest))"
                               Icon="typeof(FeatherX)"
+                              CustomOptionIcon="typeof(FeatherCopy)"
                               OnClick="@(() => this.OnTabClick.InvokeAsync((tab, this.Handler)))"
                               OnIconClick="@(() => this.OnRemoveTabClick.InvokeAsync(tab))"
+                              OnCustomOptionIconClick="@(() => this.OnCreateTabForModel.InvokeAsync(tab))"
                               IsCurrent="@(tab == this.Handler.CurrentTab)"
                               @key="tab"/>
             }

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.cs
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.cs
@@ -71,6 +71,12 @@ namespace COMETwebapp.Components.Tabs
         public Action OnOpenTabClick { get; set; }
 
         /// <summary>
+        /// Gets or sets the method to be executed when the open new tab for the selected model button is clicked
+        /// </summary>
+        [Parameter]
+        public EventCallback<TabbedApplicationInformation> OnCreateTabForModel { get; set; }
+
+        /// <summary>
         /// Gets or sets the method to be executed when the remove tab button is clicked
         /// </summary>
         [Parameter]

--- a/COMETwebapp/Pages/Tabs.razor
+++ b/COMETwebapp/Pages/Tabs.razor
@@ -30,6 +30,7 @@
         <TabsPanelComponent Handler="@(this.ViewModel)"
                             ViewModel="@(this.ViewModel)"
                             OnTabClick="@(tuple => OnTabClick(tuple.Item1, tuple.Item2))"
+                            OnCreateTabForModel="@(tab => this.OnCreateTabForModel(tab))"
                             OnRemoveTabClick="@(tab => this.OnRemoveTabClick(tab))"
                             OnOpenTabClick="@(() => this.OnOpenTabClick())"
                             Tabs="@(this.OpenTabsFromSelectedApplication.Where(x => x.Panel == null).ToList())"
@@ -60,8 +61,12 @@
          ShowHeader="false"
          ShowCloseButton="true"
          CloseOnOutsideClick="true"
-         CloseOnEscape="true">
+         CloseOnEscape="true"
+         Closed="@(() => this.ResetOpenTabPopup())">
     <OpenTab OnCancel="@(() => this.SetOpenTabVisibility(false))"
              OnTabOpened="@(() => this.SetOpenTabVisibility(false))"
-             Panel="@(this.SelectedSidePanel)"/>
+             Panel="@(this.SelectedSidePanel)"
+             ModelId="this.ModelId"
+             IterationId="this.IterationId"
+             DomainId="this.DomainId"/>
 </DxPopup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #697 From a tab, allow a user to open a new tab by only selecting the view of interest

Screenshots
![image](https://github.com/user-attachments/assets/c6ec591a-71c0-4f87-91f7-1f1dc1664b48)
![image](https://github.com/user-attachments/assets/97e833a2-ee76-4fae-b792-ff8fe5a5beb3)

