### PR TITLE
Feat #596 [Parameter Editor] Allow parameter filtering by category and domains of expertise in batch update

### DIFF
--- a/COMET.Web.Common/Components/Selectors/DomainOfExpertiseSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/DomainOfExpertiseSelector.razor
@@ -32,7 +32,7 @@
     <DxComboBox Data="@(this.ViewModel.AvailableDomainsOfExpertise)"
                 @bind-Value="@(this.ViewModel.SelectedDomainOfExpertise)"
                 FilteringMode="DataGridFilteringMode.Contains"
-                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Never"
+                ClearButtonDisplayMode="@(this.ViewModel.AllowNullSelection ? DataEditorClearButtonDisplayMode.Auto : DataEditorClearButtonDisplayMode.Never)"
                 NullText="Select a Domain Of Expertise"
                 AllowUserInput="true"
                 CssClass="@(this.CssClass)">
@@ -47,6 +47,10 @@
                 <div class="@(this.ViewModel.CurrentIterationDomain == domainOfExpertise ? "fw-bold" : string.Empty)">
                     @(domainOfExpertise.GetSelectorNameAndShortname())
                 </div>
+            }
+            else
+            {
+                <span class="text-secondary">@("Select a Domain Of Expertise")</span>
             }
         </EditBoxTemplate>
     </DxComboBox>

--- a/COMET.Web.Common/ViewModels/Components/Selectors/DomainOfExpertiseSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/DomainOfExpertiseSelectorViewModel.cs
@@ -51,7 +51,7 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         /// Creates a new instance of <see cref="DomainOfExpertiseSelectorViewModel" />
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionService" /></param>
-        /// <param name="messageBus">The <see cref="ICDPMessageBus"/></param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
         public DomainOfExpertiseSelectorViewModel(ISessionService sessionService, ICDPMessageBus messageBus)
         {
             this.SessionService = sessionService;
@@ -62,7 +62,12 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         }
 
         /// <summary>
-        /// Gets or sets the callback that is executed when the <see cref="SelectedDomainOfExpertise"/> property has changed
+        /// Gets or sets the condition to check if a null selection can be allowed
+        /// </summary>
+        public bool AllowNullSelection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback that is executed when the <see cref="SelectedDomainOfExpertise" /> property has changed
         /// </summary>
         public EventCallback<DomainOfExpertise> OnSelectedDomainOfExpertiseChange { get; set; }
 
@@ -91,11 +96,11 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         }
 
         /// <summary>
-        /// Sets the <see cref="SelectedDomainOfExpertise"/> property or resets its value
+        /// Sets the <see cref="SelectedDomainOfExpertise" /> property or resets its value
         /// </summary>
         /// <param name="reset">The condition to check if the value should be reset</param>
-        /// <param name="domainOfExpertise">The <see cref="DomainOfExpertise"/> to be set</param>
-        /// <returns>A <see cref="Task"/></returns>
+        /// <param name="domainOfExpertise">The <see cref="DomainOfExpertise" /> to be set</param>
+        /// <returns>A <see cref="Task" /></returns>
         public async Task SetSelectedDomainOfExpertiseOrReset(bool reset, DomainOfExpertise domainOfExpertise = null)
         {
             switch (reset)
@@ -124,7 +129,7 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         /// <summary>
         /// Method executed when an iteration domain has changed
         /// </summary>
-        /// <param name="domainChangedEvent">The <see cref="DomainChangedEvent"/> data</param>
+        /// <param name="domainChangedEvent">The <see cref="DomainChangedEvent" /> data</param>
         private void OnDomainChanged(DomainChangedEvent domainChangedEvent)
         {
             if (domainChangedEvent.Iteration.Iid == this.CurrentIteration?.Iid)

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IDomainOfExpertiseSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IDomainOfExpertiseSelectorViewModel.cs
@@ -52,21 +52,26 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         ISessionService SessionService { get; }
 
         /// <summary>
-        /// Gets the <see cref="DomainOfExpertise" /> from the current <see cref="Iteration"/>
+        /// Gets the <see cref="DomainOfExpertise" /> from the current <see cref="Iteration" />
         /// </summary>
         DomainOfExpertise CurrentIterationDomain { get; set; }
 
         /// <summary>
-        /// Gets or sets the callback that is executed when the <see cref="SelectedDomainOfExpertise"/> property has changed
+        /// Gets or sets the callback that is executed when the <see cref="SelectedDomainOfExpertise" /> property has changed
         /// </summary>
         EventCallback<DomainOfExpertise> OnSelectedDomainOfExpertiseChange { get; set; }
 
         /// <summary>
-        /// Sets the <see cref="SelectedDomainOfExpertise"/> property or resets its value
+        /// Gets or sets the condition to check if a null selection can be allowed
+        /// </summary>
+        bool AllowNullSelection { get; set; }
+
+        /// <summary>
+        /// Sets the <see cref="SelectedDomainOfExpertise" /> property or resets its value
         /// </summary>
         /// <param name="reset">The condition to check if the value should be reset</param>
-        /// <param name="domainOfExpertise">The <see cref="DomainOfExpertise"/> to be set</param>
-        /// <returns>A <see cref="Task"/></returns>
+        /// <param name="domainOfExpertise">The <see cref="DomainOfExpertise" /> to be set</param>
+        /// <returns>A <see cref="Task" /></returns>
         Task SetSelectedDomainOfExpertiseOrReset(bool reset, DomainOfExpertise domainOfExpertise = null);
     }
 }

--- a/COMETwebapp.Tests/Components/ParameterEditor/BatchParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ParameterEditor/BatchParameterEditorTestFixture.cs
@@ -67,6 +67,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             var parameterTypeEditorSelectorViewModel = new Mock<IParameterTypeEditorSelectorViewModel>();
             var finiteStateSelectorViewModel = new Mock<IFiniteStateSelectorViewModel>();
             var optionSelectorViewModel = new Mock<IOptionSelectorViewModel>();
+            var domainOfExpertiseSelectorViewModel = new Mock<IDomainOfExpertiseSelectorViewModel>();
             var confirmCancelPopupViewModel = new Mock<IConfirmCancelPopupViewModel>();
 
             var parameter = new Parameter
@@ -100,6 +101,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             this.viewModel.Setup(x => x.ParameterTypeSelectorViewModel).Returns(parameterTypeSelectorViewModel.Object);
             this.viewModel.Setup(x => x.FiniteStateSelectorViewModel).Returns(finiteStateSelectorViewModel.Object);
             this.viewModel.Setup(x => x.OptionSelectorViewModel).Returns(optionSelectorViewModel.Object);
+            this.viewModel.Setup(x => x.DomainOfExpertiseSelectorViewModel).Returns(domainOfExpertiseSelectorViewModel.Object);
             this.viewModel.Setup(x => x.ParameterTypeEditorSelectorViewModel).Returns(parameterTypeEditorSelectorViewModel.Object);
 
             this.renderer = this.context.RenderComponent<BatchParameterEditor>(parameters => { parameters.Add(p => p.ViewModel, this.viewModel.Object); });

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/BatchParameterEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/BatchParameterEditorViewModelTestFixture.cs
@@ -50,14 +50,17 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         private Mock<ILogger<BatchParameterEditorViewModel>> loggerMock;
         private Iteration iteration;
         private CDPMessageBus messageBus;
-        private static readonly ValueArray<string> defaultValueArray = new(["-"]);
+        private static readonly ValueArray<string> DefaultValueArray = new(["-"]);
 
         [SetUp]
         public void Setup()
         {
             this.sessionService = new Mock<ISessionService>();
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(new SiteDirectory());
+
             this.loggerMock = new Mock<ILogger<BatchParameterEditorViewModel>>();
             this.messageBus = new CDPMessageBus();
+
             this.viewModel = new BatchParameterEditorViewModel(this.sessionService.Object, this.messageBus, this.loggerMock.Object);
 
             var domain = new DomainOfExpertise();
@@ -66,7 +69,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
             {
                 Iid = Guid.NewGuid(),
                 Name = "mass",
-                ShortName = "m"
+                ShortName = "m",
+                Category =
+                {
+                    new Category()
+                }
             };
 
             var scale = new RatioScale
@@ -86,28 +93,28 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                     new ParameterValueSet
                     {
                         Iid = Guid.NewGuid(),
-                        Manual = defaultValueArray,
-                        Published = defaultValueArray,
+                        Manual = DefaultValueArray,
+                        Published = DefaultValueArray,
                         ValueSwitch = ParameterSwitchKind.MANUAL,
                         ActualOption = new Option()
                     },
                     new ParameterValueSet
                     {
                         Iid = Guid.NewGuid(),
-                        Manual = defaultValueArray,
-                        Published = defaultValueArray,
+                        Manual = DefaultValueArray,
+                        Published = DefaultValueArray,
                         ValueSwitch = ParameterSwitchKind.MANUAL,
                         ActualState = new ActualFiniteState { Container = new ActualFiniteStateList() }
                     },
                     new ParameterValueSet
                     {
                         Iid = Guid.NewGuid(),
-                        Manual = defaultValueArray,
-                        Published = defaultValueArray,
+                        Manual = DefaultValueArray,
+                        Published = DefaultValueArray,
                         ValueSwitch = ParameterSwitchKind.MANUAL,
                         ActualState = new ActualFiniteState { Container = new ActualFiniteStateList() },
                         ActualOption = new Option()
-                    },
+                    }
                 }
             };
 
@@ -173,11 +180,17 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 Assert.That(this.viewModel.ParameterTypeSelectorViewModel.SelectedParameterType, Is.Null);
                 Assert.That(this.viewModel.OptionSelectorViewModel.SelectedOption, Is.Null);
                 Assert.That(this.viewModel.FiniteStateSelectorViewModel.SelectedActualFiniteState, Is.Null);
+                Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise, Is.Null);
+                Assert.That(this.viewModel.SelectedCategory, Is.Null);
                 Assert.That(this.viewModel.SelectedValueSetsRowsToUpdate, Has.Count.EqualTo(0));
                 Assert.That(this.viewModel.IsVisible, Is.EqualTo(true));
                 Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(0));
             });
 
+            this.viewModel.SelectedCategory = new Category();
+            Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(0));
+
+            this.viewModel.SelectedCategory = null;
             var firstTopElementParameter = this.iteration.TopElement.Parameter[0];
             this.viewModel.ParameterTypeSelectorViewModel.SelectedParameterType = firstTopElementParameter.ParameterType;
             Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(3));
@@ -187,6 +200,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
             this.viewModel.FiniteStateSelectorViewModel.SelectedActualFiniteState = firstTopElementParameter.ValueSet[1].ActualState;
             Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(1));
+
+            this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise = firstTopElementParameter.Owner;
+            Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(1));
+
+            this.viewModel.SelectedCategory = new Category();
+            Assert.That(this.viewModel.Rows.Items.Count(), Is.EqualTo(0));
         }
 
         [Test]

--- a/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
+++ b/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
@@ -54,7 +54,7 @@ Copyright (c) 2024 Starion Group S.A.
                                 AllowUserInput="true"
                                 @bind-Value="@this.ViewModel.SelectedCategory"
                                 FilteringMode="DataGridFilteringMode.Contains"
-                                TextFieldName="@nameof(Option.Name)"
+                                TextFieldName="@nameof(Category.Name)"
                                 ClearButtonDisplayMode="@(DataEditorClearButtonDisplayMode.Auto)"
                                 NullText="Select a Category" />
                 </div>

--- a/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
+++ b/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
@@ -38,12 +38,29 @@ Copyright (c) 2024 Starion Group S.A.
 
         @if (this.ViewModel.ParameterTypeSelectorViewModel.SelectedParameterType != null)
         {
-            <div class="row pt-2">
+            <div class="row pt-3">
                 <div class="col">
                     <OptionSelector ViewModel="this.ViewModel.OptionSelectorViewModel"/>
                 </div>
                 <div class="col">
                     <FiniteStateSelector ViewModel="this.ViewModel.FiniteStateSelectorViewModel"/>
+                </div>
+            </div>
+
+            <div class="row pt-3">
+                <div class="col">
+                    <h6>Filter on Category:</h6>
+                    <DxComboBox Data="@this.ViewModel.AvailableCategories"
+                                AllowUserInput="true"
+                                @bind-Value="@this.ViewModel.SelectedCategory"
+                                FilteringMode="DataGridFilteringMode.Contains"
+                                TextFieldName="@nameof(Option.Name)"
+                                ClearButtonDisplayMode="@(DataEditorClearButtonDisplayMode.Auto)"
+                                NullText="Select a Category" />
+                </div>
+                <div class="col">
+                    <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)" 
+                                               DisplayText="Filter on Domain Of Expertise:"/>
                 </div>
             </div>
 

--- a/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor.cs
@@ -67,12 +67,14 @@ namespace COMETwebapp.Components.ParameterEditor.BatchParameterEditor
             this.Disposables.Add(this.WhenAnyValue(
                     x => x.ViewModel.ParameterTypeSelectorViewModel.SelectedParameterType,
                     x => x.ViewModel.OptionSelectorViewModel.SelectedOption,
-                    x => x.ViewModel.FiniteStateSelectorViewModel.SelectedActualFiniteState)
+                    x => x.ViewModel.FiniteStateSelectorViewModel.SelectedActualFiniteState,
+                    x => x.ViewModel.SelectedCategory,
+                    x => x.ViewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise)
                 .SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
         }
 
         /// <summary>
-        /// Gets the group check value based on the given <see cref="ViewModel"/>
+        /// Gets the group check value based on the given <see cref="ViewModel" />
         /// </summary>
         /// <param name="context">The column group context</param>
         /// <returns>The check box value</returns>
@@ -106,9 +108,9 @@ namespace COMETwebapp.Components.ParameterEditor.BatchParameterEditor
         }
 
         /// <summary>
-        /// Gets the <see cref="ParameterValueSetBaseRowViewModel"/>s from the selected element name group
+        /// Gets the <see cref="ParameterValueSetBaseRowViewModel" />s from the selected element name group
         /// </summary>
-        /// <param name="context">The <see cref="GridDataColumnGroupRowTemplateContext"/></param>
+        /// <param name="context">The <see cref="GridDataColumnGroupRowTemplateContext" /></param>
         /// <returns>A collection of data items contained in the given group</returns>
         private IEnumerable<object> GetGroupDataItems(GridDataColumnGroupRowTemplateContext context)
         {

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditorViewModel.cs
@@ -134,7 +134,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor
         /// <summary>
         /// Gets a collection of all available categories
         /// </summary>
-        public IEnumerable<Category> AvailableCategories => this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.DefinedCategory).Distinct();
+        public IEnumerable<Category> AvailableCategories => this.SessionService.GetSiteDirectory().AvailableReferenceDataLibraries().SelectMany(x => x.DefinedCategory).Distinct().OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
 
         /// <summary>
         /// Gets or sets the selected category

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/IBatchParameterEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/IBatchParameterEditorViewModel.cs
@@ -24,6 +24,8 @@
 
 namespace COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor
 {
+    using CDP4Common.SiteDirectoryData;
+
     using COMET.Web.Common.ViewModels.Components;
     using COMET.Web.Common.ViewModels.Components.ParameterEditors;
     using COMET.Web.Common.ViewModels.Components.Selectors;
@@ -68,7 +70,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor
         IOptionSelectorViewModel OptionSelectorViewModel { get; }
 
         /// <summary>
-        /// Gets the list of <see cref="ParameterValueSetBaseRowViewModel"/>s
+        /// Gets the list of <see cref="ParameterValueSetBaseRowViewModel" />s
         /// </summary>
         SourceList<ParameterValueSetBaseRowViewModel> Rows { get; }
 
@@ -81,6 +83,21 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor
         /// Gets or sets the collection of selected rows
         /// </summary>
         IReadOnlyList<object> SelectedValueSetsRowsToUpdate { get; set; }
+
+        /// <summary>
+        /// Gets a collection of all available categories
+        /// </summary>
+        IEnumerable<Category> AvailableCategories { get; }
+
+        /// <summary>
+        /// Gets or sets the selected category
+        /// </summary>
+        Category SelectedCategory { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IDomainOfExpertiseSelectorViewModel" />
+        /// </summary>
+        IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
 
         /// <summary>
         /// Method invoked for opening the batch update popup


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #596 [Parameter Editor] Allow parameter filtering by category and domains of expertise in batch update

Screenshot
![image](https://github.com/user-attachments/assets/e4809228-0e48-41cb-bafa-2bd2238bdb17)

