### PR TITLE
Gh721 parameter editor filter on category

### DIFF
--- a/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiCategorySelectorViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiCategorySelectorViewModelTestFixture.cs
@@ -167,5 +167,34 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.Selectors
                 Assert.That(this.viewModel.SelectedCategories, Is.Empty);
             });
         }
+
+        [Test]
+        public void VerifyOverridingApplicableClassKindsExpandsScope()
+        {
+            this.viewModel.ApplicableClassKinds = new[] { ClassKind.ParameterType };
+            this.viewModel.CurrentIteration = this.iteration;
+
+            Assert.That(this.viewModel.AvailableCategories.Select(c => c.ShortName),
+                Is.EquivalentTo(new[] { "ptCat" }),
+                "Overriding ApplicableClassKinds to ParameterType must surface only ParameterType-permissible categories.");
+        }
+
+        [Test]
+        public void VerifyEmptyApplicableClassKindsDisablesPermissibleClassFilter()
+        {
+            this.viewModel.ApplicableClassKinds = Array.Empty<ClassKind>();
+            this.viewModel.CurrentIteration = this.iteration;
+
+            var available = this.viewModel.AvailableCategories.ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(available.Select(c => c.ShortName), Is.EquivalentTo(new[] { "edCat", "euCat", "ptCat" }),
+                    "An empty ApplicableClassKinds must disable the PermissibleClass filter and surface every Category.");
+                Assert.That(available.Select(c => c.Name).ToList(),
+                    Is.EqualTo(available.Select(c => c.Name).OrderBy(n => n, StringComparer.InvariantCultureIgnoreCase).ToList()),
+                    "AvailableCategories must remain alphabetically sorted regardless of the configured scope.");
+            });
+        }
     }
 }

--- a/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiCategorySelectorViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/Selectors/MultiCategorySelectorViewModelTestFixture.cs
@@ -1,0 +1,171 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiCategorySelectorViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.ViewModels.Components.Selectors
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MultiCategorySelectorViewModelTestFixture
+    {
+        private MultiCategorySelectorViewModel viewModel;
+        private Category elementDefinitionCategory;
+        private Category elementUsageCategory;
+        private Category parameterTypeCategory;
+        private Iteration iteration;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.viewModel = new MultiCategorySelectorViewModel();
+
+            this.elementDefinitionCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "edCat",
+                Name = "ED category",
+                PermissibleClass = { ClassKind.ElementDefinition }
+            };
+
+            this.elementUsageCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "euCat",
+                Name = "EU category",
+                PermissibleClass = { ClassKind.ElementUsage }
+            };
+
+            this.parameterTypeCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "ptCat",
+                Name = "PT category",
+                PermissibleClass = { ClassKind.ParameterType }
+            };
+
+            var rdl = new SiteReferenceDataLibrary
+            {
+                ShortName = "siteRdl",
+                Name = "Site RDL",
+                DefinedCategory =
+                {
+                    this.elementDefinitionCategory,
+                    this.elementUsageCategory,
+                    this.parameterTypeCategory
+                }
+            };
+
+            var siteDirectory = new SiteDirectory
+            {
+                ShortName = "siteDir",
+                SiteReferenceDataLibrary = { rdl }
+            };
+
+            var modelSetup = new EngineeringModelSetup
+            {
+                ShortName = "model",
+                RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } }
+            };
+
+            siteDirectory.Model.Add(modelSetup);
+
+            var iterationSetup = new IterationSetup();
+            modelSetup.IterationSetup.Add(iterationSetup);
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                IterationSetup = iterationSetup
+            };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyInitialState()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableCategories, Is.Empty);
+                Assert.That(this.viewModel.SelectedCategories, Is.Empty);
+                Assert.That(this.viewModel.CurrentIteration, Is.Null);
+            });
+        }
+
+        [Test]
+        public void VerifyAvailableCategoriesAreScopedToElementBaseAndOrdered()
+        {
+            this.viewModel.CurrentIteration = this.iteration;
+
+            var available = this.viewModel.AvailableCategories.ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(available.Select(c => c.ShortName), Is.EquivalentTo(new[] { "edCat", "euCat" }),
+                    "Only categories whose PermissibleClass covers ElementBase / ElementDefinition / ElementUsage should appear.");
+                Assert.That(available.Select(c => c.Name).ToList(),
+                    Is.EqualTo(available.Select(c => c.Name).OrderBy(n => n, StringComparer.InvariantCultureIgnoreCase).ToList()),
+                    "AvailableCategories must be sorted alphabetically by Name.");
+                Assert.That(this.viewModel.SelectedCategories, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifySettingNullSelectionFallsBackToEmptyCollection()
+        {
+            this.viewModel.SelectedCategories = null;
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.SelectedCategories, Is.Not.Null);
+                Assert.That(this.viewModel.SelectedCategories, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyChangingIterationResetsSelection()
+        {
+            this.viewModel.CurrentIteration = this.iteration;
+            this.viewModel.SelectedCategories = new List<Category> { this.elementDefinitionCategory };
+
+            Assert.That(this.viewModel.SelectedCategories.Count(), Is.EqualTo(1));
+
+            this.viewModel.CurrentIteration = null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableCategories, Is.Empty);
+                Assert.That(this.viewModel.SelectedCategories, Is.Empty);
+            });
+        }
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor
@@ -1,0 +1,40 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@using CDP4Common.SiteDirectoryData
+@inherits BelongsToIterationSelector<COMET.Web.Common.ViewModels.Components.Selectors.IMultiCategorySelectorViewModel>
+
+@if (this.ViewModel.CurrentIteration != null)
+{
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
+
+    <DxTagBox Data="@(this.ViewModel.AvailableCategories)"
+              TData="Category"
+              TValue="Category"
+              Values="@(this.ViewModel.SelectedCategories)"
+              ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values)"
+              FilteringMode="DataGridFilteringMode.Contains"
+              ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+              TextFieldName="@(nameof(Category.Name))"
+              NullText="Select Categories"/>
+}

--- a/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor.cs
@@ -1,0 +1,42 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiCategorySelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select one or more <see cref="Category" />s. Multi-select filter scoped to the
+    /// current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s reference data libraries.
+    /// </summary>
+    public partial class MultiCategorySelector
+    {
+        /// <summary>
+        /// Gets or sets the heading rendered above the selector. Set to an empty string to hide the heading.
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Categories:";
+    }
+}

--- a/COMET.Web.Common/Utilities/QueryKeys.cs
+++ b/COMET.Web.Common/Utilities/QueryKeys.cs
@@ -71,5 +71,11 @@ namespace COMET.Web.Common.Utilities
         /// multi-select filters such as the Parameter Editor's parameter-type filter.
         /// </summary>
         public const string ParametersKey = "parameters";
+
+        /// <summary>
+        /// The query key for a comma-delimited list of <see cref="Category" /> short-form GUIDs, used by the
+        /// Parameter Editor's category filter.
+        /// </summary>
+        public const string CategoriesKey = "categories";
     }
 }

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiCategorySelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiCategorySelectorViewModel.cs
@@ -1,0 +1,51 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IMultiCategorySelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// View Model that enables the user to select one or more <see cref="Category" />s for use as a multi-select
+    /// filter scoped to the current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s reference data
+    /// libraries.
+    /// </summary>
+    public interface IMultiCategorySelectorViewModel : IBelongsToIterationSelectorViewModel
+    {
+        /// <summary>
+        /// Gets or sets the currently selected <see cref="Category" />s. An empty collection means "no filter" —
+        /// every <see cref="Category" /> in <see cref="AvailableCategories" /> matches.
+        /// </summary>
+        IEnumerable<Category> SelectedCategories { get; set; }
+
+        /// <summary>
+        /// Gets the collection of <see cref="Category" />s that the user can pick from. Populated from the
+        /// current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s accessible reference data libraries
+        /// and filtered to categories whose <see cref="Category.PermissibleClass" /> covers
+        /// <see cref="CDP4Common.EngineeringModelData.ElementBase" />,
+        /// <see cref="CDP4Common.EngineeringModelData.ElementDefinition" /> or
+        /// <see cref="CDP4Common.EngineeringModelData.ElementUsage" />.
+        /// </summary>
+        IEnumerable<Category> AvailableCategories { get; }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiCategorySelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiCategorySelectorViewModel.cs
@@ -23,12 +23,15 @@
 
 namespace COMET.Web.Common.ViewModels.Components.Selectors
 {
+    using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     /// View Model that enables the user to select one or more <see cref="Category" />s for use as a multi-select
     /// filter scoped to the current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s reference data
-    /// libraries.
+    /// libraries. The set of <see cref="ClassKind" />s a <see cref="Category" /> must be permissible for is
+    /// configurable via <see cref="ApplicableClassKinds" />, so the same view model can drive Element-,
+    /// ParameterType-, Requirement- or unrestricted category pickers.
     /// </summary>
     public interface IMultiCategorySelectorViewModel : IBelongsToIterationSelectorViewModel
     {
@@ -41,11 +44,20 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
         /// <summary>
         /// Gets the collection of <see cref="Category" />s that the user can pick from. Populated from the
         /// current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s accessible reference data libraries
-        /// and filtered to categories whose <see cref="Category.PermissibleClass" /> covers
-        /// <see cref="CDP4Common.EngineeringModelData.ElementBase" />,
-        /// <see cref="CDP4Common.EngineeringModelData.ElementDefinition" /> or
-        /// <see cref="CDP4Common.EngineeringModelData.ElementUsage" />.
+        /// and filtered to categories whose <see cref="Category.PermissibleClass" /> intersects
+        /// <see cref="ApplicableClassKinds" />. When <see cref="ApplicableClassKinds" /> is empty or
+        /// <see langword="null" /> every <see cref="Category" /> reachable through the RDL chain is exposed.
         /// </summary>
         IEnumerable<Category> AvailableCategories { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ClassKind" />s a <see cref="Category" /> must be permissible for to appear
+        /// in <see cref="AvailableCategories" />. An empty or <see langword="null" /> collection disables the
+        /// <see cref="Category.PermissibleClass" /> filter and surfaces every <see cref="Category" /> reachable
+        /// from the current <see cref="CDP4Common.EngineeringModelData.Iteration" />'s reference data libraries.
+        /// Set this before assigning <see cref="IBelongsToIterationSelectorViewModel.CurrentIteration" />; the
+        /// value is read on the next <see cref="MultiCategorySelectorViewModel.UpdateProperties" /> pass.
+        /// </summary>
+        IEnumerable<ClassKind> ApplicableClassKinds { get; set; }
     }
 }

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiCategorySelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiCategorySelectorViewModel.cs
@@ -31,23 +31,12 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
 
     /// <summary>
     /// Default <see cref="IMultiCategorySelectorViewModel" /> implementation. Mirrors the shape of
-    /// <see cref="MultiParameterTypeSelectorViewModel" /> but selects <see cref="Category" />s applicable to
-    /// <see cref="ElementBase" /> and its concrete subclasses.
+    /// <see cref="MultiParameterTypeSelectorViewModel" /> and lets callers tune the <see cref="ClassKind" />
+    /// scope via <see cref="ApplicableClassKinds" /> so the same view model drives Element-, ParameterType-,
+    /// Requirement- or unrestricted category pickers.
     /// </summary>
     public class MultiCategorySelectorViewModel : BelongsToIterationSelectorViewModel, IMultiCategorySelectorViewModel
     {
-        /// <summary>
-        /// The <see cref="ClassKind" />s for which a <see cref="Category" /> must be permissible to appear in
-        /// <see cref="AvailableCategories" />. Covers the abstract base and both concrete element types so that
-        /// categories defined for any of them are surfaced.
-        /// </summary>
-        private static readonly HashSet<ClassKind> ApplicableClassKinds =
-        [
-            ClassKind.ElementBase,
-            ClassKind.ElementDefinition,
-            ClassKind.ElementUsage
-        ];
-
         /// <summary>
         /// Backing field for <see cref="SelectedCategories" />.
         /// </summary>
@@ -65,11 +54,29 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
 
         /// <summary>
         /// Gets the collection of <see cref="Category" />s that the user can pick from. Populated from the
-        /// current <see cref="Iteration" />'s accessible reference data libraries and filtered to categories whose
-        /// <see cref="Category.PermissibleClass" /> covers <see cref="ElementBase" />,
-        /// <see cref="ElementDefinition" /> or <see cref="ElementUsage" />.
+        /// current <see cref="Iteration" />'s accessible reference data libraries and filtered to categories
+        /// whose <see cref="Category.PermissibleClass" /> intersects <see cref="ApplicableClassKinds" />.
+        /// When <see cref="ApplicableClassKinds" /> is empty or <see langword="null" />, no
+        /// <see cref="Category.PermissibleClass" /> filter is applied.
         /// </summary>
         public IEnumerable<Category> AvailableCategories { get; private set; } = Enumerable.Empty<Category>();
+
+        /// <summary>
+        /// Gets or sets the <see cref="ClassKind" />s a <see cref="Category" /> must be permissible for to
+        /// appear in <see cref="AvailableCategories" />. Defaults to <see cref="ClassKind.ElementBase" />,
+        /// <see cref="ClassKind.ElementDefinition" /> and <see cref="ClassKind.ElementUsage" /> so the
+        /// view model is drop-in usable as the Parameter Editor's element-row category filter. An empty or
+        /// <see langword="null" /> collection disables the <see cref="Category.PermissibleClass" /> filter
+        /// and surfaces every <see cref="Category" /> reachable from the current <see cref="Iteration" />'s
+        /// reference data libraries. Set this before assigning <see cref="BelongsToIterationSelectorViewModel.CurrentIteration" />;
+        /// the value is read on the next <see cref="UpdateProperties" /> pass.
+        /// </summary>
+        public IEnumerable<ClassKind> ApplicableClassKinds { get; set; } = new[]
+        {
+            ClassKind.ElementBase,
+            ClassKind.ElementDefinition,
+            ClassKind.ElementUsage
+        };
 
         /// <summary>
         /// Recomputes <see cref="AvailableCategories" /> from the <see cref="SiteDirectory" /> containing the
@@ -87,11 +94,20 @@ namespace COMET.Web.Common.ViewModels.Components.Selectors
 
             var siteDirectory = this.CurrentIteration.IterationSetup.GetContainerOfType<SiteDirectory>();
 
-            this.AvailableCategories = siteDirectory
+            var allowedClassKinds = (this.ApplicableClassKinds as ICollection<ClassKind>)
+                ?? this.ApplicableClassKinds?.ToList();
+
+            var query = siteDirectory
                 .AvailableReferenceDataLibraries()
                 .SelectMany(rdl => rdl.QueryCategoriesFromChainOfRdls())
-                .Distinct()
-                .Where(c => c.PermissibleClass.Any(ApplicableClassKinds.Contains))
+                .Distinct();
+
+            if (allowedClassKinds is { Count: > 0 })
+            {
+                query = query.Where(c => c.PermissibleClass.Any(allowedClassKinds.Contains));
+            }
+
+            this.AvailableCategories = query
                 .OrderBy(c => c.Name, StringComparer.InvariantCultureIgnoreCase)
                 .ToList();
         }

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiCategorySelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiCategorySelectorViewModel.cs
@@ -1,0 +1,99 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiCategorySelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Default <see cref="IMultiCategorySelectorViewModel" /> implementation. Mirrors the shape of
+    /// <see cref="MultiParameterTypeSelectorViewModel" /> but selects <see cref="Category" />s applicable to
+    /// <see cref="ElementBase" /> and its concrete subclasses.
+    /// </summary>
+    public class MultiCategorySelectorViewModel : BelongsToIterationSelectorViewModel, IMultiCategorySelectorViewModel
+    {
+        /// <summary>
+        /// The <see cref="ClassKind" />s for which a <see cref="Category" /> must be permissible to appear in
+        /// <see cref="AvailableCategories" />. Covers the abstract base and both concrete element types so that
+        /// categories defined for any of them are surfaced.
+        /// </summary>
+        private static readonly HashSet<ClassKind> ApplicableClassKinds =
+        [
+            ClassKind.ElementBase,
+            ClassKind.ElementDefinition,
+            ClassKind.ElementUsage
+        ];
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedCategories" />.
+        /// </summary>
+        private IEnumerable<Category> selectedCategories = new List<Category>();
+
+        /// <summary>
+        /// Gets or sets the currently selected <see cref="Category" />s. An empty collection means "no filter" —
+        /// every <see cref="Category" /> in <see cref="AvailableCategories" /> matches.
+        /// </summary>
+        public IEnumerable<Category> SelectedCategories
+        {
+            get => this.selectedCategories;
+            set => this.RaiseAndSetIfChanged(ref this.selectedCategories, value ?? new List<Category>());
+        }
+
+        /// <summary>
+        /// Gets the collection of <see cref="Category" />s that the user can pick from. Populated from the
+        /// current <see cref="Iteration" />'s accessible reference data libraries and filtered to categories whose
+        /// <see cref="Category.PermissibleClass" /> covers <see cref="ElementBase" />,
+        /// <see cref="ElementDefinition" /> or <see cref="ElementUsage" />.
+        /// </summary>
+        public IEnumerable<Category> AvailableCategories { get; private set; } = Enumerable.Empty<Category>();
+
+        /// <summary>
+        /// Recomputes <see cref="AvailableCategories" /> from the <see cref="SiteDirectory" /> containing the
+        /// current <see cref="Iteration" /> and resets <see cref="SelectedCategories" /> to the empty selection.
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            this.SelectedCategories = new List<Category>();
+
+            if (this.CurrentIteration is null)
+            {
+                this.AvailableCategories = Enumerable.Empty<Category>();
+                return;
+            }
+
+            var siteDirectory = this.CurrentIteration.IterationSetup.GetContainerOfType<SiteDirectory>();
+
+            this.AvailableCategories = siteDirectory
+                .AvailableReferenceDataLibraries()
+                .SelectMany(rdl => rdl.QueryCategoriesFromChainOfRdls())
+                .Distinct()
+                .Where(c => c.PermissibleClass.Any(ApplicableClassKinds.Contains))
+                .OrderBy(c => c.Name, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
@@ -86,6 +86,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             parameterEditorViewModel.Setup(x => x.ElementSelector).Returns(new ElementBaseSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.OptionSelector).Returns(new OptionSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.ParameterTypeSelector).Returns(new MultiParameterTypeSelectorViewModel());
+            parameterEditorViewModel.Setup(x => x.CategorySelector).Returns(new MultiCategorySelectorViewModel());
             parameterEditorViewModel.Setup(x => x.ParameterTableViewModel).Returns(new ParameterTableViewModel(sessionService.Object, this.messageBus));
 
             var configuration = new Mock<IConfigurationService>();
@@ -164,6 +165,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
         {
             var elementFilterCombo = this.renderedComponent.FindComponent<ElementBaseSelector>();
             var parameterFilterCombo = this.renderedComponent.FindComponent<MultiParameterTypeSelector>();
+            var categoryFilterCombo = this.renderedComponent.FindComponent<MultiCategorySelector>();
             var optionFilterCombo = this.renderedComponent.FindComponent<OptionSelector>();
 
             var isOwnedCheckbox = this.renderedComponent.FindComponent<DxCheckBox<bool>>();
@@ -174,6 +176,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             {
                 Assert.That(elementFilterCombo, Is.Not.Null);
                 Assert.That(parameterFilterCombo, Is.Not.Null);
+                Assert.That(categoryFilterCombo, Is.Not.Null);
                 Assert.That(optionFilterCombo, Is.Not.Null);
                 Assert.That(isOwnedCheckbox, Is.Not.Null);
                 Assert.That(parameterTable, Is.Not.Null);

--- a/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
@@ -130,6 +130,7 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
             parameterEditorBodyViewModel.Setup(x => x.OptionSelector).Returns(new Mock<IOptionSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.BatchParameterEditorViewModel).Returns(new Mock<IBatchParameterEditorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ParameterTypeSelector).Returns(new Mock<IMultiParameterTypeSelectorViewModel>().Object);
+            parameterEditorBodyViewModel.Setup(x => x.CategorySelector).Returns(new Mock<IMultiCategorySelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ElementSelector).Returns(new Mock<IElementBaseSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ParameterTableViewModel).Returns(parameterTableViewModel.Object);
 

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
@@ -199,8 +199,16 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 }
             };
 
+            var rdl = new SiteReferenceDataLibrary { ShortName = "siteRdl", Name = "Site RDL" };
+            var siteDirectory = new SiteDirectory { ShortName = "siteDir", SiteReferenceDataLibrary = { rdl } };
+            var modelSetup = new EngineeringModelSetup { ShortName = "model", RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } } };
+            siteDirectory.Model.Add(modelSetup);
+            var iterationSetup = new IterationSetup();
+            modelSetup.IterationSetup.Add(iterationSetup);
+
             this.iteration = new Iteration();
             this.iteration.Iid = Guid.NewGuid();
+            this.iteration.IterationSetup = iterationSetup;
             this.iteration.TopElement = topElement;
             this.iteration.Element.AddRange(new List<ElementDefinition> { topElement, elementDefinition1, elementDefinition2, elementDefinition3, elementDefinition4 });
             this.iteration.Option.Add(new Option(Guid.NewGuid(), cache, uri));
@@ -246,7 +254,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
             this.viewModel.ApplyFilters();
 
-            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<Option>(), It.IsAny<ElementBase>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<bool>()), Times.AtLeastOnce);
+            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<Option>(), It.IsAny<ElementBase>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<IEnumerable<Category>>(), It.IsAny<bool>()), Times.AtLeastOnce);
         }
 
         [Test]
@@ -257,6 +265,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 Assert.That(this.viewModel.SubscriptionService, Is.Not.Null);
                 Assert.That(this.viewModel.ElementSelector, Is.Not.Null);
                 Assert.That(this.viewModel.ParameterTypeSelector, Is.Not.Null);
+                Assert.That(this.viewModel.CategorySelector, Is.Not.Null);
+                Assert.That(this.viewModel.CategorySelector.CurrentIteration, Is.SameAs(this.viewModel.CurrentThing));
                 Assert.That(this.viewModel.OptionSelector, Is.Not.Null);
                 Assert.That(this.viewModel.OptionSelector.SelectedOption, Is.Not.Null);
                 Assert.That(this.viewModel.IsOwnedParameters, Is.True);

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
@@ -297,16 +297,16 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
             this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.Option.Last(), null, null, true);
+            this.viewModel.ApplyFilters(this.iteration.Option.Last(), null, null, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, this.iteration.Element[^1], null, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, this.iteration.Element[^1], null, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { new ArrayParameterType { Iid = Guid.NewGuid() } }, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { new ArrayParameterType { Iid = Guid.NewGuid() } }, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(0));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { this.iteration.TopElement.Parameter[0].ParameterType }, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { this.iteration.TopElement.Parameter[0].ParameterType }, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
             var multipleParameterTypes = new[]
@@ -314,14 +314,61 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 this.iteration.TopElement.Parameter[0].ParameterType,
                 new ArrayParameterType { Iid = Guid.NewGuid() }
             };
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, multipleParameterTypes, true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, multipleParameterTypes, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, Array.Empty<ParameterType>(), true);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, Array.Empty<ParameterType>(), null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, false);
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, null, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+        }
+
+        [Test]
+        public void VerifyCategoryFiltering()
+        {
+            // Categorize the "Box" ElementDefinition (Element[^1] in the fixture). Parameters belonging to that
+            // definition (parameter1, parameter2) should match; parameter3 lives on the un-categorized topElement,
+            // and the override on usage1 inherits its referenced ElementDefinition's category via
+            // CategorizableThingExtensions.GetAllCategories — so it should match too.
+            var boxCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "Box",
+                Name = "Box"
+            };
+
+            var unrelatedCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                ShortName = "Other",
+                Name = "Other"
+            };
+
+            this.iteration.Element[^1].Category.Add(boxCategory);
+
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+
+            // Empty/null category set — no filter applied.
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, null, false);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, Array.Empty<Category>(), false);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
+
+            // Filtering by an unrelated category drops every row.
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { unrelatedCategory }, false);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(0));
+
+            // Filtering by the box category retains only the rows whose owning ElementBase carries it directly
+            // (parameter1, parameter2 on Box) or inherits it (the override on usage1, which references Box).
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { boxCategory }, false);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
+
+            // Multi-select OR semantics: union of matching rows.
+            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { boxCategory, unrelatedCategory }, false);
+            Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
         }
 
         [Test]

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
@@ -39,6 +39,11 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </div>
             <div class="col">
                 <div class="width-fit-content">
+                    <MultiCategorySelector ViewModel="this.ViewModel.CategorySelector"></MultiCategorySelector>
+                </div>
+            </div>
+            <div class="col">
+                <div class="width-fit-content">
                     <OptionSelector ViewModel="this.ViewModel.OptionSelector"></OptionSelector>
                 </div>
             </div>

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -50,6 +50,7 @@ namespace COMETwebapp.Components.ParameterEditor
                     x => x.ViewModel.OptionSelector.SelectedOption,
                     x => x.ViewModel.ParameterTypeSelector.SelectedParameterTypes,
                     x => x.ViewModel.ElementSelector.SelectedElementBase,
+                    x => x.ViewModel.CategorySelector.SelectedCategories,
                     x => x.ViewModel.IsOwnedParameters)
                 .Subscribe(_ => this.UpdateUrl()));
 
@@ -87,6 +88,18 @@ namespace COMETwebapp.Components.ParameterEditor
                     this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = new List<ParameterType> { match };
                 }
             }
+
+            if (parameters.TryGetValue(QueryKeys.CategoriesKey, out var categoriesValue) && !string.IsNullOrWhiteSpace(categoriesValue))
+            {
+                var ids = categoriesValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.CategorySelector.SelectedCategories = this.ViewModel.CategorySelector.AvailableCategories
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
+            }
         }
 
         /// <summary>
@@ -111,6 +124,13 @@ namespace COMETwebapp.Components.ParameterEditor
             if (selectedParameterTypes.Count > 0)
             {
                 additionalParameters[QueryKeys.ParametersKey] = string.Join(",", selectedParameterTypes.Select(x => x.Iid.ToShortGuid()));
+            }
+
+            var selectedCategories = this.ViewModel.CategorySelector.SelectedCategories?.ToList() ?? new List<Category>();
+
+            if (selectedCategories.Count > 0)
+            {
+                additionalParameters[QueryKeys.CategoriesKey] = string.Join(",", selectedCategories.Select(x => x.Iid.ToShortGuid()));
             }
 
             if (this.ViewModel.IsOwnedParameters)

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
@@ -55,6 +55,13 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; }
 
         /// <summary>
+        /// Gets the <see cref="IMultiCategorySelectorViewModel" /> driving the category filter on the building
+        /// blocks (<see cref="CDP4Common.EngineeringModelData.ElementBase" />). An empty selection means no
+        /// category filtering is applied.
+        /// </summary>
+        public IMultiCategorySelectorViewModel CategorySelector { get; }
+
+        /// <summary>
         /// Sets if only parameters owned by the active domain are shown
         /// </summary>
         bool IsOwnedParameters { get; set; }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
@@ -66,7 +66,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         void UpdateDomain(DomainOfExpertise currentDomain);
 
         /// <summary>
-        /// Apply filters based on <see cref="Option"/>, <see cref="ElementBase"/>, <see cref="ParameterType"/> and <see cref="DomainOfExpertise"/>.
+        /// Apply filters based on <see cref="Option"/>, <see cref="ElementBase"/>, <see cref="ParameterType"/>,
+        /// <see cref="Category"/> and <see cref="DomainOfExpertise"/>.
         /// </summary>
         /// <param name="selectedOption">The selected <see cref="Option"/>.</param>
         /// <param name="selectedElementBase">The selected <see cref="ElementBase"/>.</param>
@@ -75,7 +76,14 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType"/> is not in the
         /// collection are removed.
         /// </param>
+        /// <param name="selectedCategories">
+        /// The collection of <see cref="Category"/>s to filter on. <c>null</c> or an empty collection means no
+        /// category filter is applied; otherwise rows whose owning <see cref="ElementBase"/> does not carry at
+        /// least one of these categories (transitively, including the referenced
+        /// <see cref="ElementDefinition"/>'s categories for an <see cref="ElementUsage"/>, and super-categories)
+        /// are removed.
+        /// </param>
         /// <param name="isOwnedParameters">Value asserting that only <see cref="Thing"/>s owned by the current <see cref="DomainOfExpertise"/> should be visible.</param>
-        void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, bool isOwnedParameters);
+        void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
@@ -98,6 +98,12 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; private set; } = new MultiParameterTypeSelectorViewModel();
 
         /// <summary>
+        /// Gets the <see cref="IMultiCategorySelectorViewModel" /> driving the category filter on the building
+        /// blocks (<see cref="ElementBase" />). An empty selection means no category filtering is applied.
+        /// </summary>
+        public IMultiCategorySelectorViewModel CategorySelector { get; private set; } = new MultiCategorySelectorViewModel();
+
+        /// <summary>
         /// Sets if only parameters owned by the active domain are shown
         /// </summary>
         public bool IsOwnedParameters
@@ -124,7 +130,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             if (this.CurrentThing != null)
             {
                 this.ParameterTableViewModel.ApplyFilters(this.OptionSelector.SelectedOption, this.ElementSelector.SelectedElementBase,
-                    this.ParameterTypeSelector.SelectedParameterTypes, this.IsOwnedParameters);
+                    this.ParameterTypeSelector.SelectedParameterTypes, this.CategorySelector.SelectedCategories, this.IsOwnedParameters);
             }
         }
 
@@ -186,6 +192,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 this.ElementSelector.CurrentIteration = this.CurrentThing;
                 this.OptionSelector.CurrentIteration = this.CurrentThing;
                 this.ParameterTypeSelector.CurrentIteration = this.CurrentThing;
+                this.CategorySelector.CurrentIteration = this.CurrentThing;
                 this.BatchParameterEditorViewModel.CurrentIteration = this.CurrentThing;
             }
 

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -71,6 +71,14 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private HashSet<Guid> currentParameterTypeIds = new();
 
         /// <summary>
+        /// The set of <see cref="Category.Iid" />s currently selected as a multi-select filter. Empty means
+        /// "no filter"; otherwise rows whose owning <see cref="ElementBase" /> does not carry (directly or
+        /// through its referenced <see cref="ElementDefinition" /> / super-categories) at least one of these
+        /// categories are removed.
+        /// </summary>
+        private HashSet<Guid> currentCategoryIds = new();
+
+        /// <summary>
         /// Gets or sets the <see cref="ParameterBaseRowViewModel" /> for this <see cref="ParameterTableViewModel" />
         /// </summary>
         private DomainOfExpertise domainOfExpertise;
@@ -163,7 +171,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
 
         /// <summary>
         /// Apply filters based on <see cref="Option" />, <see cref="ElementBase" />, a multi-select set of
-        /// <see cref="ParameterType" />s and <see cref="DomainOfExpertise" />.
+        /// <see cref="ParameterType" />s, a multi-select set of <see cref="Category" />s and
+        /// <see cref="DomainOfExpertise" />.
         /// </summary>
         /// <param name="selectedOption">The selected <see cref="Option" />.</param>
         /// <param name="selectedElementBase">The selected <see cref="ElementBase" />.</param>
@@ -172,11 +181,18 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType" /> is not in the
         /// collection are removed.
         /// </param>
+        /// <param name="selectedCategories">
+        /// The collection of <see cref="Category" />s to filter on. <c>null</c> or an empty collection means no
+        /// category filter is applied; otherwise rows whose owning <see cref="ElementBase" /> does not carry at
+        /// least one of these categories (transitively, including the referenced
+        /// <see cref="ElementDefinition" />'s categories for an <see cref="ElementUsage" />, and super-categories)
+        /// are removed.
+        /// </param>
         /// <param name="isOwnedParameters">
         /// Value asserting that only <see cref="Thing" />s owned by the current <see cref="DomainOfExpertise" />
         /// should be visible.
         /// </param>
-        public void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, bool isOwnedParameters)
+        public void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters)
         {
             if (this.iteration == null)
             {
@@ -188,6 +204,9 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             this.currentParameterTypeIds = selectedParameterTypes == null
                 ? new HashSet<Guid>()
                 : new HashSet<Guid>(selectedParameterTypes.Select(x => x.Iid));
+            this.currentCategoryIds = selectedCategories == null
+                ? new HashSet<Guid>()
+                : new HashSet<Guid>(selectedCategories.Select(x => x.Iid));
             this.ownedParameters = isOwnedParameters;
 
             var rows = this.CreateRowsBasedOnFilters(this.iteration.QueryParameterAndOverrideBases(selectedOption).ToList());
@@ -317,6 +336,11 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 ApplyParameterTypeFilter(parameters, this.currentParameterTypeIds);
             }
 
+            if (this.currentCategoryIds.Count > 0)
+            {
+                ApplyCategoryFilter(parameters, this.currentCategoryIds);
+            }
+
             return this.CreateParameterBaseRowViewModels(parameters, this.currentOption.Iid).DistinctBy(x => x.ValueSetId);
         }
 
@@ -346,6 +370,28 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private static void ApplyParameterTypeFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> parameterTypeIds)
         {
             parameters.RemoveAll(x => !parameterTypeIds.Contains(x.ParameterType.Iid));
+        }
+
+        /// <summary>
+        /// Apply a filtering pass that retains only parameters whose owning <see cref="ElementBase" /> carries at
+        /// least one of the categories whose identifier is in <paramref name="categoryIds" />. Resolution uses
+        /// <see cref="CategorizableThingExtensions.GetAllCategories(ICategorizableThing, bool)" /> so that an
+        /// <see cref="ElementUsage" /> inherits the categories of its referenced <see cref="ElementDefinition" />,
+        /// and super-categories are honoured. Mutates <paramref name="parameters" /> in place.
+        /// </summary>
+        /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter.</param>
+        /// <param name="categoryIds">The <see cref="ISet{T}" /> of allowed <see cref="Category.Iid" /> values.</param>
+        private static void ApplyCategoryFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> categoryIds)
+        {
+            parameters.RemoveAll(p =>
+            {
+                if (p.Container is not ElementBase elementBase)
+                {
+                    return true;
+                }
+
+                return !elementBase.GetAllCategories().Any(c => categoryIds.Contains(c.Iid));
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- New reusable MultiCategorySelector{ViewModel} in COMET.Web.Common, with configurable ApplicableClassKinds (defaults to
  ElementBase/Definition/Usage) so the same picker drives Element, ParameterType, Requirement, or unrestricted scopes.
  - ParameterEditorBody gets a fifth filter column between Parameter Types and Option; selection persists via the new
  QueryKeys.CategoriesKey URL parameter.
  - ParameterTableViewModel.ApplyFilters extended to take IEnumerable<Category>; row pruning uses
  CategorizableThingExtensions.GetAllCategories() so ElementUsage rows match through their referenced ElementDefinition and
  super-categories (OR semantics across the selection).
  - Tests: new MultiCategorySelectorViewModelTestFixture (6 cases incl. override + empty-scope), new VerifyCategoryFiltering in
  ParameterTableViewModelTestFixture, plus signature/wiring updates to four existing Parameter Editor fixtures.

<!-- Thanks for contributing to COMET-WEB! -->

