### PR TITLE
[Add] Categories tab to DomainOfExpertise form; extract reusable CategoriesTable

### DIFF
--- a/COMET.Web.Common.Tests/Components/CategoriesTableTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/CategoriesTableTestFixture.cs
@@ -1,0 +1,135 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CategoriesTableTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.Test.Helpers;
+
+    using DevExpress.Blazor;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CategoriesTableTestFixture
+    {
+        private BunitContext context;
+        private DomainOfExpertise thing;
+        private Category alpha;
+        private Category bravo;
+        private Category charlie;
+        private List<Category> availableCategories;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.alpha = new Category { Iid = Guid.NewGuid(), ShortName = "alpha", Name = "Alpha" };
+            this.bravo = new Category { Iid = Guid.NewGuid(), ShortName = "bravo", Name = "Bravo" };
+            this.charlie = new Category { Iid = Guid.NewGuid(), ShortName = "charlie", Name = "Charlie" };
+
+            this.availableCategories = new List<Category> { this.charlie, this.alpha, this.bravo };
+
+            this.thing = new DomainOfExpertise
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "doe",
+                Name = "Domain"
+            };
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.Dispose();
+        }
+
+        [Test]
+        public void VerifyGridRendersOneRowPerAvailableCategory()
+        {
+            var renderer = this.context.Render<CategoriesTable>(parameter =>
+            {
+                parameter.Add(p => p.Thing, this.thing);
+                parameter.Add(p => p.AvailableCategories, this.availableCategories);
+            });
+
+            var grid = renderer.FindComponent<DxGrid>();
+            var data = ((IEnumerable<object>)grid.Instance.Data).Cast<Category>().ToList();
+
+            Assert.That(data, Has.Count.EqualTo(this.availableCategories.Count));
+            Assert.That(data, Is.EquivalentTo(this.availableCategories));
+        }
+
+        [Test]
+        public void VerifySelectedCategoriesAreOrderedFirstThenAlphabetically()
+        {
+            this.thing.Category.Add(this.charlie);
+
+            var renderer = this.context.Render<CategoriesTable>(parameter =>
+            {
+                parameter.Add(p => p.Thing, this.thing);
+                parameter.Add(p => p.AvailableCategories, this.availableCategories);
+            });
+
+            var grid = renderer.FindComponent<DxGrid>();
+            var data = ((IEnumerable<object>)grid.Instance.Data).Cast<Category>().ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(data[0], Is.EqualTo(this.charlie), "Selected category must appear first.");
+                Assert.That(data[1], Is.EqualTo(this.alpha), "Unselected categories must follow alphabetically.");
+                Assert.That(data[2], Is.EqualTo(this.bravo));
+            });
+        }
+
+        [Test]
+        public async Task VerifySelectionChangeUpdatesThingAndRaisesThingChanged()
+        {
+            ICategorizableThing capturedThing = null;
+
+            var renderer = this.context.Render<CategoriesTable>(parameter =>
+            {
+                parameter.Add(p => p.Thing, this.thing);
+                parameter.Add(p => p.AvailableCategories, this.availableCategories);
+                parameter.Add(p => p.ThingChanged, t => capturedThing = t);
+            });
+
+            var grid = renderer.FindComponent<DxGrid>();
+
+            await renderer.InvokeAsync(() => grid.Instance.SelectedDataItemsChanged.InvokeAsync(new object[] { this.alpha, this.bravo }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.thing.Category, Is.EquivalentTo(new[] { this.alpha, this.bravo }));
+                Assert.That(capturedThing, Is.SameAs(this.thing));
+            });
+        }
+    }
+}

--- a/COMET.Web.Common/Components/CategoriesTable.razor
+++ b/COMET.Web.Common/Components/CategoriesTable.razor
@@ -1,0 +1,42 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of CDP4-COMET WEB Community Edition
+    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+    Annex A and Annex C.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+------------------------------------------------------------------------------->
+
+@using CDP4Common.CommonData
+@using CDP4Common.SiteDirectoryData
+@inherits DisposableComponent
+
+<DxGrid Data="@(this.AvailableCategories
+                  .OrderByDescending(c => this.Thing.Category.Contains(c))
+                  .ThenBy(c => c.Name))"
+        ShowAllRows="true"
+        FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
+        SelectionMode="GridSelectionMode.Multiple"
+        SelectAllCheckboxMode="GridSelectAllCheckboxMode.AllPages"
+        KeyFieldName="@nameof(Category.Iid)"
+        SelectedDataItems="@(this.Thing.Category.Cast<object>().ToArray())"
+        SelectedDataItemsChanged="@(items => this.OnSelectedCategoriesChanged(items))"
+        CssClass="cw-480">
+    <Columns>
+        <DxGridSelectionColumn Width="60px" AllowSelectAll="true"/>
+        <DxGridDataColumn FieldName="@nameof(Category.Name)" AllowSort="true"/>
+        <DxGridDataColumn FieldName="@nameof(Category.ShortName)" AllowSort="true"/>
+        <DxGridDataColumn FieldName="@nameof(Category.IsDeprecated)" Caption="Deprecated" AllowSort="true"/>
+    </Columns>
+</DxGrid>

--- a/COMET.Web.Common/Components/CategoriesTable.razor.cs
+++ b/COMET.Web.Common/Components/CategoriesTable.razor.cs
@@ -1,0 +1,74 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CategoriesTable.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Inline grid that manages the <see cref="ICategorizableThing.Category" /> collection of a parent
+    /// <see cref="ICategorizableThing" />. The grid renders one row per available <see cref="Category" /> with a
+    /// checkbox column; ticking or unticking a row mutates the parent's category list in place so the change is
+    /// committed together with the parent when the surrounding form is saved. Selected categories are pulled to
+    /// the top of the list and the remainder is sorted alphabetically by name.
+    /// </summary>
+    public partial class CategoriesTable : DisposableComponent
+    {
+        /// <summary>
+        /// The parent <see cref="ICategorizableThing" /> whose <see cref="ICategorizableThing.Category" /> collection
+        /// is being edited.
+        /// </summary>
+        [Parameter]
+        public ICategorizableThing Thing { get; set; }
+
+        /// <summary>
+        /// The categories the user may pick from. The caller is expected to have already filtered this list by the
+        /// applicable <see cref="ReferenceDataLibrary" /> chain and by <see cref="Category.PermissibleClass" /> for
+        /// the parent's class kind.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<Category> AvailableCategories { get; set; } = Enumerable.Empty<Category>();
+
+        /// <summary>
+        /// Notifies the surrounding form that the parent's <see cref="ICategorizableThing.Category" /> collection
+        /// has changed. Fired after each toggle of a row's selection.
+        /// </summary>
+        [Parameter]
+        public EventCallback<ICategorizableThing> ThingChanged { get; set; }
+
+        /// <summary>
+        /// Persists the new selection back onto the parent's <see cref="ICategorizableThing.Category" /> list and
+        /// fires <see cref="ThingChanged" />.
+        /// </summary>
+        /// <param name="items">The grid's currently selected data items.</param>
+        /// <returns>A <see cref="Task" />.</returns>
+        protected async Task OnSelectedCategoriesChanged(IReadOnlyList<object> items)
+        {
+            this.Thing.Category = items.Cast<Category>().ToList();
+            await this.ThingChanged.InvokeAsync(this.Thing);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/SiteDirectory/DomainsOfExpertiseTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/DomainsOfExpertiseTableTestFixture.cs
@@ -85,6 +85,7 @@ namespace COMETwebapp.Tests.Components.SiteDirectory
             this.viewModel.Setup(x => x.Rows).Returns(rows);
             this.viewModel.Setup(x => x.ShowHideDeprecatedThingsService).Returns(this.showHideService.Object);
             this.viewModel.Setup(x => x.CurrentThing).Returns(new DomainOfExpertise());
+            this.viewModel.Setup(x => x.Categories).Returns([]);
 
             this.context.Services.AddSingleton(this.viewModel.Object);
             this.context.ConfigureDevExpressBlazor();

--- a/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/DomainsOfExpertiseTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SiteDirectory/DomainsOfExpertiseTableViewModelTestFixture.cs
@@ -45,6 +45,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory
 
     using NUnit.Framework;
 
+    using Result = FluentResults.Result;
+
     [TestFixture]
     public class DomainsOfExpertiseTableViewModelTestFixture
     {
@@ -56,6 +58,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory
         private CDPMessageBus messageBus;
         private Mock<IShowHideDeprecatedThingsService> showHideService;
         private DomainOfExpertise domainOfExpertise;
+        private SiteDirectory siteDirectory;
 
         [SetUp]
         public void Setup()
@@ -72,12 +75,26 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory
                 Name = "scale",
             };
 
-            var siteDirectory = new SiteDirectory()
+            this.siteDirectory = new SiteDirectory()
             {
-                ShortName = "siteDirectory"
+                ShortName = "siteDirectory",
+                SiteReferenceDataLibrary =
+                {
+                    new SiteReferenceDataLibrary
+                    {
+                        ShortName = "siteRdl",
+                        Name = "Site RDL",
+                        DefinedCategory =
+                        {
+                            new Category { ShortName = "domCat", Name = "Domain category", PermissibleClass = { ClassKind.DomainOfExpertise } },
+                            new Category { ShortName = "definedCat", Name = "Defined-thing category", PermissibleClass = { ClassKind.DefinedThing } },
+                            new Category { ShortName = "elCat", Name = "Element category", PermissibleClass = { ClassKind.ElementDefinition } }
+                        }
+                    }
+                }
             };
 
-            siteDirectory.Domain.Add(this.domainOfExpertise);
+            this.siteDirectory.Domain.Add(this.domainOfExpertise);
 
             this.assembler = new Assembler(new Uri("http://localhost:5000/"), this.messageBus);
             var lazyDomain = new Lazy<Thing>(this.domainOfExpertise);
@@ -87,9 +104,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory
             var session = new Mock<ISession>();
             session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
             session.Setup(x => x.Assembler).Returns(this.assembler);
-            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDirectory);
             this.sessionService.Setup(x => x.Session).Returns(session.Object);
-            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(this.siteDirectory);
 
             this.viewModel = new DomainsOfExpertiseTableViewModel(this.sessionService.Object, this.showHideService.Object, this.messageBus, this.loggerMock.Object);
         }
@@ -180,6 +197,67 @@ namespace COMETwebapp.Tests.ViewModels.Components.SiteDirectory
 
             await this.viewModel.CreateOrEditDomainOfExpertise(true);
             this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<SiteDirectory>(), It.Is<List<Thing>>(c => c.Count == 2), It.IsAny<NotificationDescription>()), Times.Once);
+        }
+
+        [Test]
+        public void VerifyCategoriesAreFilteredByPermissibleClass()
+        {
+            this.viewModel.InitializeViewModel();
+
+            // CurrentThing is a DomainOfExpertise.
+            // domCat (PermissibleClass = DomainOfExpertise, literal match) — eligible.
+            // definedCat (PermissibleClass = DefinedThing, superclass match via the inheritance chain) — eligible.
+            // elCat (ElementDefinition, unrelated branch) — excluded.
+            Assert.That(this.viewModel.Categories.Select(c => c.ShortName), Is.EquivalentTo(new[] { "domCat", "definedCat" }));
+        }
+
+        [Test]
+        public void VerifyCategoriesIncludesPermissibleClassesAcrossInheritanceChain()
+        {
+            this.viewModel.InitializeViewModel();
+
+            var eligibleShortNames = this.viewModel.Categories.Select(c => c.ShortName).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(eligibleShortNames, Does.Contain("definedCat"),
+                    "A Category whose PermissibleClass is the DefinedThing superclass must be eligible for DomainOfExpertise via the inheritance chain.");
+                Assert.That(eligibleShortNames, Does.Contain("domCat"),
+                    "A Category whose PermissibleClass is DomainOfExpertise must be eligible.");
+                Assert.That(eligibleShortNames, Does.Not.Contain("elCat"),
+                    "elCat targets ElementDefinition and must remain excluded.");
+            });
+        }
+
+        [Test]
+        public async Task VerifyCategoriesArePersistedAlongsideTheDomainOfExpertise()
+        {
+            this.viewModel.InitializeViewModel();
+
+            var category = this.siteDirectory.SiteReferenceDataLibrary.First().DefinedCategory.First(c => c.ShortName == "domCat");
+
+            this.viewModel.CurrentThing = new DomainOfExpertise
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "withCategory",
+                Name = "with category",
+                Category = { category }
+            };
+
+            List<Thing> capturedThings = null;
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<SiteDirectory>(), It.IsAny<List<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((_, things, _) => capturedThings = things.ToList())
+                .ReturnsAsync(new Result());
+
+            await this.viewModel.CreateOrEditDomainOfExpertise(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(capturedThings, Does.Contain(this.viewModel.CurrentThing));
+                Assert.That(this.viewModel.CurrentThing.Category, Does.Contain(category));
+            });
         }
     }
 }

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -181,24 +181,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             }
 
             <DxFormLayoutTabPage Caption="Categories">
-                <DxGrid Data="@(this.ViewModel.Categories
-                                  .OrderByDescending(c => this.ViewModel.CurrentThing.Category.Contains(c))
-                                  .ThenBy(c => c.Name))"
-                        ShowAllRows="true"
-                        FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-                        SelectionMode="GridSelectionMode.Multiple"
-                        SelectAllCheckboxMode="GridSelectAllCheckboxMode.AllPages"
-                        KeyFieldName="@nameof(Category.Iid)"
-                        SelectedDataItems="@(this.ViewModel.CurrentThing.Category.Cast<object>().ToArray())"
-                        SelectedDataItemsChanged="@(items => this.ViewModel.CurrentThing.Category = items.Cast<Category>().ToList())"
-                        CssClass="cw-480">
-                    <Columns>
-                        <DxGridSelectionColumn Width="60px" AllowSelectAll="true"/>
-                        <DxGridDataColumn FieldName="@nameof(Category.Name)" AllowSort="true"/>
-                        <DxGridDataColumn FieldName="@nameof(Category.ShortName)" AllowSort="true"/>
-                        <DxGridDataColumn FieldName="@nameof(Category.IsDeprecated)" Caption="Deprecated" AllowSort="true"/>
-                    </Columns>
-                </DxGrid>
+                <CategoriesTable Thing="@this.ViewModel.CurrentThing"
+                                 AvailableCategories="@this.ViewModel.Categories"/>
             </DxFormLayoutTabPage>
 
             <DxFormLayoutTabPage Caption="Definitions">

--- a/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseForm.razor
+++ b/COMETwebapp/Components/SiteDirectory/DomainsOfExpertiseForm.razor
@@ -1,4 +1,4 @@
-﻿<!------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------
 Copyright (c) 2023-2026 Starion Group S.A.
     This file is part of CDP4-COMET WEB Community Edition
      The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
@@ -19,15 +19,24 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <EditForm Context="editFormContext" Model="@(this.ViewModel.CurrentThing)" OnValidSubmit="@(this.OnValidSubmit)">
     <FluentValidationValidator />
     <DxFormLayout CssClass="w-100">
-        <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.ShortName"/>
-        </DxFormLayoutItem>
-        <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
-            <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
-        </DxFormLayoutItem>
-        <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
-            <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
-        </DxFormLayoutItem>
+        <DxFormLayoutTabPages>
+            <DxFormLayoutTabPage Caption="Basic">
+                <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.ShortName"/>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
+                    <DxTextBox @bind-Text="@this.ViewModel.CurrentThing.Name"/>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Deprecated:" ColSpanMd="6">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.CurrentThing.IsDeprecated"/>
+                </DxFormLayoutItem>
+            </DxFormLayoutTabPage>
+
+            <DxFormLayoutTabPage Caption="Categories">
+                <CategoriesTable Thing="@this.ViewModel.CurrentThing"
+                                 AvailableCategories="@this.ViewModel.Categories"/>
+            </DxFormLayoutTabPage>
+        </DxFormLayoutTabPages>
     </DxFormLayout>
     <FormButtons SaveButtonEnabled="@(this.IsSaveButtonEnabled(editFormContext))"
                  OnCancel="@(this.OnCancel)"

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/DomainsOfExpertiseTableViewModel.cs
@@ -23,6 +23,7 @@
 namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
 {
     using CDP4Common.CommonData;
+    using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal;
@@ -53,6 +54,13 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
         {
             this.CurrentThing = new DomainOfExpertise();
         }
+
+        /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="DomainOfExpertise" />, drawn from
+        /// the chain of <see cref="ReferenceDataLibrary" />s available in the <see cref="SiteDirectory" /> and
+        /// filtered by <see cref="Category.PermissibleClass" />.
+        /// </summary>
+        public IEnumerable<Category> Categories => this.GetPossibleCategories();
 
         /// <summary>
         /// Creates or edits a <see cref="DomainOfExpertise"/>
@@ -94,6 +102,34 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
         protected override List<DomainOfExpertise> QueryListOfThings()
         {
             return this.SessionService.GetSiteDirectory().Domain;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="DomainOfExpertise" />, aggregated
+        /// across the <see cref="ReferenceDataLibrary" />s available in the <see cref="SiteDirectory" /> and
+        /// filtered by <see cref="Category.PermissibleClass" /> against the full inheritance chain of
+        /// <see cref="DomainOfExpertise" /> via <see cref="TypeResolver.GetAllSuperTypes" />.
+        /// </summary>
+        /// <returns>A collection of <see cref="Category" />s</returns>
+        private IEnumerable<Category> GetPossibleCategories()
+        {
+            if (this.CurrentThing is null)
+            {
+                return Enumerable.Empty<Category>();
+            }
+
+            var applicableClassKinds = TypeResolver.GetAllSuperTypes(this.CurrentThing)
+                .Select(t => Enum.TryParse<ClassKind>(t.Name, out var kind) ? (ClassKind?)kind : null)
+                .Where(kind => kind.HasValue)
+                .Select(kind => kind.Value)
+                .ToHashSet();
+
+            return this.SessionService.GetSiteDirectory()
+                .AvailableReferenceDataLibraries()
+                .SelectMany(rdl => rdl.QueryCategoriesFromChainOfRdls())
+                .Distinct()
+                .Where(c => c.PermissibleClass.Any(applicableClassKinds.Contains))
+                .OrderBy(c => c.Name, StringComparer.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/IDomainsOfExpertiseTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/DomainsOfExpertise/IDomainsOfExpertiseTableViewModel.cs
@@ -33,6 +33,13 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise
     public interface IDomainsOfExpertiseTableViewModel : IDeprecatableDataItemTableViewModel<DomainOfExpertise, DomainOfExpertiseRowViewModel>
     {
         /// <summary>
+        /// Gets the <see cref="Category" />s eligible for the current <see cref="DomainOfExpertise" />, drawn from
+        /// the chain of <see cref="ReferenceDataLibrary" />s available in the <see cref="SiteDirectory" /> and
+        /// filtered by <see cref="Category.PermissibleClass" />.
+        /// </summary>
+        IEnumerable<Category> Categories { get; }
+
+        /// <summary>
         /// Creates or edits a <see cref="DomainOfExpertise"/>
         /// </summary>
         /// <param name="shouldCreate">The value to check if a new <see cref="DomainOfExpertise"/> should be created</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
 - refactor categories selection into a reusable component
 - add component to domainofexpertise and parametertype

<!-- Thanks for contributing to COMET-WEB! -->

