### PR TITLE
[Add] Multi-select Parameter Editor parameter-type filter

### DIFF
--- a/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiParameterTypeSelectorViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiParameterTypeSelectorViewModelTestFixture.cs
@@ -1,0 +1,129 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiParameterTypeSelectorViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MultiParameterTypeSelectorViewModelTestFixture
+    {
+        private MultiParameterTypeSelectorViewModel viewModel;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.viewModel = new MultiParameterTypeSelectorViewModel();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyInitialState()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableParameterTypes, Is.Empty);
+                Assert.That(this.viewModel.SelectedParameterTypes, Is.Empty);
+                Assert.That(this.viewModel.CurrentIteration, Is.Null);
+            });
+        }
+
+        [Test]
+        public void VerifyUpdatePropertiesAndFilter()
+        {
+            var booleanParameterType = new BooleanParameterType { Name = "bool", Iid = Guid.NewGuid() };
+            var textParameterType = new TextParameterType { Name = "text", Iid = Guid.NewGuid() };
+            var booleanParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = booleanParameterType };
+            var textParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = textParameterType };
+            var element = new ElementDefinition { Iid = Guid.NewGuid(), Parameter = { textParameter, booleanParameter } };
+            var iteration = new Iteration { Iid = Guid.NewGuid(), Element = { element } };
+            this.viewModel.CurrentIteration = iteration;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableParameterTypes.Count(), Is.EqualTo(2));
+                Assert.That(this.viewModel.SelectedParameterTypes, Is.Empty);
+            });
+
+            this.viewModel.SelectedParameterTypes = new List<ParameterType> { booleanParameterType, textParameterType };
+            this.viewModel.FilterAvailableParameterTypes(new List<Guid> { textParameterType.Iid });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableParameterTypes.Count(), Is.EqualTo(1));
+                Assert.That(this.viewModel.SelectedParameterTypes, Has.Count.EqualTo(1));
+                Assert.That(this.viewModel.SelectedParameterTypes.Single(), Is.SameAs(textParameterType));
+            });
+
+            this.viewModel.FilterAvailableParameterTypes(new List<Guid> { textParameterType.Iid, booleanParameterType.Iid });
+            this.viewModel.SelectedParameterTypes = new List<ParameterType> { booleanParameterType, textParameterType };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableParameterTypes.Count(), Is.EqualTo(2));
+                Assert.That(this.viewModel.SelectedParameterTypes.Count(), Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void VerifyExcludeAvailableParameterTypes()
+        {
+            var booleanParameterType = new BooleanParameterType { Name = "bool", Iid = Guid.NewGuid() };
+            var textParameterType = new TextParameterType { Name = "text", Iid = Guid.NewGuid() };
+            var booleanParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = booleanParameterType };
+            var textParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = textParameterType };
+            var element = new ElementDefinition { Iid = Guid.NewGuid(), Parameter = { textParameter, booleanParameter } };
+            var iteration = new Iteration { Iid = Guid.NewGuid(), Element = { element } };
+            this.viewModel.CurrentIteration = iteration;
+            this.viewModel.SelectedParameterTypes = new List<ParameterType> { booleanParameterType, textParameterType };
+
+            this.viewModel.ExcludeAvailableParameterTypes(new List<Guid> { booleanParameterType.Iid });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableParameterTypes.Count(), Is.EqualTo(1));
+                Assert.That(this.viewModel.AvailableParameterTypes.Single(), Is.SameAs(textParameterType));
+                Assert.That(this.viewModel.SelectedParameterTypes, Has.Count.EqualTo(1));
+                Assert.That(this.viewModel.SelectedParameterTypes.Single(), Is.SameAs(textParameterType));
+            });
+        }
+
+        [Test]
+        public void VerifySettingNullSelectionFallsBackToEmptyCollection()
+        {
+            this.viewModel.SelectedParameterTypes = null;
+            Assert.That(this.viewModel.SelectedParameterTypes, Is.Not.Null);
+            Assert.That(this.viewModel.SelectedParameterTypes, Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor
@@ -1,0 +1,40 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@using CDP4Common.SiteDirectoryData
+@inherits BelongsToIterationSelector<COMET.Web.Common.ViewModels.Components.Selectors.IMultiParameterTypeSelectorViewModel>
+
+@if (this.ViewModel.CurrentIteration != null)
+{
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
+
+    <DxTagBox Data="@(this.ViewModel.AvailableParameterTypes)"
+              TData="ParameterType"
+              TValue="ParameterType"
+              Values="@(this.ViewModel.SelectedParameterTypes)"
+              ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypes = values)"
+              FilteringMode="DataGridFilteringMode.Contains"
+              ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+              TextFieldName="@(nameof(ParameterType.Name))"
+              NullText="Select Parameter Types"/>
+}

--- a/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor.cs
@@ -1,0 +1,41 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiParameterTypeSelector.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select one or more <see cref="ParameterType" />s. Multi-select counterpart of
+    /// <see cref="ParameterTypeSelector" />.
+    /// </summary>
+    public partial class MultiParameterTypeSelector
+    {
+        /// <summary>
+        /// Gets or sets the heading rendered above the selector. Set to an empty string to hide the heading.
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Parameter Types:";
+    }
+}

--- a/COMET.Web.Common/Utilities/QueryKeys.cs
+++ b/COMET.Web.Common/Utilities/QueryKeys.cs
@@ -65,5 +65,11 @@ namespace COMET.Web.Common.Utilities
         /// The query key for the <see cref="ParameterType" />
         /// </summary>
         public const string ParameterKey = "parameter";
+
+        /// <summary>
+        /// The query key for a comma-delimited list of <see cref="ParameterType" /> short-form GUIDs, used by
+        /// multi-select filters such as the Parameter Editor's parameter-type filter.
+        /// </summary>
+        public const string ParametersKey = "parameters";
     }
 }

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiParameterTypeSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiParameterTypeSelectorViewModel.cs
@@ -1,0 +1,60 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IMultiParameterTypeSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// View Model that enables the user to select one or more <see cref="ParameterType" />s for use as a multi-select filter.
+    /// </summary>
+    public interface IMultiParameterTypeSelectorViewModel : IBelongsToIterationSelectorViewModel
+    {
+        /// <summary>
+        /// Gets or sets the currently selected <see cref="ParameterType" />s. An empty collection means
+        /// "no filter" — every <see cref="ParameterType" /> in <see cref="AvailableParameterTypes" /> matches.
+        /// </summary>
+        IEnumerable<ParameterType> SelectedParameterTypes { get; set; }
+
+        /// <summary>
+        /// Gets the collection of <see cref="ParameterType" />s that the user can pick from.
+        /// </summary>
+        IEnumerable<ParameterType> AvailableParameterTypes { get; }
+
+        /// <summary>
+        /// Restricts the <see cref="AvailableParameterTypes" /> collection to only the entries whose
+        /// <see cref="ParameterType.Iid" /> appears in <paramref name="parameterTypesId" />. Any entries in
+        /// <see cref="SelectedParameterTypes" /> that no longer appear in <see cref="AvailableParameterTypes" />
+        /// are dropped from the selection.
+        /// </summary>
+        /// <param name="parameterTypesId">A collection of <see cref="System.Guid" />s identifying the <see cref="ParameterType" />s to retain.</param>
+        void FilterAvailableParameterTypes(IEnumerable<Guid> parameterTypesId);
+
+        /// <summary>
+        /// Excludes the entries whose <see cref="ParameterType.Iid" /> appears in <paramref name="parameterTypesId" />
+        /// from <see cref="AvailableParameterTypes" />.
+        /// </summary>
+        /// <param name="parameterTypesId">A collection of <see cref="System.Guid" />s identifying the <see cref="ParameterType" />s to exclude.</param>
+        void ExcludeAvailableParameterTypes(IEnumerable<Guid> parameterTypesId);
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiParameterTypeSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiParameterTypeSelectorViewModel.cs
@@ -1,0 +1,125 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiParameterTypeSelectorViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Default <see cref="IMultiParameterTypeSelectorViewModel" /> implementation. Mirrors the single-select
+    /// <see cref="ParameterTypeSelectorViewModel" /> but exposes a collection-valued selection so callers can
+    /// filter on more than one <see cref="ParameterType" /> at a time.
+    /// </summary>
+    public class MultiParameterTypeSelectorViewModel : BelongsToIterationSelectorViewModel, IMultiParameterTypeSelectorViewModel
+    {
+        /// <summary>
+        /// The full set of <see cref="ParameterType" />s computed from the current <see cref="Iteration" />,
+        /// before any user-side filtering or exclusion is applied.
+        /// </summary>
+        private IEnumerable<ParameterType> allAvailableParameterTypes = new List<ParameterType>();
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedParameterTypes" />.
+        /// </summary>
+        private IEnumerable<ParameterType> selectedParameterTypes = new List<ParameterType>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="UpdateProperties" /> should restrict
+        /// <see cref="AvailableParameterTypes" /> to the <see cref="ParameterType" />s actually used by parameters
+        /// of the current <see cref="Iteration" /> (the default), or expose every <see cref="ParameterType" />
+        /// reachable through the available reference data libraries.
+        /// </summary>
+        public bool QueryOnlyUsedParameterTypes { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the currently selected <see cref="ParameterType" />s. An empty collection means
+        /// "no filter" — every <see cref="ParameterType" /> in <see cref="AvailableParameterTypes" /> matches.
+        /// </summary>
+        public IEnumerable<ParameterType> SelectedParameterTypes
+        {
+            get => this.selectedParameterTypes;
+            set => this.RaiseAndSetIfChanged(ref this.selectedParameterTypes, value ?? new List<ParameterType>());
+        }
+
+        /// <summary>
+        /// Gets the collection of <see cref="ParameterType" />s that the user can pick from.
+        /// </summary>
+        public IEnumerable<ParameterType> AvailableParameterTypes { get; private set; } = Enumerable.Empty<ParameterType>();
+
+        /// <summary>
+        /// Restricts the <see cref="AvailableParameterTypes" /> collection to only the entries whose
+        /// <see cref="ParameterType.Iid" /> appears in <paramref name="parameterTypesId" />. Any entries in
+        /// <see cref="SelectedParameterTypes" /> that no longer appear in <see cref="AvailableParameterTypes" />
+        /// are dropped from the selection.
+        /// </summary>
+        /// <param name="parameterTypesId">A collection of <see cref="Guid" />s identifying the <see cref="ParameterType" />s to retain.</param>
+        public void FilterAvailableParameterTypes(IEnumerable<Guid> parameterTypesId)
+        {
+            var allowedIds = parameterTypesId as ICollection<Guid> ?? parameterTypesId.ToList();
+            this.AvailableParameterTypes = this.allAvailableParameterTypes.Where(x => allowedIds.Any(p => p == x.Iid)).ToList();
+            this.SelectedParameterTypes = this.SelectedParameterTypes.Where(x => allowedIds.Contains(x.Iid)).ToList();
+        }
+
+        /// <summary>
+        /// Excludes the entries whose <see cref="ParameterType.Iid" /> appears in <paramref name="parameterTypesId" />
+        /// from <see cref="AvailableParameterTypes" />.
+        /// </summary>
+        /// <param name="parameterTypesId">A collection of <see cref="Guid" />s identifying the <see cref="ParameterType" />s to exclude.</param>
+        public void ExcludeAvailableParameterTypes(IEnumerable<Guid> parameterTypesId)
+        {
+            var excluded = parameterTypesId as ICollection<Guid> ?? parameterTypesId.ToList();
+            this.AvailableParameterTypes = this.allAvailableParameterTypes.Where(x => !excluded.Contains(x.Iid)).ToList();
+            this.SelectedParameterTypes = this.SelectedParameterTypes.Where(x => !excluded.Contains(x.Iid)).ToList();
+        }
+
+        /// <summary>
+        /// Recomputes <see cref="AvailableParameterTypes" /> from the current <see cref="Iteration" /> and
+        /// resets <see cref="SelectedParameterTypes" /> to the empty selection.
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            this.SelectedParameterTypes = new List<ParameterType>();
+            IEnumerable<ParameterType> parameterTypes;
+
+            if (this.QueryOnlyUsedParameterTypes)
+            {
+                parameterTypes = this.CurrentIteration?
+                    .QueryUsedParameterTypes()
+                    .OrderBy(x => x.Name) ?? Enumerable.Empty<ParameterType>();
+            }
+            else
+            {
+                var siteDirectory = this.CurrentIteration.IterationSetup.GetContainerOfType<SiteDirectory>();
+
+                parameterTypes = siteDirectory
+                    .AvailableReferenceDataLibraries()
+                    .SelectMany(x => x.ParameterType);
+            }
+
+            this.allAvailableParameterTypes = parameterTypes.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase).ToList();
+            this.AvailableParameterTypes = new List<ParameterType>(this.allAvailableParameterTypes);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
@@ -85,7 +85,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
 
             parameterEditorViewModel.Setup(x => x.ElementSelector).Returns(new ElementBaseSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.OptionSelector).Returns(new OptionSelectorViewModel());
-            parameterEditorViewModel.Setup(x => x.ParameterTypeSelector).Returns(new ParameterTypeSelectorViewModel());
+            parameterEditorViewModel.Setup(x => x.ParameterTypeSelector).Returns(new MultiParameterTypeSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.ParameterTableViewModel).Returns(new ParameterTableViewModel(sessionService.Object, this.messageBus));
 
             var configuration = new Mock<IConfigurationService>();
@@ -163,7 +163,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
         public void VerifyComponentUi()
         {
             var elementFilterCombo = this.renderedComponent.FindComponent<ElementBaseSelector>();
-            var parameterFilterCombo = this.renderedComponent.FindComponent<ParameterTypeSelector>();
+            var parameterFilterCombo = this.renderedComponent.FindComponent<MultiParameterTypeSelector>();
             var optionFilterCombo = this.renderedComponent.FindComponent<OptionSelector>();
 
             var isOwnedCheckbox = this.renderedComponent.FindComponent<DxCheckBox<bool>>();

--- a/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
@@ -129,7 +129,7 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
             var parameterEditorBodyViewModel = new Mock<IParameterEditorBodyViewModel>();
             parameterEditorBodyViewModel.Setup(x => x.OptionSelector).Returns(new Mock<IOptionSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.BatchParameterEditorViewModel).Returns(new Mock<IBatchParameterEditorViewModel>().Object);
-            parameterEditorBodyViewModel.Setup(x => x.ParameterTypeSelector).Returns(new Mock<IParameterTypeSelectorViewModel>().Object);
+            parameterEditorBodyViewModel.Setup(x => x.ParameterTypeSelector).Returns(new Mock<IMultiParameterTypeSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ElementSelector).Returns(new Mock<IElementBaseSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ParameterTableViewModel).Returns(parameterTableViewModel.Object);
 

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
@@ -240,13 +240,13 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
 
             this.viewModel.ElementSelector.SelectedElementBase = this.viewModel.ElementSelector.AvailableElements.First();
-            this.viewModel.ParameterTypeSelector.SelectedParameterType = this.viewModel.ParameterTypeSelector.AvailableParameterTypes.First();
+            this.viewModel.ParameterTypeSelector.SelectedParameterTypes = new List<ParameterType> { this.viewModel.ParameterTypeSelector.AvailableParameterTypes.First() };
             this.viewModel.OptionSelector.SelectedOption = this.viewModel.CurrentThing.Option.Last();
             this.viewModel.IsOwnedParameters = false;
 
             this.viewModel.ApplyFilters();
 
-            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<Option>(), It.IsAny<ElementBase>(), It.IsAny<ParameterType>(), It.IsAny<bool>()), Times.AtLeastOnce);
+            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<Option>(), It.IsAny<ElementBase>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<bool>()), Times.AtLeastOnce);
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
@@ -303,10 +303,21 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
             this.viewModel.ApplyFilters(this.iteration.DefaultOption, this.iteration.Element[^1], null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new ArrayParameterType() { Iid = Guid.NewGuid() }, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { new ArrayParameterType { Iid = Guid.NewGuid() } }, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(0));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, this.iteration.TopElement.Parameter[0].ParameterType, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { this.iteration.TopElement.Parameter[0].ParameterType }, true);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+
+            var multipleParameterTypes = new[]
+            {
+                this.iteration.TopElement.Parameter[0].ParameterType,
+                new ArrayParameterType { Iid = Guid.NewGuid() }
+            };
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, multipleParameterTypes, true);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, Array.Empty<ParameterType>(), true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
             this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, false);

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
@@ -34,7 +34,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </div>
             <div class="col">
                 <div class="width-fit-content">
-                    <ParameterTypeSelector ViewModel="this.ViewModel.ParameterTypeSelector"></ParameterTypeSelector>
+                    <MultiParameterTypeSelector ViewModel="this.ViewModel.ParameterTypeSelector"></MultiParameterTypeSelector>
                 </div>
             </div>
             <div class="col">

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -22,6 +22,8 @@
 
 namespace COMETwebapp.Components.ParameterEditor
 {
+    using CDP4Common.SiteDirectoryData;
+
     using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
@@ -46,7 +48,7 @@ namespace COMETwebapp.Components.ParameterEditor
 
             this.Disposables.Add(this.WhenAnyValue(
                     x => x.ViewModel.OptionSelector.SelectedOption,
-                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterType,
+                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterTypes,
                     x => x.ViewModel.ElementSelector.SelectedElementBase,
                     x => x.ViewModel.IsOwnedParameters)
                 .Subscribe(_ => this.UpdateUrl()));
@@ -65,9 +67,25 @@ namespace COMETwebapp.Components.ParameterEditor
                 this.ViewModel.OptionSelector.SelectedOption = this.ViewModel.OptionSelector.AvailableOptions.FirstOrDefault(x => x.Iid == option.FromShortGuid());
             }
 
-            if (parameters.TryGetValue(QueryKeys.ParameterKey, out var parameter))
+            if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                this.ViewModel.ParameterTypeSelector.SelectedParameterType = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes.FirstOrDefault(x => x.Iid == parameter.FromShortGuid());
+                var ids = parametersValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
+            }
+            else if (parameters.TryGetValue(QueryKeys.ParameterKey, out var parameter))
+            {
+                var match = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes.FirstOrDefault(x => x.Iid == parameter.FromShortGuid());
+
+                if (match != null)
+                {
+                    this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = new List<ParameterType> { match };
+                }
             }
         }
 
@@ -88,9 +106,11 @@ namespace COMETwebapp.Components.ParameterEditor
                 additionalParameters["option"] = this.ViewModel.OptionSelector.SelectedOption.Iid.ToShortGuid();
             }
 
-            if (this.ViewModel.ParameterTypeSelector.SelectedParameterType != null)
+            var selectedParameterTypes = this.ViewModel.ParameterTypeSelector.SelectedParameterTypes?.ToList() ?? new List<ParameterType>();
+
+            if (selectedParameterTypes.Count > 0)
             {
-                additionalParameters["parameter"] = this.ViewModel.ParameterTypeSelector.SelectedParameterType.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.ParametersKey] = string.Join(",", selectedParameterTypes.Select(x => x.Iid.ToShortGuid()));
             }
 
             if (this.ViewModel.IsOwnedParameters)

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
@@ -49,9 +49,10 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public IOptionSelectorViewModel OptionSelector { get; }
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter.
+        /// An empty selection means no parameter-type filtering is applied.
         /// </summary>
-        public IParameterTypeSelectorViewModel ParameterTypeSelector { get; }
+        public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; }
 
         /// <summary>
         /// Sets if only parameters owned by the active domain are shown

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
@@ -66,12 +66,16 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         void UpdateDomain(DomainOfExpertise currentDomain);
 
         /// <summary>
-        /// Apply filters based on <see cref="Option"/>, <see cref="ElementBase"/>, <see cref="ParameterType"/> and <see cref="DomainOfExpertise"/>
+        /// Apply filters based on <see cref="Option"/>, <see cref="ElementBase"/>, <see cref="ParameterType"/> and <see cref="DomainOfExpertise"/>.
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option"/></param>
-        /// <param name="selectedElementBase">The selected <see cref="ElementBase"/></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType"/></param>
-        /// <param name="isOwnedParameters">Value asserting that the only <see cref="Thing"/> owned by the current <see cref="DomainOfExpertise"/> should be visible</param>
-        void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, ParameterType selectedParameterType, bool isOwnedParameters);
+        /// <param name="selectedOption">The selected <see cref="Option"/>.</param>
+        /// <param name="selectedElementBase">The selected <see cref="ElementBase"/>.</param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of <see cref="ParameterType"/>s to filter on. <c>null</c> or an empty collection means
+        /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType"/> is not in the
+        /// collection are removed.
+        /// </param>
+        /// <param name="isOwnedParameters">Value asserting that only <see cref="Thing"/>s owned by the current <see cref="DomainOfExpertise"/> should be visible.</param>
+        void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, bool isOwnedParameters);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
@@ -92,9 +92,10 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public IOptionSelectorViewModel OptionSelector { get; private set; } = new OptionSelectorViewModel(false);
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter.
+        /// An empty selection means no parameter-type filtering is applied.
         /// </summary>
-        public IParameterTypeSelectorViewModel ParameterTypeSelector { get; private set; } = new ParameterTypeSelectorViewModel();
+        public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; private set; } = new MultiParameterTypeSelectorViewModel();
 
         /// <summary>
         /// Sets if only parameters owned by the active domain are shown
@@ -123,7 +124,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             if (this.CurrentThing != null)
             {
                 this.ParameterTableViewModel.ApplyFilters(this.OptionSelector.SelectedOption, this.ElementSelector.SelectedElementBase,
-                    this.ParameterTypeSelector.SelectedParameterType, this.IsOwnedParameters);
+                    this.ParameterTypeSelector.SelectedParameterTypes, this.IsOwnedParameters);
             }
         }
 

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -65,9 +65,10 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private Option currentOption;
 
         /// <summary>
-        /// The currently selected <see cref="ParameterType" />
+        /// The set of <see cref="ParameterType.Iid" />s currently selected as a multi-select filter. Empty
+        /// means "no filter".
         /// </summary>
-        private ParameterType currentParameterType;
+        private HashSet<Guid> currentParameterTypeIds = new();
 
         /// <summary>
         /// Gets or sets the <see cref="ParameterBaseRowViewModel" /> for this <see cref="ParameterTableViewModel" />
@@ -141,7 +142,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             this.domainOfExpertise = currentDomain;
             this.currentOption = selectedOption;
             this.currentElementBase = null;
-            this.currentParameterType = null;
+            this.currentParameterTypeIds = new HashSet<Guid>();
             this.Rows.Clear();
 
             if (this.iteration != null)
@@ -161,17 +162,21 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         }
 
         /// <summary>
-        /// Apply filters based on <see cref="Option" />, <see cref="ElementBase" />, <see cref="ParameterType" /> and
-        /// <see cref="DomainOfExpertise" />
+        /// Apply filters based on <see cref="Option" />, <see cref="ElementBase" />, a multi-select set of
+        /// <see cref="ParameterType" />s and <see cref="DomainOfExpertise" />.
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedElementBase">The selected <see cref="ElementBase" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
-        /// <param name="isOwnedParameters">
-        /// Value asserting that the only <see cref="Thing" /> owned by the current
-        /// <see cref="DomainOfExpertise" /> should be visible
+        /// <param name="selectedOption">The selected <see cref="Option" />.</param>
+        /// <param name="selectedElementBase">The selected <see cref="ElementBase" />.</param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of <see cref="ParameterType" />s to filter on. <c>null</c> or an empty collection means
+        /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType" /> is not in the
+        /// collection are removed.
         /// </param>
-        public void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, ParameterType selectedParameterType, bool isOwnedParameters)
+        /// <param name="isOwnedParameters">
+        /// Value asserting that only <see cref="Thing" />s owned by the current <see cref="DomainOfExpertise" />
+        /// should be visible.
+        /// </param>
+        public void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, bool isOwnedParameters)
         {
             if (this.iteration == null)
             {
@@ -180,7 +185,9 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
 
             this.currentOption = selectedOption;
             this.currentElementBase = selectedElementBase;
-            this.currentParameterType = selectedParameterType;
+            this.currentParameterTypeIds = selectedParameterTypes == null
+                ? new HashSet<Guid>()
+                : new HashSet<Guid>(selectedParameterTypes.Select(x => x.Iid));
             this.ownedParameters = isOwnedParameters;
 
             var rows = this.CreateRowsBasedOnFilters(this.iteration.QueryParameterAndOverrideBases(selectedOption).ToList());
@@ -305,9 +312,9 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 ApplyElementBaseFilter(parameters, this.currentElementBase.Iid);
             }
 
-            if (this.currentParameterType != null)
+            if (this.currentParameterTypeIds.Count > 0)
             {
-                ApplyParameterTypeFilter(parameters, this.currentParameterType.Iid);
+                ApplyParameterTypeFilter(parameters, this.currentParameterTypeIds);
             }
 
             return this.CreateParameterBaseRowViewModels(parameters, this.currentOption.Iid).DistinctBy(x => x.ValueSetId);
@@ -331,13 +338,14 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         }
 
         /// <summary>
-        /// Apply a filtering base on <see cref="ParameterType" />
+        /// Apply a filtering pass that retains only parameters whose <see cref="ParameterType" /> identifier is in
+        /// <paramref name="parameterTypeIds" />. Mutates <paramref name="parameters" /> in place.
         /// </summary>
-        /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter</param>
-        /// <param name="parameterTypeId">The <see cref="Guid" /> of the <see cref="ParameterType" /> for filtering</param>
-        private static void ApplyParameterTypeFilter(List<ParameterOrOverrideBase> parameters, Guid parameterTypeId)
+        /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter.</param>
+        /// <param name="parameterTypeIds">The <see cref="ISet{T}" /> of allowed <see cref="ParameterType.Iid" /> values.</param>
+        private static void ApplyParameterTypeFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> parameterTypeIds)
         {
-            parameters.RemoveAll(x => x.ParameterType.Iid != parameterTypeId);
+            parameters.RemoveAll(x => !parameterTypeIds.Contains(x.ParameterType.Iid));
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Introduces MultiParameterTypeSelector + IMultiParameterTypeSelectorViewModel
  in COMET.Web.Common (DxTagBox-based) and switches the Parameter Editor's
  ParameterTypeSelector to it. The existing single-select ParameterTypeSelector
  is untouched so other consumers (ModelDashboard, BatchParameterEditor,
  AddParameter, SubscriptionDashboard) keep working.

  ParameterTableViewModel.ApplyFilters now accepts IEnumerable<ParameterType>;
  empty or null means no parameter-type filter. URL state migrates from a
  single ?parameter=<id> to a comma-delimited ?parameters=<id,id,...>; the
  legacy single-value key is still parsed as a fallback.

<!-- Thanks for contributing to COMET-WEB! -->

