### PR TITLE
[Add] Categories tab to ParameterType editor; fixes #747

### DIFF
--- a/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
@@ -64,6 +64,7 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
             this.viewModel = new Mock<IParameterTypeTableViewModel>();
             this.viewModel.Setup(x => x.ParameterTypes).Returns([new ClassKindWrapper(ClassKind.BooleanParameterType)]);
             this.viewModel.Setup(x => x.CurrentThing).Returns(new BooleanParameterType());
+            this.viewModel.Setup(x => x.Categories).Returns([]);
 
             this.renderer = this.context.Render<ParameterTypeForm>(parameters =>
             {
@@ -136,6 +137,12 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
             // the Definitions tab caption is exposed for every parameter type — the inner DefinitionsTable
             // body is rendered lazily by DevExpress when the tab becomes active, so we only assert the caption.
             Assert.That(this.renderer.Markup, Does.Contain("Definitions"));
+        }
+
+        [Test]
+        public void VerifyCategoriesTabIsRendered()
+        {
+            Assert.That(this.renderer.Markup, Does.Contain("Categories"));
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -95,6 +95,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                     {
                         Unit = new SimpleUnit()
                     }
+                },
+                DefinedCategory =
+                {
+                    new Category { ShortName = "ptCat", Name = "PT category", PermissibleClass = { ClassKind.BooleanParameterType, ClassKind.TextParameterType } },
+                    new Category { ShortName = "elCat", Name = "Element category", PermissibleClass = { ClassKind.ElementDefinition } },
+                    new Category { ShortName = "anyPtCat", Name = "Any PT category", PermissibleClass = { ClassKind.ParameterType } }
                 }
             };
 
@@ -204,6 +210,74 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Assert.That(capturedThings, Does.Contain(existingDefinition));
                 Assert.That(capturedThings, Does.Contain(newDefinition));
                 Assert.That(capturedThings, Does.Contain(this.viewModel.CurrentThing));
+            });
+        }
+
+        [Test]
+        public void VerifyCategoriesAreFilteredByPermissibleClass()
+        {
+            this.viewModel.InitializeViewModel();
+
+            // CurrentThing defaults to BooleanParameterType.
+            // ptCat (PermissibleClass includes BooleanParameterType, literal match) — eligible.
+            // anyPtCat (PermissibleClass = ParameterType, superclass match via the inheritance chain) — eligible.
+            // elCat (ElementDefinition only, unrelated branch) — excluded.
+            Assert.That(this.viewModel.Categories.Select(c => c.ShortName), Is.EquivalentTo(new[] { "ptCat", "anyPtCat" }));
+        }
+
+        [Test]
+        public void VerifyCategoriesIncludesPermissibleClassesAcrossInheritanceChain()
+        {
+            this.viewModel.InitializeViewModel();
+
+            this.viewModel.CurrentThing = new SimpleQuantityKind
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "sqk",
+                Name = "simple quantity kind"
+            };
+
+            var eligibleShortNames = this.viewModel.Categories.Select(c => c.ShortName).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eligibleShortNames, Does.Contain("anyPtCat"),
+                    "A Category whose PermissibleClass is the ParameterType superclass must be eligible for SimpleQuantityKind via the inheritance chain.");
+                Assert.That(eligibleShortNames, Does.Not.Contain("ptCat"),
+                    "ptCat lists only Boolean/Text leaves and must not match SimpleQuantityKind.");
+                Assert.That(eligibleShortNames, Does.Not.Contain("elCat"),
+                    "elCat targets ElementDefinition and must remain excluded.");
+            });
+        }
+
+        [Test]
+        public async Task VerifyCategoriesArePersistedAlongsideTheParameterType()
+        {
+            this.viewModel.InitializeViewModel();
+
+            var category = this.siteDirectory.SiteReferenceDataLibrary.First().DefinedCategory.First(c => c.ShortName == "ptCat");
+
+            this.viewModel.CurrentThing = new TextParameterType
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "withCategory",
+                Name = "with category",
+                Category = { category }
+            };
+
+            List<Thing> capturedThings = null;
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<ReferenceDataLibrary>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
+                .ReturnsAsync(new Result());
+
+            await this.viewModel.CreateOrEditParameterType(true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(capturedThings, Does.Contain(this.viewModel.CurrentThing));
+                Assert.That(((TextParameterType)this.viewModel.CurrentThing).Category, Does.Contain(category));
             });
         }
 

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -180,6 +180,27 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 </DxFormLayoutTabPage>
             }
 
+            <DxFormLayoutTabPage Caption="Categories">
+                <DxGrid Data="@(this.ViewModel.Categories
+                                  .OrderByDescending(c => this.ViewModel.CurrentThing.Category.Contains(c))
+                                  .ThenBy(c => c.Name))"
+                        ShowAllRows="true"
+                        FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
+                        SelectionMode="GridSelectionMode.Multiple"
+                        SelectAllCheckboxMode="GridSelectAllCheckboxMode.AllPages"
+                        KeyFieldName="@nameof(Category.Iid)"
+                        SelectedDataItems="@(this.ViewModel.CurrentThing.Category.Cast<object>().ToArray())"
+                        SelectedDataItemsChanged="@(items => this.ViewModel.CurrentThing.Category = items.Cast<Category>().ToList())"
+                        CssClass="cw-480">
+                    <Columns>
+                        <DxGridSelectionColumn Width="60px" AllowSelectAll="true"/>
+                        <DxGridDataColumn FieldName="@nameof(Category.Name)" AllowSort="true"/>
+                        <DxGridDataColumn FieldName="@nameof(Category.ShortName)" AllowSort="true"/>
+                        <DxGridDataColumn FieldName="@nameof(Category.IsDeprecated)" Caption="Deprecated" AllowSort="true"/>
+                    </Columns>
+                </DxGrid>
+            </DxFormLayoutTabPage>
+
             <DxFormLayoutTabPage Caption="Definitions">
                 <DefinitionsTable Thing="@(this.ViewModel.CurrentThing)"/>
             </DxFormLayoutTabPage>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
@@ -64,6 +64,12 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         IEnumerable<MeasurementScaleRowViewModel> MeasurementScales { get; }
 
         /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="ParameterType" />, drawn from the chain of
+        /// <see cref="ReferenceDataLibrary" />s and filtered by <see cref="Category.PermissibleClass" />.
+        /// </summary>
+        IEnumerable<Category> Categories { get; }
+
+        /// <summary>
         /// Creates or edits a <see cref="ParameterType" />
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="ParameterType" /> should be created</param>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -23,6 +23,7 @@
 namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
 {
     using CDP4Common.CommonData;
+    using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal;
@@ -88,6 +89,12 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// Gets the possible available <see cref="MeasurementScale" />s
         /// </summary>
         public IEnumerable<MeasurementScaleRowViewModel> MeasurementScales => this.GetPossibleMeasurementScales();
+
+        /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="ParameterType" />, drawn from the chain of
+        /// <see cref="ReferenceDataLibrary" />s and filtered by <see cref="Category.PermissibleClass" />.
+        /// </summary>
+        public IEnumerable<Category> Categories => this.GetPossibleCategories();
 
         /// <summary>
         /// Gets the available parameter types <see cref="ClassKindWrapper" />s
@@ -277,6 +284,31 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
 
             var filteredMeasurementScales = allMeasurementScales.Where(x => !specializedQuantity.General.AllPossibleScale.Contains(x.Thing));
             return filteredMeasurementScales;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="ParameterType" />, drawn from the
+        /// chain of <see cref="ReferenceDataLibrary" />s and filtered by <see cref="Category.PermissibleClass" />
+        /// against the full inheritance chain of the current <see cref="ParameterType" /> via
+        /// <see cref="TypeResolver.GetAllSuperTypes" />.
+        /// </summary>
+        /// <returns>A collection of <see cref="Category" />s</returns>
+        private IEnumerable<Category> GetPossibleCategories()
+        {
+            if (this.SelectedReferenceDataLibrary is null || this.CurrentThing is null)
+            {
+                return Enumerable.Empty<Category>();
+            }
+
+            var applicableClassKinds = TypeResolver.GetAllSuperTypes(this.CurrentThing)
+                .Select(t => Enum.TryParse<ClassKind>(t.Name, out var kind) ? (ClassKind?)kind : null)
+                .Where(kind => kind.HasValue)
+                .Select(kind => kind.Value)
+                .ToHashSet();
+
+            return this.SelectedReferenceDataLibrary.QueryCategoriesFromChainOfRdls()
+                .Where(c => c.PermissibleClass.Any(applicableClassKinds.Contains))
+                .OrderBy(c => c.Name, StringComparer.InvariantCultureIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- Add a tab `categories` to the ParameterType edit window that allows a user to select the category that a PatameterType shall become a member of (also unselect)
- The categories are order in alphabetical order, where the selected categories appear at the top of the list, the unselected ones are below


<!-- Thanks for contributing to COMET-WEB! -->

