### PR TITLE
Feat #702 Reduce the need to horizontally scroll when split screen is applied 

### DIFF
--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
@@ -17,7 +17,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 
 @namespace COMETwebapp.Components.Common
 
-<div class="ps-3 data-items-panel-container" style="width: @this.Width;">
+<div class="data-items-panel-container @(this.CssClass)" style="width: @this.Width;">
     <div class="data-item-details-section">
         @if (this.IsSelected)
         {

--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.cs
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.cs
@@ -66,5 +66,11 @@ namespace COMETwebapp.Components.Common
         /// </summary>
         [Parameter]
         public string Width { get; set; } = "50%";
+
+        /// <summary>
+        /// The custom css class to be used in the container component
+        /// </summary>
+        [Parameter]
+        public string CssClass { get; set; }
     }
 }

--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.css
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.css
@@ -6,12 +6,6 @@
     overflow: auto;
 }
 
-.data-items-panel-container {
-    max-height: 90vh;
-    position: sticky;
-    top: 10px;
-}
-
 .data-item-details-image {
     margin: auto;
     display: block;

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
@@ -16,7 +16,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemBase<CommonFileStore, CommonFileStoreRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -32,7 +32,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(CommonFileStoreRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(CommonFileStoreRowViewModel.CreatedOn)" MinWidth="80" DisplayFormat="{0:dd/MM/yyyy HH:mm:ss}" SearchEnabled="false"/>

--- a/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
@@ -16,7 +16,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemBase<DomainFileStore, DomainFileStoreRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -32,7 +32,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(DomainFileStoreRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(DomainFileStoreRowViewModel.CreatedOn)" MinWidth="80" DisplayFormat="{0:dd/MM/yyyy HH:mm:ss}" SearchEnabled="false"/>

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
@@ -16,7 +16,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDataItemBase<Option, OptionRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -33,7 +33,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(OptionRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(OptionRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTable.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTable.razor
@@ -26,69 +26,69 @@
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
     <ValidationMessageComponent ValidationMessage="@(this.ErrorMessage)" />
-    <div style="display: flex">
-        <div>
-            <h4>Source Model</h4>
-            <div class="model-elements-column sticky-scrollable-column">
-                <DxGrid @ref="this.SecondGrid"
-                        Data="this.ViewModel.RowsSource"
-                        ShowAllRows="true"
-                        CssClass="second-grid"
-                        AllowSort="false"
-                        RowClick="this.OnElementSelected"
-                        AllowSelectRowByClick="true"
-                        SelectionMode="GridSelectionMode.Single"
-                        VerticalScrollBarMode="ScrollBarMode.Visible"
-                        CustomizeElement="@(OnCustomizeElement)">
-                    <Columns>
-                        <DxGridDataColumn Caption="Element Definition" FieldName="@nameof(ElementDefinitionRowViewModel.ElementDefinitionName)" GroupIndex="0" GroupInterval="GridColumnGroupInterval.Value" />
-                        <DxGridDataColumn Caption="Element Usage" FieldName="@nameof(ElementDefinitionRowViewModel.ElementUsageName)" />
-                        <DxGridDataColumn FieldName="@nameof(ElementDefinitionRowViewModel.IsTopElement)" Visible="false"/>
-                    </Columns>
-                </DxGrid>
+    <div class="selected-data-item-page">
+        <div class="selected-data-item-table d-flex" style="flex: 1 1 58%!important;">
+            <div>
+                <h4>Source Model</h4>
+                <div class="sticky-scrollable-column">
+                    <DxGrid @ref="this.SecondGrid"
+                            Data="this.ViewModel.RowsSource"
+                            ShowAllRows="true"
+                            CssClass="second-grid"
+                            AllowSort="false"
+                            RowClick="this.OnElementSelected"
+                            AllowSelectRowByClick="true"
+                            SelectionMode="GridSelectionMode.Single"
+                            VerticalScrollBarMode="ScrollBarMode.Visible"
+                            CustomizeElement="@(OnCustomizeElement)">
+                        <Columns>
+                            <DxGridDataColumn Caption="Element Definition" FieldName="@nameof(ElementDefinitionRowViewModel.ElementDefinitionName)" GroupIndex="0" GroupInterval="GridColumnGroupInterval.Value" />
+                            <DxGridDataColumn Caption="Element Usage" FieldName="@nameof(ElementDefinitionRowViewModel.ElementUsageName)" />
+                            <DxGridDataColumn FieldName="@nameof(ElementDefinitionRowViewModel.IsTopElement)" Visible="false"/>
+                        </Columns>
+                    </DxGrid>
+                </div>
+            </div>
+            <div>
+                <h4>Target Model</h4>
+                <div class="sticky-scrollable-column">
+                    <DxGrid @ref="this.FirstGrid"
+                            Data="this.ViewModel.RowsTarget"
+                            ShowAllRows="true"
+                            CssClass="first-grid"
+                            AllowSort="false"
+                            RowClick="this.OnElementSelected"
+                            AllowSelectRowByClick="true"
+                            SelectionMode="GridSelectionMode.Single"
+                            VerticalScrollBarMode="ScrollBarMode.Visible"
+                            CustomizeElement="@(OnCustomizeElement)">
+                        <Columns>
+                            <DxGridDataColumn Caption="Element Definition" FieldName="@nameof(ElementDefinitionRowViewModel.ElementDefinitionName)" GroupIndex="0" GroupInterval="GridColumnGroupInterval.Value"/>
+                            <DxGridDataColumn Caption="Element Usage" FieldName="@nameof(ElementDefinitionRowViewModel.ElementUsageName)"/>
+                        </Columns>
+                    </DxGrid>
+                </div>
             </div>
         </div>
-        <div style="padding-left: 10px">
-            <h4>Target Model</h4>
-            <div class="model-elements-column sticky-scrollable-column">
-                <DxGrid @ref="this.FirstGrid"
-                        Data="this.ViewModel.RowsTarget"
-                        ShowAllRows="true"
-                        CssClass="first-grid"
-                        AllowSort="false"
-                        RowClick="this.OnElementSelected"
-                        AllowSelectRowByClick="true"
-                        SelectionMode="GridSelectionMode.Single"
-                        VerticalScrollBarMode="ScrollBarMode.Visible"
-                        CustomizeElement="@(OnCustomizeElement)">
-                    <Columns>
-                        <DxGridDataColumn Caption="Element Definition" FieldName="@nameof(ElementDefinitionRowViewModel.ElementDefinitionName)" GroupIndex="0" GroupInterval="GridColumnGroupInterval.Value"/>
-                        <DxGridDataColumn Caption="Element Usage" FieldName="@nameof(ElementDefinitionRowViewModel.ElementUsageName)"/>
-                    </Columns>
-                </DxGrid>
+        <DataItemDetailsComponent IsSelected="@(this.ViewModel.SelectedElementDefinition is not null)"
+                                  NotSelectedText="Select an item to view or edit"
+                                  Width="100%"
+                                  CssClass="model-editor-details">
+            <div class="mb-2 row">
+                <h4 class="d-inline">Panel Editor</h4>
+                <div class="float-end">
+                    @if (this.ViewModel.SelectedElementDefinition is not null)
+                    {
+                        <DxButton Id="addParameter" Text="Add Parameter" IconCssClass="oi oi-plus" Click="@(this.ViewModel.OpenAddParameterPopup)"/>
+                    }
+
+                    <DxButton Id="addElementDefinition" Text="Add Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
+                </div>
             </div>
-        </div>
-
-        <div style="width: 1300px;">
-            <DataItemDetailsComponent IsSelected="@(this.ViewModel.SelectedElementDefinition is not null)"
-                                      NotSelectedText="Select an item to view or edit"
-                                      Width="100%">
-                <div class="mb-2">
-                    <h4 class="d-inline">Panel Editor</h4>
-                    <div class="float-end">
-                        @if (this.ViewModel.SelectedElementDefinition is not null)
-                        {
-                            <DxButton Id="addParameter" Text="Add Parameter" IconCssClass="oi oi-plus" Click="@(this.ViewModel.OpenAddParameterPopup)"/>
-                        }
-
-                        <DxButton Id="addElementDefinition" Text="Add Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
-                    </div>
-                </div>
-                <div style="height: 73vh!important;" class="sticky-scrollable-column d-flex justify-content-between">
-                        <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"/>
-                </div>
-            </DataItemDetailsComponent>
-        </div>
+            <div style="height: 73vh!important;" class="sticky-scrollable-column d-flex justify-content-between">
+                <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"/>
+            </div>
+        </DataItemDetailsComponent>
     </div>
     <DxPopup CloseOnOutsideClick="false" HeaderText="Create Element Definition" @bind-Visible="@this.ViewModel.IsOnCreationMode" Width="40vw">
         <Content>

--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.css
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.css
@@ -16,7 +16,7 @@
 }
 
 .table-container {
-    min-width: 1400px;
+    width: fit-content;
     margin-top: 15px;
     max-height: 80vh;
 }

--- a/COMETwebapp/Components/ReferenceData/Categories/CategoriesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/Categories/CategoriesTable.razor
@@ -1,7 +1,7 @@
 ﻿<!------------------------------------------------------------------------------
 Copyright (c) 2023-2024 Starion Group S.A.
 
-    Authors: Justine Veirier d'aiguebonne, Sam Gerené, Alex Vorobiev, Alexander van Delft, Nabil Abbar
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 
     This file is part of CDP4-COMET WEB Community Edition
      The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -22,7 +22,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits SelectedDeprecatableDataItemBase<Category, CategoryRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -39,7 +39,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(CategoryRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(CategoryRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesTable.razor
@@ -22,7 +22,7 @@ Copyright (c) 2024 Starion Group S.A.
 
 @inherits SelectedDeprecatableDataItemBase<MeasurementScale, MeasurementScaleRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -39,7 +39,7 @@ Copyright (c) 2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(MeasurementScaleRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnits/MeasurementUnitsTable.razor
@@ -17,7 +17,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits SelectedDeprecatableDataItemBase<MeasurementUnit, MeasurementUnitRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -34,7 +34,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(MeasurementUnitRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeTable.razor
@@ -17,8 +17,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits SelectedDeprecatableDataItemBase<ParameterType, ParameterTypeRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
-
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -35,7 +34,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(ParameterTypeRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>
@@ -53,7 +52,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
             <ParameterTypeForm ViewModel="@(this.ViewModel)"
                                @bind-IsVisible="@(this.IsOnEditMode)"
                                ShouldCreate="@(this.ShouldCreateThing)"
-                               OnSaved="@(this.OnSaved)" />
+                               OnSaved="@(this.OnSaved)"/>
         </DataItemDetailsComponent>
     </div>
 </LoadingComponent>

--- a/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseTable.razor
@@ -18,7 +18,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits SelectedDeprecatableDataItemBase<DomainOfExpertise, DomainOfExpertiseRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -35,7 +35,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new int[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(DomainOfExpertiseRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(DomainOfExpertiseRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
@@ -17,7 +17,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits SelectedDataItemBase<EngineeringModelSetup, EngineeringModelRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div style="display: flex; justify-content: space-between;">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -33,7 +33,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(EngineeringModelRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(EngineeringModelRowViewModel.ShortName)" MinWidth="80"/>

--- a/COMETwebapp/Components/SiteDirectory/OrganizationsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/OrganizationsTable.razor
@@ -17,7 +17,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
 @inherits COMETwebapp.Components.Common.SelectedDeprecatableDataItemBase<CDP4Common.SiteDirectoryData.Organization, OrganizationRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -34,7 +34,7 @@ Copyright (c) 2023-2024 Starion Group S.A.
                 PageSizeSelectorItems="@(new int[] { 20, 35, 50 })"
                 PageSizeSelectorAllRowsItemVisible="true"
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <Columns>
                 <DxGridDataColumn FieldName="@nameof(OrganizationRowViewModel.Name)" MinWidth="150"/>
                 <DxGridDataColumn FieldName="@nameof(OrganizationRowViewModel.ShortName)" MinWidth="80" />

--- a/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRolesTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/Roles/ParticipantRolesTable.razor
@@ -21,7 +21,7 @@ Copyright (c) 2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDeprecatableDataItemBase<ParticipantRole, ParticipantRoleRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -38,7 +38,7 @@ Copyright (c) 2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(ParticipantRoleRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(ParticipantRoleRowViewModel.ShortName)" MinWidth="80"/>

--- a/COMETwebapp/Components/SiteDirectory/Roles/PersonRolesTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/Roles/PersonRolesTable.razor
@@ -21,7 +21,7 @@ Copyright (c) 2024 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits SelectedDeprecatableDataItemBase<PersonRole, PersonRoleRowViewModel>
 
-<div class="d-flex justify-content-between">
+<div class="selected-data-item-page">
     <DxGrid @ref="this.Grid"
             Data="this.ViewModel.Rows.Items"
             ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -38,7 +38,7 @@ Copyright (c) 2024 Starion Group S.A.
             PageSizeSelectorItems="@(new[] { 20, 35, 50 })"
             PageSizeSelectorAllRowsItemVisible="true"
             FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-            CssClass="height-fit-content">
+            CssClass="selected-data-item-table">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(PersonRoleRowViewModel.Name)" MinWidth="150"/>
             <DxGridDataColumn FieldName="@nameof(PersonRoleRowViewModel.ShortName)" MinWidth="80"/>

--- a/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor
@@ -22,7 +22,7 @@
 @inherits SelectedDeprecatableDataItemBase<Person, PersonRowViewModel>
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
-    <div class="d-flex justify-content-between">
+    <div class="selected-data-item-page">
         <DxGrid @ref="this.Grid"
                 Data="this.ViewModel.Rows.Items"
                 ColumnResizeMode="GridColumnResizeMode.ColumnsContainer"
@@ -41,7 +41,7 @@
                 FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
                 CustomSummary="CustomSummary"
                 CustomizeSummaryDisplayText="CustomizeSummaryDisplayText"
-                CssClass="height-fit-content">
+                CssClass="selected-data-item-table">
             <TotalSummary>
                 <DxGridSummaryItem SummaryType="GridSummaryItemType.Count" FieldName="IsActive" ValueDisplayFormat="{0} Total"/>
                 <DxGridSummaryItem SummaryType="GridSummaryItemType.Custom" Name="Inactive" FieldName="IsActive"/>

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.css
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.css
@@ -3,11 +3,10 @@
     border-bottom: solid 1px var(--colors-gray-100);
     padding: 16px;
     border-radius: 24px 0px 0px 0px;
-    min-width: 60vw;
+    overflow: auto;
 }
 
 #tabs-page-content {
-    min-width: 60vw;
 }
 
 .panel-view {

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.css
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.css
@@ -6,9 +6,6 @@
     overflow: auto;
 }
 
-#tabs-page-content {
-}
-
 .panel-view {
     overflow-x: auto;
     width: 100%;

--- a/COMETwebapp/Pages/_Host.cshtml
+++ b/COMETwebapp/Pages/_Host.cshtml
@@ -2,7 +2,7 @@
 <!------------------------------------------------------------------------------
 // Copyright (c) 2023-2024 Starion Group S.A.
 //
-//   Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, Nabil Abbar
+//   Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 //
 //   This file is part of CDP4-COMET WEB Community Edition
 //   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/EngineeringModels/EngineeringModelsTableViewModel.cs
@@ -187,10 +187,10 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
 
                 var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
                 var thingsToCreate = new List<Thing>();
-                this.CurrentThing.EngineeringModelIid = Guid.NewGuid();
 
                 if (shouldCreate)
                 {
+                    this.CurrentThing.EngineeringModelIid = Guid.NewGuid();
                     siteDirectoryClone.Model.Add(this.CurrentThing);
                     thingsToCreate.Add(siteDirectoryClone);
 
@@ -248,6 +248,11 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels
         /// <param name="siteRdl">The updated <see cref="SiteReferenceDataLibrary"/></param>
         private void OnSelectedSiteRdlChanged(SiteReferenceDataLibrary siteRdl)
         {
+            if (this.CurrentThing.Iid != Guid.Empty)
+            {
+                return;
+            }
+
             this.CurrentThing.RequiredRdl.Clear();
 
             if (siteRdl != null)

--- a/COMETwebapp/wwwroot/css/app.css
+++ b/COMETwebapp/wwwroot/css/app.css
@@ -266,3 +266,28 @@ sub {
 #tabs-page-content{
     padding-top: 16px!important;
 }
+
+.selected-data-item-page {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.selected-data-item-table {
+    flex: 1 1 63%;
+    min-width: 300px;
+    height: fit-content;
+}
+
+.data-items-panel-container {
+    max-height: 90vh;
+    position: sticky;
+    top: 10px;
+    flex: 1 1 35%;
+    min-width: 350px;
+}
+
+.model-editor-details {
+    flex: 1 1 40% !important;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #702 Reduce the need to horizontally scroll when split screen is applied => Now pages are responsive

- Additionally, a bug in model updates was solved

