### PR TITLE
[Add] Definitions tab to ParameterType editor; fixes #745

### DIFF
--- a/COMETwebapp.Tests/Components/Common/DefinitionsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Common/DefinitionsTableTestFixture.cs
@@ -1,0 +1,111 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DefinitionsTableTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Common
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Common;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DevExpress.Blazor;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DefinitionsTableTestFixture
+    {
+        private BunitContext context;
+        private IRenderedComponent<DefinitionsTable> renderer;
+        private TextParameterType parameterType;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.parameterType = new TextParameterType
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "txt",
+                Name = "text"
+            };
+
+            this.parameterType.Definition.Add(new Definition
+            {
+                Iid = Guid.NewGuid(),
+                Content = "Existing definition",
+                LanguageCode = "en-GB"
+            });
+
+            this.renderer = this.context.Render<DefinitionsTable>(parameters => parameters
+                .Add(p => p.Thing, this.parameterType));
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public void VerifyExistingDefinitionIsRendered()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.Thing, Is.SameAs(this.parameterType));
+                Assert.That(this.renderer.Markup, Does.Contain("Existing definition"));
+                Assert.That(this.renderer.Markup, Does.Contain("en-GB"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyAddDefinition()
+        {
+            var addButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
+            await this.renderer.InvokeAsync(addButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.ShouldCreate, Is.True);
+                Assert.That(this.renderer.Instance.Item, Is.Not.Null);
+                Assert.That(this.renderer.Instance.Item.LanguageCode, Is.EqualTo("en-GB"));
+                Assert.That(this.parameterType.Definition, Has.Count.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task VerifyRemoveDefinition()
+        {
+            var removeButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "removeDefinitionButton");
+            await this.renderer.InvokeAsync(removeButton.Instance.Click.InvokeAsync);
+
+            Assert.That(this.parameterType.Definition, Is.Empty);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
@@ -129,5 +129,13 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
             await this.renderer.InvokeAsync(editForm.Instance.OnValidSubmit.InvokeAsync);
             this.viewModel.Verify(x => x.CreateOrEditParameterType(true), Times.Once);
         }
+
+        [Test]
+        public void VerifyDefinitionsTabIsRendered()
+        {
+            // the Definitions tab caption is exposed for every parameter type — the inner DefinitionsTable
+            // body is rendered lazily by DevExpress when the tab becomes active, so we only assert the caption.
+            Assert.That(this.renderer.Markup, Does.Contain("Definitions"));
+        }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -22,10 +22,15 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
 {
+    using System.Collections.Concurrent;
+
+    using CDP4Common;
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using COMET.Web.Common.Model;
@@ -166,6 +171,110 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             this.sessionService.Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>())).Throws(new Exception("Error"));
             await this.viewModel.CreateOrEditParameterType(false);
             this.loggerMock.Verify(LogLevel.Error, x => !string.IsNullOrWhiteSpace(x.ToString()), Times.Once());
+        }
+
+        [Test]
+        public async Task VerifyDefinitionsArePersistedAlongsideTheParameterType()
+        {
+            this.viewModel.InitializeViewModel();
+
+            var existingDefinition = new Definition { Iid = Guid.NewGuid(), Content = "Existing", LanguageCode = "en-GB" };
+            var newDefinition = new Definition { Iid = Guid.NewGuid(), Content = "New", LanguageCode = "fr-FR" };
+
+            this.viewModel.CurrentThing = new TextParameterType
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "withDefinitions",
+                Name = "with definitions",
+                Definition = { existingDefinition, newDefinition }
+            };
+
+            List<Thing> capturedThings = null;
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
+                .Returns(Task.FromResult(new Result()));
+
+            await this.viewModel.CreateOrEditParameterType(true);
+
+            Assert.That(capturedThings, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(capturedThings, Does.Contain(existingDefinition));
+                Assert.That(capturedThings, Does.Contain(newDefinition));
+                Assert.That(capturedThings, Does.Contain(this.viewModel.CurrentThing));
+            });
+        }
+
+        [Test]
+        public async Task VerifyEditingExistingParameterTypeWithNewDefinitionProducesCorrectOperations()
+        {
+            // Mirrors the production edit-existing flow: the cached parameter type is deep-cloned, a new
+            // definition is appended in memory, then the resulting clones are fed through a real
+            // ThingTransaction so we can assert the produced operation container matches what the server
+            // expects (a Create for the new definition, an Update for the parameter type whose Definition
+            // list now references the new Iid).
+            this.viewModel.InitializeViewModel();
+
+            var cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var siteDir = new SiteDirectory(Guid.NewGuid(), cache, null) { ShortName = "siteDir" };
+            cache.TryAdd(siteDir.CacheKey, new Lazy<Thing>(() => siteDir));
+
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), cache, null) { ShortName = "cached-rdl" };
+            siteDir.SiteReferenceDataLibrary.Add(rdl);
+            cache.TryAdd(rdl.CacheKey, new Lazy<Thing>(() => rdl));
+
+            var cachedParameterType = new TextParameterType(Guid.NewGuid(), cache, null) { ShortName = "cached", Name = "cached" };
+            rdl.ParameterType.Add(cachedParameterType);
+            cache.TryAdd(cachedParameterType.CacheKey, new Lazy<Thing>(() => cachedParameterType));
+
+            var cachedDefinition = new Definition(Guid.NewGuid(), cache, null) { Content = "cached", LanguageCode = "en-GB" };
+            cachedParameterType.Definition.Add(cachedDefinition);
+            cache.TryAdd(cachedDefinition.CacheKey, new Lazy<Thing>(() => cachedDefinition));
+
+            var parameterTypeClone = cachedParameterType.Clone(true);
+            var newDefinition = new Definition { Iid = Guid.NewGuid(), Content = "new", LanguageCode = "fr-FR" };
+            parameterTypeClone.Definition.Add(newDefinition);
+
+            this.viewModel.CurrentThing = parameterTypeClone;
+            this.viewModel.SelectedReferenceDataLibrary = rdl;
+
+            List<Thing> capturedThings = null;
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
+                .Returns(Task.FromResult(new Result()));
+
+            await this.viewModel.CreateOrEditParameterType(false);
+
+            Assert.That(capturedThings, Is.Not.Null);
+
+            var rdlClone = rdl.Clone(false);
+            var transaction = new ThingTransaction(TransactionContextResolver.ResolveContext(rdlClone));
+
+            foreach (var thing in capturedThings)
+            {
+                transaction.CreateOrUpdate(thing);
+            }
+
+            var operationContainer = transaction.FinalizeTransaction();
+            var operations = operationContainer.Operations.ToList();
+
+            var createOps = operations.Where(o => o.OperationKind == CDP4DalCommon.Protocol.Operations.OperationKind.Create).ToList();
+            var updateOps = operations.Where(o => o.OperationKind == CDP4DalCommon.Protocol.Operations.OperationKind.Update).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(createOps, Has.Count.EqualTo(1), "exactly one Create op should be produced for the new Definition");
+                Assert.That(createOps[0].ModifiedThing.Iid, Is.EqualTo(newDefinition.Iid));
+                Assert.That(updateOps.Any(o => o.ModifiedThing.Iid == parameterTypeClone.Iid), Is.True, "the parameter type must be in an Update op");
+
+                var ptDto = (CDP4Common.DTO.TextParameterType)updateOps.Single(o => o.ModifiedThing.Iid == parameterTypeClone.Iid).ModifiedThing;
+                Assert.That(ptDto.Definition, Does.Contain(newDefinition.Iid), "the updated parameter type DTO must reference the new Definition Iid");
+                Assert.That(ptDto.Definition, Does.Contain(cachedDefinition.Iid), "the updated parameter type DTO must keep the existing Definition Iid");
+            });
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -194,7 +194,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             this.sessionService
                 .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
                 .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
-                .Returns(Task.FromResult(new Result()));
+                .ReturnsAsync(new Result());
 
             await this.viewModel.CreateOrEditParameterType(true);
 
@@ -245,7 +245,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
             this.sessionService
                 .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
                 .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
-                .Returns(Task.FromResult(new Result()));
+                .ReturnsAsync(new Result());
 
             await this.viewModel.CreateOrEditParameterType(false);
 

--- a/COMETwebapp/Components/Common/DefinitionsTable.razor
+++ b/COMETwebapp/Components/Common/DefinitionsTable.razor
@@ -1,0 +1,64 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+@inherits DisposableComponent
+
+<DxGrid @ref="this.Grid"
+        Data="this.GetRows()"
+        EditMode="GridEditMode.PopupEditForm"
+        PopupEditFormHeaderText="Definition"
+        EditModelSaving="@(() => this.OnEditItemSaving())"
+        CustomizeEditModel="this.CustomizeEditDefinition">
+    <Columns>
+        <DxGridDataColumn FieldName="@nameof(DefinitionRowViewModel.LanguageCode)" Caption="Language" MinWidth="80" />
+        <DxGridDataColumn FieldName="@nameof(DefinitionRowViewModel.Content)" Caption="Content" MinWidth="200" />
+        <DxGridCommandColumn Width="100px" EditButtonVisible="false">
+            <HeaderTemplate>
+                <DxButton Id="addDefinitionButton" Text="Add" IconCssClass="oi oi-plus" Click="() => this.Grid.StartEditNewRowAsync()"/>
+            </HeaderTemplate>
+            <CellDisplayTemplate>
+                @{
+                    var row = (DefinitionRowViewModel)context.DataItem;
+
+                    <DxButton Id="editDefinitionButton"
+                              IconCssClass="oi oi-pencil"
+                              Click="@(() => this.Grid.StartEditRowAsync(context.VisibleIndex))"/>
+
+                    <DxButton Id="removeDefinitionButton"
+                              IconCssClass="oi oi-trash"
+                              Click="() => this.RemoveItem(row)"/>
+                }
+            </CellDisplayTemplate>
+        </DxGridCommandColumn>
+    </Columns>
+
+    <EditFormTemplate Context="EditFormContext">
+        <FluentValidationValidator/>
+        <DxFormLayout CssClass="w-100">
+            <DxFormLayoutItem Caption="Language Code:" ColSpanMd="10">
+                <DxTextBox Id="definitionLanguageCodeInput" @bind-Text="@(this.Item.LanguageCode)"/>
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Content:" ColSpanMd="10">
+                <DxMemo Id="definitionContentInput" @bind-Text="@(this.Item.Content)" Rows="5"/>
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        <div class="pt-3"></div>
+        <ValidationSummary/>
+    </EditFormTemplate>
+</DxGrid>

--- a/COMETwebapp/Components/Common/DefinitionsTable.razor.cs
+++ b/COMETwebapp/Components/Common/DefinitionsTable.razor.cs
@@ -1,0 +1,129 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DefinitionsTable.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Common
+{
+    using CDP4Common.CommonData;
+
+    using COMET.Web.Common.Components;
+
+    using COMETwebapp.Services.RowViewModelFactoryService;
+    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Inline grid that manages the <see cref="DefinedThing.Definition" /> collection of a parent
+    /// <see cref="DefinedThing" />. Stages additions, edits and removals on the in-memory parent so they are committed
+    /// together with the parent when the surrounding form is saved.
+    /// </summary>
+    public partial class DefinitionsTable : DisposableComponent
+    {
+        /// <summary>
+        /// The parent <see cref="DefinedThing" /> whose <see cref="DefinedThing.Definition" /> collection is being edited.
+        /// </summary>
+        [Parameter]
+        public DefinedThing Thing { get; set; }
+
+        /// <summary>
+        /// Notifies the surrounding form that the parent <see cref="DefinedThing" />'s definition collection has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<DefinedThing> ThingChanged { get; set; }
+
+        /// <summary>
+        /// True when the popup edit form is creating a new <see cref="Definition" /> rather than editing an existing one.
+        /// </summary>
+        public bool ShouldCreate { get; private set; }
+
+        /// <summary>
+        /// The <see cref="Definition" /> currently bound to the popup edit form.
+        /// </summary>
+        public Definition Item { get; private set; }
+
+        /// <summary>
+        /// The <see cref="DxGrid" /> hosting the table — kept so that the toolbar buttons can drive its edit state.
+        /// </summary>
+        public IGrid Grid { get; private set; }
+
+        /// <summary>
+        /// Builds the row view models displayed by the grid from the parent's current <see cref="Definition" /> list.
+        /// </summary>
+        /// <returns>Rows for the grid, ordered by language code.</returns>
+        protected List<DefinitionRowViewModel> GetRows()
+        {
+            return this.Thing?.Definition
+                .Select(x => (DefinitionRowViewModel)RowViewModelFactory.CreateRow(x))
+                .OrderBy(x => x.LanguageCode, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Adds a freshly-created <see cref="Definition" /> when the grid asks for the popup edit form's bound item, or
+        /// hands it a clone of the selected row's underlying <see cref="Definition" /> when editing an existing one.
+        /// </summary>
+        /// <param name="e">The grid customize-edit-model event.</param>
+        protected void CustomizeEditDefinition(GridCustomizeEditModelEventArgs e)
+        {
+            var dataItem = (DefinitionRowViewModel)e.DataItem;
+            this.ShouldCreate = e.IsNew;
+
+            this.Item = dataItem == null
+                ? new Definition { Iid = Guid.NewGuid(), LanguageCode = "en-GB" }
+                : dataItem.Thing.Clone(true);
+
+            e.EditModel = this.Item;
+        }
+
+        /// <summary>
+        /// Persists the popup edit form's <see cref="Item" /> back onto the parent's <see cref="Definition" /> collection,
+        /// either appending it (create) or replacing the matching existing entry in place (edit).
+        /// </summary>
+        protected void OnEditItemSaving()
+        {
+            if (this.ShouldCreate)
+            {
+                this.Thing.Definition.Add(this.Item);
+            }
+            else
+            {
+                var indexToUpdate = this.Thing.Definition.FindIndex(x => x.Iid == this.Item.Iid);
+                this.Thing.Definition[indexToUpdate] = this.Item;
+            }
+
+            this.ThingChanged.InvokeAsync(this.Thing);
+        }
+
+        /// <summary>
+        /// Removes the underlying <see cref="Definition" /> from the parent's collection.
+        /// </summary>
+        /// <param name="row">The row whose <see cref="Definition" /> should be removed.</param>
+        /// <returns>A <see cref="Task" />.</returns>
+        protected async Task RemoveItem(DefinitionRowViewModel row)
+        {
+            this.Thing.Definition.Remove(row.Thing);
+            await this.ThingChanged.InvokeAsync(this.Thing);
+        }
+    }
+}

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -179,6 +179,10 @@ Copyright (c) 2023-2026 Starion Group S.A.
                                               QuantityKindParameterTypes="@(this.ViewModel.ExistingParameterTypes.OfType<QuantityKind>())"/>
                 </DxFormLayoutTabPage>
             }
+
+            <DxFormLayoutTabPage Caption="Definitions">
+                <DefinitionsTable Thing="@(this.ViewModel.CurrentThing)"/>
+            </DxFormLayoutTabPage>
         </DxFormLayoutTabPages>
     </DxFormLayout>
     <FormButtons SaveButtonEnabled="@(this.IsSaveButtonEnabled(editFormContext))"

--- a/COMETwebapp/Health/CometHasStartedService.cs
+++ b/COMETwebapp/Health/CometHasStartedService.cs
@@ -34,7 +34,7 @@ namespace COMETwebapp.Health
         /// <summary>
         /// Single source of truth for both <see cref="HasStarted"/> and <see cref="StartedAt"/>,
         /// stored as UTC ticks so that <see cref="Interlocked.CompareExchange(ref long, long, long)"/>
-        /// can publish the timestamp atomically and all reads go through <see cref="Interlocked.Read"/>.
+        /// can publish the timestamp atomically and all reads go through <see cref="Interlocked.Read(ref readonly long)"/>.
         /// </summary>
         private long startedAtTicks;
 

--- a/COMETwebapp/Services/RowViewModelFactoryService/RowViewModelFactory.cs
+++ b/COMETwebapp/Services/RowViewModelFactoryService/RowViewModelFactory.cs
@@ -47,6 +47,7 @@ namespace COMETwebapp.Services.RowViewModelFactoryService
             {
                 // Reference data rows
                 Category castThing => new CategoryRowViewModel(castThing),
+                Definition castThing => new DefinitionRowViewModel(castThing),
                 DependentParameterTypeAssignment castThing => new DependentParameterTypeRowViewModel(castThing),
                 EnumerationValueDefinition castThing => new EnumerationValueDefinitionRowViewModel(castThing),
                 IndependentParameterTypeAssignment castThing => new IndependentParameterTypeRowViewModel(castThing),

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -176,6 +176,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
                         break;
                 }
 
+                thingsToCreate.AddRange(this.CurrentThing.Definition);
                 thingsToCreate.Add(this.CurrentThing);
 
                 await this.SessionService.CreateOrUpdateThingsWithNotification(rdlClone, thingsToCreate, this.GetNotificationDescription(shouldCreate));

--- a/COMETwebapp/ViewModels/Components/ReferenceData/Rows/DefinitionRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/Rows/DefinitionRowViewModel.cs
@@ -1,0 +1,54 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DefinitionRowViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ReferenceData.Rows
+{
+    using CDP4Common.CommonData;
+
+    using COMETwebapp.ViewModels.Components.Common.Rows;
+
+    /// <summary>
+    /// Row View Model for a <see cref="Definition" /> shown in a <see cref="DefinedThing" />'s definitions grid.
+    /// </summary>
+    public class DefinitionRowViewModel : BaseDataItemRowViewModel<Definition>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefinitionRowViewModel" /> class.
+        /// </summary>
+        /// <param name="definition">The associated <see cref="Definition" /></param>
+        public DefinitionRowViewModel(Definition definition) : base(definition)
+        {
+            this.Content = definition.Content;
+            this.LanguageCode = definition.LanguageCode;
+        }
+
+        /// <summary>
+        /// The textual content of the <see cref="Definition" />.
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// The ISO language code of the <see cref="Definition" /> (for example <c>en-GB</c>).
+        /// </summary>
+        public string LanguageCode { get; set; }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds an integration test that drives ParameterTypeTableViewModel.CreateOrEditParameterType through a real ThingTransaction (no mocks), asserting one Create op for the new Definition and an Update op whose TextParameterType DTO references both the existing and new Definition Iids. Documents and locks in the persistence contract.

<!-- Thanks for contributing to COMET-WEB! -->

