### PR TITLE
[Add] Liveness, Startup and Readiness health probes

### DIFF
--- a/COMETwebapp.Tests/Health/CometHasStartedServiceTestFixture.cs
+++ b/COMETwebapp.Tests/Health/CometHasStartedServiceTestFixture.cs
@@ -1,0 +1,83 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CometHasStartedServiceTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Health
+{
+    using System;
+
+    using COMETwebapp.Health;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CometHasStartedServiceTestFixture
+    {
+        private CometHasStartedService service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.service = new CometHasStartedService();
+        }
+
+        [Test]
+        public void VerifyInitialState()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.service.HasStarted, Is.False);
+                Assert.That(this.service.StartedAt, Is.EqualTo(DateTime.MinValue));
+            });
+        }
+
+        [Test]
+        public void VerifyMarkStartedFlipsTheFlag()
+        {
+            var before = DateTime.UtcNow;
+            this.service.MarkStarted();
+            var after = DateTime.UtcNow;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.service.HasStarted, Is.True);
+                Assert.That(this.service.StartedAt, Is.InRange(before, after));
+                Assert.That(this.service.StartedAt.Kind, Is.EqualTo(DateTimeKind.Utc));
+            });
+        }
+
+        [Test]
+        public void VerifyMarkStartedIsIdempotent()
+        {
+            this.service.MarkStarted();
+            var firstTimestamp = this.service.StartedAt;
+
+            System.Threading.Thread.Sleep(5);
+            this.service.MarkStarted();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.service.HasStarted, Is.True);
+                Assert.That(this.service.StartedAt, Is.EqualTo(firstTimestamp));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Health/StartupHealthCheckTestFixture.cs
+++ b/COMETwebapp.Tests/Health/StartupHealthCheckTestFixture.cs
@@ -1,0 +1,70 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="StartupHealthCheckTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Health
+{
+    using COMETwebapp.Health;
+
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StartupHealthCheckTestFixture
+    {
+        private CometHasStartedService startedService;
+        private StartupHealthCheck check;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.startedService = new CometHasStartedService();
+            this.check = new StartupHealthCheck(this.startedService);
+        }
+
+        [Test]
+        public async Task VerifyUnhealthyBeforeStartupCompletes()
+        {
+            var result = await this.check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Status, Is.EqualTo(HealthStatus.Unhealthy));
+                Assert.That(result.Description, Is.EqualTo("Startup in progress"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyHealthyAfterMarkStarted()
+        {
+            this.startedService.MarkStarted();
+
+            var result = await this.check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Status, Is.EqualTo(HealthStatus.Healthy));
+                Assert.That(result.Description, Does.StartWith("Started since "));
+            });
+        }
+    }
+}

--- a/COMETwebapp/Dockerfile
+++ b/COMETwebapp/Dockerfile
@@ -29,6 +29,6 @@ RUN chown -R "$APP_UID" /app
 USER $APP_UID
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
- CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
+ CMD wget --no-verbose --tries=1 --spider http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["dotnet", "COMETwebapp.dll"]

--- a/COMETwebapp/Health/CometHasStartedService.cs
+++ b/COMETwebapp/Health/CometHasStartedService.cs
@@ -1,0 +1,80 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CometHasStartedService.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Health
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// Default <see cref="ICometHasStartedService"/> backed by a single in-process flag.
+    /// Registered as a singleton so all probe checks observe the same state.
+    /// </summary>
+    public class CometHasStartedService : ICometHasStartedService
+    {
+        /// <summary>
+        /// Backing field for <see cref="StartedAt"/>, stored as UTC ticks so that
+        /// <see cref="Interlocked.CompareExchange(ref long, long, long)"/> can be used to publish
+        /// the timestamp atomically.
+        /// </summary>
+        private long startedAtTicks;
+
+        /// <summary>
+        /// Backing field for <see cref="HasStarted"/>. Marked <c>volatile</c> so that probe
+        /// requests on other threads observe the flip immediately.
+        /// </summary>
+        private volatile bool hasStarted;
+
+        /// <summary>
+        /// Gets a value indicating whether startup bootstrap has completed.
+        /// </summary>
+        public bool HasStarted => this.hasStarted;
+
+        /// <summary>
+        /// Gets the timestamp at which <see cref="MarkStarted"/> was first called, or
+        /// <see cref="DateTime.MinValue"/> if startup has not yet completed.
+        /// </summary>
+        public DateTime StartedAt
+        {
+            get
+            {
+                var ticks = Interlocked.Read(ref this.startedAtTicks);
+                return ticks == 0 ? DateTime.MinValue : new DateTime(ticks, DateTimeKind.Utc);
+            }
+        }
+
+        /// <summary>
+        /// Marks the application as started. Idempotent — subsequent calls are ignored and the
+        /// original <see cref="StartedAt"/> timestamp is preserved.
+        /// </summary>
+        public void MarkStarted()
+        {
+            if (this.hasStarted)
+            {
+                return;
+            }
+
+            Interlocked.CompareExchange(ref this.startedAtTicks, DateTime.UtcNow.Ticks, 0);
+            this.hasStarted = true;
+        }
+    }
+}

--- a/COMETwebapp/Health/CometHasStartedService.cs
+++ b/COMETwebapp/Health/CometHasStartedService.cs
@@ -32,22 +32,16 @@ namespace COMETwebapp.Health
     public class CometHasStartedService : ICometHasStartedService
     {
         /// <summary>
-        /// Backing field for <see cref="StartedAt"/>, stored as UTC ticks so that
-        /// <see cref="Interlocked.CompareExchange(ref long, long, long)"/> can be used to publish
-        /// the timestamp atomically.
+        /// Single source of truth for both <see cref="HasStarted"/> and <see cref="StartedAt"/>,
+        /// stored as UTC ticks so that <see cref="Interlocked.CompareExchange(ref long, long, long)"/>
+        /// can publish the timestamp atomically and all reads go through <see cref="Interlocked.Read"/>.
         /// </summary>
         private long startedAtTicks;
 
         /// <summary>
-        /// Backing field for <see cref="HasStarted"/>. Marked <c>volatile</c> so that probe
-        /// requests on other threads observe the flip immediately.
-        /// </summary>
-        private volatile bool hasStarted;
-
-        /// <summary>
         /// Gets a value indicating whether startup bootstrap has completed.
         /// </summary>
-        public bool HasStarted => this.hasStarted;
+        public bool HasStarted => Interlocked.Read(ref this.startedAtTicks) != 0;
 
         /// <summary>
         /// Gets the timestamp at which <see cref="MarkStarted"/> was first called, or
@@ -68,13 +62,7 @@ namespace COMETwebapp.Health
         /// </summary>
         public void MarkStarted()
         {
-            if (this.hasStarted)
-            {
-                return;
-            }
-
             Interlocked.CompareExchange(ref this.startedAtTicks, DateTime.UtcNow.Ticks, 0);
-            this.hasStarted = true;
         }
     }
 }

--- a/COMETwebapp/Health/ICometHasStartedService.cs
+++ b/COMETwebapp/Health/ICometHasStartedService.cs
@@ -1,0 +1,50 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ICometHasStartedService.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Health
+{
+    using System;
+
+    /// <summary>
+    /// Tracks whether the CDP4-COMET WEB application has finished its startup bootstrap and is
+    /// ready to accept traffic. Backs the Startup and Readiness health probes.
+    /// </summary>
+    public interface ICometHasStartedService
+    {
+        /// <summary>
+        /// Gets a value indicating whether startup bootstrap has completed.
+        /// </summary>
+        bool HasStarted { get; }
+
+        /// <summary>
+        /// Gets the timestamp at which <see cref="MarkStarted"/> was first called, or
+        /// <see cref="DateTime.MinValue"/> if startup has not yet completed.
+        /// </summary>
+        DateTime StartedAt { get; }
+
+        /// <summary>
+        /// Marks the application as started. Idempotent — subsequent calls are ignored and the
+        /// original <see cref="StartedAt"/> timestamp is preserved.
+        /// </summary>
+        void MarkStarted();
+    }
+}

--- a/COMETwebapp/Health/StartupHealthCheck.cs
+++ b/COMETwebapp/Health/StartupHealthCheck.cs
@@ -1,0 +1,86 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="StartupHealthCheck.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Health
+{
+    using System.Globalization;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+    /// <summary>
+    /// Health check that reports Healthy once <see cref="ICometHasStartedService.HasStarted"/> is
+    /// <c>true</c>. Used by both the Startup and Readiness probe endpoints.
+    /// </summary>
+    public class StartupHealthCheck : IHealthCheck
+    {
+        /// <summary>
+        /// The (injected) <see cref="ICometHasStartedService"/> that holds the shared
+        /// startup-completion flag observed by this check.
+        /// </summary>
+        private readonly ICometHasStartedService cometHasStartedService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartupHealthCheck"/> class.
+        /// </summary>
+        /// <param name="cometHasStartedService">
+        /// The (injected) <see cref="ICometHasStartedService"/> whose <see cref="ICometHasStartedService.HasStarted"/>
+        /// flag determines the result of this health check.
+        /// </param>
+        public StartupHealthCheck(ICometHasStartedService cometHasStartedService)
+        {
+            this.cometHasStartedService = cometHasStartedService;
+        }
+
+        /// <summary>
+        /// Runs the health check, returning <see cref="HealthStatus.Healthy"/> once the
+        /// application has finished startup bootstrap and <see cref="HealthStatus.Unhealthy"/>
+        /// while startup is still in progress.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="HealthCheckContext"/> describing the registration. Not inspected here;
+        /// the same check answers both the Startup and Readiness probe endpoints.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> propagated by the host. Unused — the check is a
+        /// non-blocking flag read.
+        /// </param>
+        /// <returns>
+        /// A completed <see cref="Task{TResult}"/> wrapping a <see cref="HealthCheckResult"/>:
+        /// <see cref="HealthCheckResult.Healthy(string, System.Collections.Generic.IReadOnlyDictionary{string, object})"/>
+        /// once started (description includes the start timestamp in ISO 8601 format), otherwise
+        /// <see cref="HealthCheckResult.Unhealthy(string, System.Exception, System.Collections.Generic.IReadOnlyDictionary{string, object})"/>
+        /// with description <c>"Startup in progress"</c>.
+        /// </returns>
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            if (this.cometHasStartedService.HasStarted)
+            {
+                var description = string.Format(CultureInfo.InvariantCulture, "Started since {0:O}", this.cometHasStartedService.StartedAt);
+                return Task.FromResult(HealthCheckResult.Healthy(description));
+            }
+
+            return Task.FromResult(HealthCheckResult.Unhealthy("Startup in progress"));
+        }
+    }
+}

--- a/COMETwebapp/Model/Configuration/HealthConfig.cs
+++ b/COMETwebapp/Model/Configuration/HealthConfig.cs
@@ -1,0 +1,37 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="HealthConfig.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Model.Configuration
+{
+    /// <summary>
+    /// Configuration bound from the <c>Health</c> section of <c>appsettings.json</c> that controls
+    /// access to the Liveness, Startup and Readiness probe endpoints.
+    /// </summary>
+    public class HealthConfig
+    {
+        /// <summary>
+        /// Gets or sets the hostnames that are allowed to reach the health probe endpoints.
+        /// When empty, no host restriction is applied.
+        /// </summary>
+        public string[] AllowedHosts { get; set; } = [];
+    }
+}

--- a/COMETwebapp/Program.cs
+++ b/COMETwebapp/Program.cs
@@ -31,12 +31,17 @@ namespace COMETwebapp
     using ReactiveUI.Builder;
 
     using COMETwebapp.Extensions;
+    using COMETwebapp.Health;
     using COMETwebapp.Model;
+    using COMETwebapp.Model.Configuration;
     using COMETwebapp.Resources;
     using COMETwebapp.Shared;
     using COMETwebapp.Shared.SideBarEntry;
     using COMETwebapp.Shared.TopMenuEntry;
-    
+
+    using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+    using Microsoft.Extensions.Options;
+
     using Serilog;
 
     /// <summary>
@@ -72,6 +77,12 @@ namespace COMETwebapp
             builder.Services.RegisterViewModels();
             builder.Services.AddAntDesign();
 
+            builder.Services.Configure<HealthConfig>(builder.Configuration.GetSection("Health"));
+            builder.Services.AddSingleton<ICometHasStartedService, CometHasStartedService>();
+            builder.Services.AddSingleton<StartupHealthCheck>();
+            builder.Services.AddHealthChecks()
+                .AddCheck<StartupHealthCheck>("startup", tags: ["startup", "ready"]);
+
             builder.Host.UseSerilog((hostingContext, loggerConfiguration) =>
             {
                 loggerConfiguration.ReadFrom
@@ -98,7 +109,22 @@ namespace COMETwebapp
                 app.MapBlazorHub();
                 app.MapFallbackToPage("/_Host");
 
+                var healthConfig = app.Services.GetRequiredService<IOptions<HealthConfig>>().Value;
+
+                var liveness = app.MapHealthChecks("/healthz", new HealthCheckOptions { Predicate = _ => false });
+                var startup = app.MapHealthChecks("/health/startup", new HealthCheckOptions { Predicate = c => c.Tags.Contains("startup") });
+                var ready = app.MapHealthChecks("/ready", new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
+
+                if (healthConfig.AllowedHosts is { Length: > 0 })
+                {
+                    liveness.RequireHost(healthConfig.AllowedHosts);
+                    startup.RequireHost(healthConfig.AllowedHosts);
+                    ready.RequireHost(healthConfig.AllowedHosts);
+                }
+
                 await app.Services.InitializeCdp4CometCommonServices();
+
+                app.Services.GetRequiredService<ICometHasStartedService>().MarkStarted();
 
                 logger.LogInformation("CDP4-COMET WEB is running and accepting connections");
 

--- a/COMETwebapp/appsettings.json
+++ b/COMETwebapp/appsettings.json
@@ -20,6 +20,9 @@
       "ShowShortName": true
     }
   },
+  "Health": {
+    "AllowedHosts": []
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Wires Microsoft.Extensions.Diagnostics.HealthChecks into Program.cs and  exposes /healthz, /health/startup and /ready. Startup completion is  tracked via a new ICometHasStartedService, flipped after  InitializeCdp4CometCommonServices completes. HealthConfig.AllowedHosts optionally restricts probe endpoints by host. Dockerfile HEALTHCHECK now  targets /healthz instead of /.

<!-- Thanks for contributing to COMET-WEB! -->

