### PR TITLE
Fix #430 Parameter overrides are shown with no clear distinction & Fix #347 [3D Viewer] Improvements on spacing and parameter editor

### DIFF
--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
@@ -76,7 +76,16 @@
             CustomizeElement="this.OnCustomizeElement">
         <Columns>
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.ElementBaseName)" GroupIndex="0" GroupInterval="GridColumnGroupInterval.Value" Caption="@("Element Name")" AllowSort="true" />
-            <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.ParameterName)" Caption="@("Parameter")" AllowGroup="false" AllowSort="true" />
+            <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.ParameterName)" Caption="@("Parameter")" AllowGroup="false" AllowSort="true">
+                <CellDisplayTemplate>
+                    @context.DisplayText
+                    
+                    @if (context.DataItem is ParameterBaseRowViewModel parameterBaseRowViewModel && parameterBaseRowViewModel.Parameter is ParameterOverride)
+                    {
+                        <span class="fw-bold"> [Overridden]</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.Option)" Caption="@("Option")" AllowGroup="false" AllowSort="true" />
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.State)" Caption="@("State")" AllowGroup="false" AllowSort="true" />
             <DxGridDataColumn FieldName="@nameof(ParameterBaseRowViewModel.PublishedValue)" Caption="@("Published Value")" AllowGroup="false" AllowSort="false" />

--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor
@@ -80,9 +80,9 @@
                 <CellDisplayTemplate>
                     @context.DisplayText
                     
-                    @if (context.DataItem is ParameterBaseRowViewModel parameterBaseRowViewModel && parameterBaseRowViewModel.Parameter is ParameterOverride)
+                    @if (context.DataItem is ParameterBaseRowViewModel { Parameter: ParameterOverride })
                     {
-                        <span class="fw-bold"> [Overridden]</span>
+                        <span class="fw-bold"> [Override]</span>
                     }
                 </CellDisplayTemplate>
             </DxGridDataColumn>

--- a/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor
+++ b/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor
@@ -1,7 +1,7 @@
 ﻿<!------------------------------------------------------------------------------
 Copyright (c) 2023-2024 Starion Group S.A.
 
-    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
+    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
 
     This file is part of CDP4-COMET WEB Community Edition
      The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -19,29 +19,27 @@ Copyright (c) 2023-2024 Starion Group S.A.
     You should have received a copy of the GNU Affero General Public License
     along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
-
-@using CDP4Dal
+@inherits DisposableComponent
 
 <div id="propertiesPanel">
 
     @if (this.ViewModel.IsVisible)
     {
-        var selectedSceneObject = this.ViewModel.SelectionMediator.SelectedSceneObject;
-        var title = selectedSceneObject is not null ? selectedSceneObject.ElementBase.Name + " - Properties:" : "Properties";
-        var buttonClass = this.ViewModel.ParameterHaveChanges ? "submit-button button-blue" : "submit-button";
-
         <div id="properties-header">
-            <h4 id="properties-title">@title</h4>
-            <button @onclick="()=>this.ViewModel.OnSubmit()" class="@buttonClass" disabled="@(!this.ViewModel.ParameterHaveChanges)">Submit</button>
+            <h4 id="properties-title">@(this.Title)</h4>
+            <DxButton Click="@(() => this.ViewModel.OnSubmit())"
+                      Text="Submit"
+                      Enabled="@(this.ViewModel.ParameterHaveChanges)"/>
         </div>
 
         <div id="parameters-section">
             @{
-                var parameters = this.ViewModel.ParametersInUse is not null ? this.ViewModel.ParametersInUse : new List<CDP4Common.EngineeringModelData.ParameterBase>();
+                var parameters = this.ViewModel.ParametersInUse ?? [];
+
                 @foreach (var parameter in parameters)
                 {
                     var classNames = parameter == this.ViewModel.SelectedParameter ? "parameter-item parameter-item-selected" : "parameter-item";
-                    <p class="@classNames" @onclick="()=> this.ViewModel.SelectedParameter = parameter">@parameter.ParameterType?.Name</p>
+                    <p class="@classNames" @onclick="() => this.ViewModel.SelectedParameter = parameter">@parameter.ParameterType?.Name</p>
                 }
             }
         </div>

--- a/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor.cs
+++ b/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor.cs
@@ -1,46 +1,54 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="PropertiesComponent.razor.cs" company="Starion Group S.A.">
-//    Copyright (c) 2023-2024 Starion Group S.A.
-//
-//    Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar
-//
-//    This file is part of CDP4-COMET WEB Community Edition
-//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//
-//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Affero General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or (at your option) any later version.
-//
-//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  <copyright file="PropertiesComponent.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2024 Starion Group S.A.
+// 
+//     Authors: Sam Gerené, Alex Vorobiev, Alexander van Delft, Jaime Bernar, Théate Antoine, João Rua
+// 
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
-//
+// 
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace COMETwebapp.Components.Viewer.PropertiesPanel
 {
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.Extensions;
+
     using COMETwebapp.ViewModels.Components.Viewer.PropertiesPanel;
-    
+
     using Microsoft.AspNetCore.Components;
-    
+
     using ReactiveUI;
 
     /// <summary>
     /// The properties component used for displaying data about the selected primitive
     /// </summary>
-    public partial class PropertiesComponent
+    public partial class PropertiesComponent : DisposableComponent
     {
         /// <summary>
-        /// Gets or sets the <see cref="IPropertiesComponentViewModel"/>
+        /// Gets or sets the <see cref="IPropertiesComponentViewModel" />
         /// </summary>
         [Parameter]
         public IPropertiesComponentViewModel ViewModel { get; set; }
-        
+
+        /// <summary>
+        /// Gets the properties component title
+        /// </summary>
+        private string Title => this.ViewModel.SelectionMediator.SelectedSceneObject is not null ? this.ViewModel.SelectionMediator.SelectedSceneObject.ElementBase.Name + " - Properties:" : "Properties";
+
         /// <summary>
         /// Method invoked when the component is ready to start, having received its
         /// initial parameters from its parent in the render tree.
@@ -49,9 +57,11 @@ namespace COMETwebapp.Components.Viewer.PropertiesPanel
         {
             base.OnInitialized();
 
-            this.WhenAnyValue(x => x.ViewModel.IsVisible,
-            x => x.ViewModel.SelectedParameter,
-            x => x.ViewModel.ParameterHaveChanges).Subscribe(_ => this.InvokeAsync(this.StateHasChanged));
+            this.Disposables.Add(this.WhenAnyValue(
+                    x => x.ViewModel.IsVisible,
+                    x => x.ViewModel.SelectedParameter,
+                    x => x.ViewModel.ParameterHaveChanges)
+                .SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
         }
     }
 }

--- a/COMETwebapp/Components/Viewer/ViewerBody.razor.css
+++ b/COMETwebapp/Components/Viewer/ViewerBody.razor.css
@@ -6,6 +6,7 @@
     grid-template-rows: 1fr;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
+    gap: 10px;
 }
 
 #leftColumn {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #430 [Parameter Editor] Both parameter values and parameter overrides are shown with no clear distinction 
Closes #347 [3D Viewer] improvements on spacing and parameter editor

