### PR TITLE
[Add] delete ElementUsage and ElementDefinition in Model Editor; fixes #771 and #772

### DIFF
--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -1,0 +1,272 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ModelEditorViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Model;
+    using COMET.Web.Common.Services.Cache;
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.ViewModels.Components.ModelEditor;
+
+    using DynamicData;
+
+    using FluentResults;
+
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ModelEditorViewModelTestFixture
+    {
+        /// <summary>
+        /// The view model under test.
+        /// </summary>
+        private ModelEditorViewModel viewModel;
+
+        /// <summary>
+        /// The mocked <see cref="ISessionService" />.
+        /// </summary>
+        private Mock<ISessionService> sessionService;
+
+        /// <summary>
+        /// The message bus used by the view model.
+        /// </summary>
+        private CDPMessageBus messageBus;
+
+        /// <summary>
+        /// The iteration providing the test fixture's element graph.
+        /// </summary>
+        private Iteration iteration;
+
+        /// <summary>
+        /// The iteration's top element — must not be deletable.
+        /// </summary>
+        private ElementDefinition topElement;
+
+        /// <summary>
+        /// A non-top <see cref="ElementDefinition" /> referenced by <see cref="elementUsage" />.
+        /// </summary>
+        private ElementDefinition referencedElementDefinition;
+
+        /// <summary>
+        /// An <see cref="ElementUsage" /> contained by <see cref="topElement" /> referencing
+        /// <see cref="referencedElementDefinition" />.
+        /// </summary>
+        private ElementUsage elementUsage;
+
+        /// <summary>
+        /// Builds the iteration graph (TopElement, a referenced ElementDefinition, and a usage) and the
+        /// view model with mocked dependencies.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.messageBus = new CDPMessageBus();
+            this.sessionService = new Mock<ISessionService>();
+            var cacheService = new Mock<ICacheService>();
+
+            var session = new Mock<ISession>();
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            var rdl = new SiteReferenceDataLibrary { ShortName = "siteRdl", Name = "Site RDL" };
+            var siteDirectory = new SiteDirectory { Domain = { domain }, SiteReferenceDataLibrary = { rdl } };
+            var modelSetup = new EngineeringModelSetup { Name = "ModelName", ShortName = "ModelShortName", ActiveDomain = { domain }, RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } } };
+            siteDirectory.Model.Add(modelSetup);
+            var iterationSetup = new IterationSetup { IterationNumber = 1 };
+            modelSetup.IterationSetup.Add(iterationSetup);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+
+            this.topElement = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Container",
+                ShortName = "CONT",
+                Owner = domain
+            };
+
+            this.referencedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = domain
+            };
+
+            this.elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = this.referencedElementDefinition,
+                Owner = domain
+            };
+
+            this.topElement.ContainedElement.Add(this.elementUsage);
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                Element = { this.topElement, this.referencedElementDefinition },
+                TopElement = this.topElement,
+                IterationSetup = iterationSetup,
+                Container = new EngineeringModel { EngineeringModelSetup = modelSetup }
+            };
+
+            var logger = new Mock<ILogger<ModelEditorViewModel>>();
+
+            this.viewModel = new ModelEditorViewModel(this.sessionService.Object, this.messageBus, cacheService.Object, logger.Object)
+            {
+                CurrentThing = this.iteration
+            };
+        }
+
+        /// <summary>
+        /// Tears down the message bus and disposes of the view model.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.messageBus.ClearSubscriptions();
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyOpenDeleteElementPopupForUsage()
+        {
+            this.viewModel.SelectElement(this.elementUsage);
+            this.viewModel.OpenDeleteElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnDeletionMode, Is.True);
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.IsVisible, Is.True);
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Contain("Element Usage"));
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Contain(this.elementUsage.Name));
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Contain(this.topElement.Name),
+                    "Popup must mention the parent ElementDefinition name.");
+            });
+        }
+
+        [Test]
+        public void VerifyOpenDeleteElementPopupForDefinition()
+        {
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenDeleteElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnDeletionMode, Is.True);
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Contain("Element Definition"));
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Contain(this.referencedElementDefinition.Name));
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.ContentText, Does.Not.Contain("referenced"),
+                    "Server cascades cleanup, so the popup must not warn about referencing usages.");
+            });
+        }
+
+        [Test]
+        public void VerifyTopElementCannotBeDeleted()
+        {
+            this.viewModel.SelectElement(this.topElement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsSelectedElementTopElement, Is.True);
+            });
+
+            this.viewModel.OpenDeleteElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnDeletionMode, Is.False, "OpenDeleteElementPopup must be a no-op for the iteration's TopElement.");
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.IsVisible, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task VerifyDeleteElementUsageCallsSessionServiceWithCorrectContainer()
+        {
+            this.sessionService
+                .Setup(x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.elementUsage);
+            await this.viewModel.DeleteSelectedElementAsync();
+
+            this.sessionService.Verify(
+                x => x.DeleteThingsWithNotification(
+                    It.Is<Thing>(t => t is ElementDefinition && t.Iid == this.topElement.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.Count == 1 && c.Single() is ElementUsage && c.Single().Iid == this.elementUsage.Iid),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyDeleteElementDefinitionCallsSessionServiceWithCorrectContainer()
+        {
+            this.sessionService
+                .Setup(x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            await this.viewModel.DeleteSelectedElementAsync();
+
+            this.sessionService.Verify(
+                x => x.DeleteThingsWithNotification(
+                    It.Is<Thing>(t => t is Iteration && t.Iid == this.iteration.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.Count == 1 && c.Single() is ElementDefinition && c.Single().Iid == this.referencedElementDefinition.Iid),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyDeleteClearsSelectionOnSuccess()
+        {
+            this.sessionService
+                .Setup(x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.elementUsage);
+            await this.viewModel.DeleteSelectedElementAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.SelectedElement, Is.Null);
+                Assert.That(this.viewModel.SelectedElementDefinition, Is.Null);
+                Assert.That(this.viewModel.IsOnDeletionMode, Is.False);
+                Assert.That(this.viewModel.DeleteElementPopupViewModel.IsVisible, Is.False);
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModelTestFixture.cs
@@ -22,6 +22,8 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor.Rows
 {
+    using System.Collections.Specialized;
+
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -142,6 +144,46 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor.Rows
         {
             Assert.That(() => new ElementDefinitionTreeRowViewModel(elementDefinition).UpdateProperties(null), Throws.ArgumentNullException);
             Assert.That(() => new ElementDefinitionTreeRowViewModel().UpdateProperties(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void VerifyUpdatePropertiesEmitsItemChangesNotReset()
+        {
+            var testVM = new ElementDefinitionTreeRowViewModel(elementDefinition);
+
+            var actions = new List<NotifyCollectionChangedAction>();
+            testVM.Rows.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+            elementDefinition.ContainedElement.Clear();
+            testVM.UpdateProperties(new ElementDefinitionTreeRowViewModel(elementDefinition));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(testVM.Rows.Count, Is.Zero, "Removing the last contained ElementUsage must clear Rows.");
+                Assert.That(actions, Does.Not.Contain(NotifyCollectionChangedAction.Reset),
+                    "UpdateProperties must not raise Reset on Rows — DevExpress's bound TreeView mishandles Reset and leaves the parent's expand-icon stale.");
+                Assert.That(actions, Does.Contain(NotifyCollectionChangedAction.Remove),
+                    "Removed usages must be reported as Remove notifications so the bound TreeView updates incrementally.");
+            });
+        }
+
+        [Test]
+        public void VerifyUpdatePropertiesAddsNewUsageInSortedOrder()
+        {
+            var testVM = new ElementDefinitionTreeRowViewModel(elementDefinition);
+
+            var newerUsage = new ElementUsage(Guid.NewGuid(), null, null) { Name = "AAA_FirstAlphabetically", Owner = owner };
+            elementDefinition.ContainedElement.Add(newerUsage);
+
+            testVM.UpdateProperties(new ElementDefinitionTreeRowViewModel(elementDefinition));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(testVM.Rows.Count, Is.EqualTo(2));
+                Assert.That(testVM.Rows[0].ElementName, Is.EqualTo("AAA_FirstAlphabetically"),
+                    "Newly added usages must be inserted alphabetically by ElementName.");
+                Assert.That(testVM.Rows[1].ElementName, Is.EqualTo(elementUsageName));
+            });
         }
     }
 }

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -102,6 +102,17 @@
                         }
 
                         <DxButton Id="addElementDefinition" Text="Add Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
+
+                        @if (this.ViewModel.SelectedElement is not null)
+                        {
+                            <DxButton Id="deleteElement"
+                                      Text="Delete"
+                                      IconCssClass="oi oi-trash"
+                                      RenderStyle="ButtonRenderStyle.Danger"
+                                      Click="@this.ViewModel.OpenDeleteElementPopup"
+                                      Enabled="@(!this.ViewModel.IsSelectedElementTopElement)"
+                                      title="@(this.ViewModel.IsSelectedElementTopElement ? "The top element of the iteration cannot be deleted" : "Delete the selected element")"/>
+                        }
                     </div>
                 </div>
                 <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"/>
@@ -125,5 +136,7 @@
             <CopySettings ViewModel="this.ViewModel.CopySettingsViewModel" OnAfterSaveSettings="this.StateHasChanged"/>
         </BodyContentTemplate>
     </DxPopup>
+
+    <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteElementPopupViewModel"/>
 
 </LoadingComponent>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
@@ -24,6 +24,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
 {
     using CDP4Common.EngineeringModelData;
 
+    using COMET.Web.Common.ViewModels.Components;
     using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Components.ModelEditor;
@@ -126,5 +127,47 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// <param name="fromElementBase">The <see cref="ElementBase"/> to be added as <see cref="ElementUsage"/></param>
         /// <param name="toElementBase">The <see cref="ElementBase"/> where to add the new <see cref="ElementUsage"/> to</param>
         Task AddNewElementUsageAsync(ElementBase fromElementBase, ElementBase toElementBase);
+
+        /// <summary>
+        /// Gets the currently selected <see cref="ElementBase" /> — either an <see cref="ElementDefinition" /> or
+        /// an <see cref="ElementUsage" />. Mirrors <see cref="SelectedElementDefinition" /> for the
+        /// <see cref="ElementDefinition" /> case, but preserves the <see cref="ElementUsage" /> identity so the
+        /// delete affordance can target the usage rather than its containing definition.
+        /// </summary>
+        ElementBase SelectedElement { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user is currently confirming deletion of
+        /// <see cref="SelectedElement" />.
+        /// </summary>
+        bool IsOnDeletionMode { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> driving the delete-confirmation popup.
+        /// </summary>
+        IConfirmCancelPopupViewModel DeleteElementPopupViewModel { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="SelectedElement" /> is the iteration's
+        /// <see cref="Iteration.TopElement" />. The Delete affordance must be disabled in that case because
+        /// the iteration always requires a top element.
+        /// </summary>
+        bool IsSelectedElementTopElement { get; }
+
+        /// <summary>
+        /// Opens the delete-confirmation popup, composing a content message that names the selected
+        /// <see cref="ElementUsage" /> and its parent <see cref="ElementDefinition" />, or names the selected
+        /// <see cref="ElementDefinition" /> directly. No reference scan is performed: the COMET server
+        /// cascades cleanup of any referencing <see cref="ElementUsage" />s automatically when an
+        /// <see cref="ElementDefinition" /> is deleted.
+        /// </summary>
+        void OpenDeleteElementPopup();
+
+        /// <summary>
+        /// Performs the deletion of <see cref="SelectedElement" /> via the session service and clears the
+        /// selection on success.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous delete operation.</returns>
+        Task DeleteSelectedElementAsync();
     }
 }

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -32,9 +32,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     using CDP4DalCommon.Protocol.Operations;
 
     using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.Cache;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities;
+    using COMET.Web.Common.ViewModels.Components;
     using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Components.ModelEditor;
@@ -44,7 +46,10 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
     using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows;
 
+    using DevExpress.Blazor;
+
     using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Logging;
 
     using ReactiveUI;
 
@@ -62,6 +67,12 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// The <see cref="ICacheService" />
         /// </summary>
         private readonly ICacheService cacheService;
+
+        /// <summary>
+        /// The <see cref="ILogger{T}" /> used to record any exception thrown by the delete pipeline so that
+        /// it surfaces in the application log without aborting the popup-close path.
+        /// </summary>
+        private readonly ILogger<ModelEditorViewModel> logger;
 
         /// <summary>
         /// Backing field for <see cref="IsOnAddingParameterMode" />
@@ -94,15 +105,27 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         private Iteration sourceIteration;
 
         /// <summary>
+        /// Backing field for <see cref="SelectedElement" />.
+        /// </summary>
+        private ElementBase selectedElement;
+
+        /// <summary>
+        /// Backing field for <see cref="IsOnDeletionMode" />.
+        /// </summary>
+        private bool isOnDeletionMode;
+
+        /// <summary>
         /// Creates a new instance of <see cref="ModelEditorViewModel" />
         /// </summary>
         /// <param name="sessionService">the <see cref="ISessionService" /></param>
         /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
         /// <param name="cacheService">The <see cref="ICacheService"/></param>
-        public ModelEditorViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ICacheService cacheService) : base(sessionService, messageBus)
+        /// <param name="logger">The <see cref="ILogger{T}"/> used to record delete-pipeline exceptions.</param>
+        public ModelEditorViewModel(ISessionService sessionService, ICDPMessageBus messageBus, ICacheService cacheService, ILogger<ModelEditorViewModel> logger) : base(sessionService, messageBus)
         {
             this.sessionService = sessionService;
             this.cacheService = cacheService;
+            this.logger = logger;
             var eventCallbackFactory = new EventCallbackFactory();
 
             this.ElementDefinitionCreationViewModel = new ElementDefinitionCreationViewModel.ElementDefinitionCreationViewModel(sessionService, messageBus)
@@ -118,6 +141,15 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
             this.CopySettingsViewModel = new CopySettingsViewModel(cacheService)
             {
                 OnSaveSettings = eventCallbackFactory.Create(this, () => this.IsOnCopySettingsMode = false)
+            };
+
+            this.DeleteElementPopupViewModel = new ConfirmCancelPopupViewModel
+            {
+                HeaderText = "Delete element",
+                ConfirmRenderStyle = ButtonRenderStyle.Danger,
+                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                OnCancel = eventCallbackFactory.Create(this, this.OnDeleteCancelled),
+                OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedElementAsync)
             };
 
             this.InitializeSubscriptions([typeof(ElementBase)]);
@@ -231,6 +263,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         {
             // It is preferable to have a selection based on the Iid of the Thing
             this.ElementDefinitionDetailsViewModel.SelectedSystemNode = selectedElementBase;
+            this.SelectedElement = selectedElementBase;
 
             this.SelectedElementDefinition = selectedElementBase switch
             {
@@ -241,6 +274,147 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
 
             this.ElementDefinitionDetailsViewModel.Rows = this.SelectedElementDefinition?.Parameter.Select(x => new ElementDefinitionDetailsRowViewModel(x)).ToList();
             this.AddParameterViewModel.SetSelectedElementDefinition(this.SelectedElementDefinition);
+        }
+
+        /// <summary>
+        /// Gets the currently selected <see cref="ElementBase" /> — preserves the <see cref="ElementUsage" />
+        /// identity so that delete operates on the usage rather than its containing definition.
+        /// </summary>
+        public ElementBase SelectedElement
+        {
+            get => this.selectedElement;
+            private set => this.RaiseAndSetIfChanged(ref this.selectedElement, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user is currently confirming deletion of
+        /// <see cref="SelectedElement" />.
+        /// </summary>
+        public bool IsOnDeletionMode
+        {
+            get => this.isOnDeletionMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnDeletionMode, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> that drives the delete-confirmation popup.
+        /// </summary>
+        public IConfirmCancelPopupViewModel DeleteElementPopupViewModel { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="SelectedElement" /> is the iteration's
+        /// <see cref="Iteration.TopElement" /> — in which case deletion must be blocked because the
+        /// iteration always requires a top element.
+        /// </summary>
+        public bool IsSelectedElementTopElement
+            => this.SelectedElement is ElementDefinition selectedDefinition
+               && this.CurrentThing?.TopElement != null
+               && selectedDefinition.Iid == this.CurrentThing.TopElement.Iid;
+
+        /// <summary>
+        /// Opens the delete-confirmation popup with a content message describing the element to delete. No
+        /// reference scan is performed because the COMET server cascades cleanup of any referencing
+        /// <see cref="ElementUsage" />s when an <see cref="ElementDefinition" /> is deleted.
+        /// </summary>
+        public void OpenDeleteElementPopup()
+        {
+            if (this.SelectedElement is null || this.IsSelectedElementTopElement)
+            {
+                return;
+            }
+
+            this.DeleteElementPopupViewModel.ContentText = this.SelectedElement switch
+            {
+                ElementUsage usage => $"You are about to delete the Element Usage '{usage.Name}' ({usage.ShortName}) from {((ElementDefinition)usage.Container).Name}. This cannot be undone.",
+                ElementDefinition definition => $"You are about to delete the Element Definition '{definition.Name}' ({definition.ShortName}). This cannot be undone.",
+                _ => $"You are about to delete '{this.SelectedElement.Name}'. This cannot be undone."
+            };
+
+            this.DeleteElementPopupViewModel.IsVisible = true;
+            this.IsOnDeletionMode = true;
+        }
+
+        /// <summary>
+        /// Performs the deletion of <see cref="SelectedElement" /> using
+        /// <see cref="ISessionService.DeleteThingsWithNotification" /> with the cloned containing
+        /// <see cref="Thing" /> as the operation top container. Clears the selection on success and always
+        /// closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous delete operation.</returns>
+        public async Task DeleteSelectedElementAsync()
+        {
+            var thing = this.SelectedElement;
+
+            if (thing is null || this.IsSelectedElementTopElement)
+            {
+                this.CloseDeleteElementPopup();
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                var clonedContainer = thing.Container.Clone(false);
+                var clonedThing = thing.Clone(false);
+
+                var result = await this.sessionService.DeleteThingsWithNotification(clonedContainer, new[] { clonedThing }, GetDeletionNotificationDescription(thing));
+
+                if (result.IsSuccess)
+                {
+                    this.SelectElement(null);
+                }
+            }
+            catch (Exception exception)
+            {
+                this.logger?.LogError(exception, "An error occurred while deleting the {Kind} with iid {Iid}", thing.GetType().Name, thing.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+                this.CloseDeleteElementPopup();
+            }
+        }
+
+        /// <summary>
+        /// Closes the delete-confirmation popup and resets the deletion-mode flag.
+        /// </summary>
+        private void CloseDeleteElementPopup()
+        {
+            this.DeleteElementPopupViewModel.IsVisible = false;
+            this.IsOnDeletionMode = false;
+        }
+
+        /// <summary>
+        /// Cancellation handler bound to <see cref="IConfirmCancelPopupViewModel.OnCancel" />.
+        /// </summary>
+        private void OnDeleteCancelled()
+        {
+            this.CloseDeleteElementPopup();
+        }
+
+        /// <summary>
+        /// Builds a <see cref="NotificationDescription" /> used to surface the success / failure of a delete
+        /// operation through the existing <see cref="COMET.Web.Common.Services.NotificationService.INotificationService" /> pipeline.
+        /// </summary>
+        /// <param name="thing">The <see cref="ElementBase" /> being deleted.</param>
+        /// <returns>The <see cref="NotificationDescription" /> describing the operation.</returns>
+        private static NotificationDescription GetDeletionNotificationDescription(ElementBase thing)
+        {
+            var kind = thing switch
+            {
+                ElementUsage => "Element Usage",
+                ElementDefinition => "Element Definition",
+                _ => "Element"
+            };
+
+            var label = string.IsNullOrWhiteSpace(thing.Name) ? thing.ShortName : thing.Name;
+
+            return new NotificationDescription
+            {
+                OnSuccess = $"{kind} '{label}' deleted",
+                OnError = $"Failed to delete {kind} '{label}'"
+            };
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModel.cs
@@ -80,9 +80,14 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.Rows
         }
 
         /// <summary>
-        /// Update this row view model properties
+        /// Update this row view model properties.
+        /// Performs a diff-based update of <see cref="Rows" /> rather than Clear-then-AddRange so that the
+        /// bound DevExpress TreeView never receives a Reset notification followed by a re-population. A
+        /// Reset triggers DevExpress's internal mapping to enumerate and dispose its child bindings, and a
+        /// subsequent population during that enumeration raises "Collection was modified" — which also
+        /// leaves the parent's expand-indicator stale when the last child is removed.
         /// </summary>
-        /// <param name="elementDefinitionTreeRow">The <see cref="ElementDefinitionTreeRowViewModel" /> to use for updating</param>
+        /// <param name="elementDefinitionTreeRow">The <see cref="ElementDefinitionTreeRowViewModel" /> to use for updating.</param>
         public void UpdateProperties(ElementDefinitionTreeRowViewModel elementDefinitionTreeRow)
         {
             ArgumentNullException.ThrowIfNull(elementDefinitionTreeRow);
@@ -90,13 +95,37 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.Rows
             base.UpdateProperties(elementDefinitionTreeRow);
             this.IsTopElement = elementDefinitionTreeRow.isTopElement;
 
-            this.Rows.Clear();
+            var containedElements = (elementDefinitionTreeRow.ElementBase as ElementDefinition)?.ContainedElement
+                                    ?? (IEnumerable<ElementUsage>)Array.Empty<ElementUsage>();
 
-            var elementUsages = (elementDefinitionTreeRow.ElementBase as ElementDefinition)?.ContainedElement;
+            var desiredIids = containedElements.Select(x => x.Iid).ToHashSet();
 
-            if (elementUsages != null)
+            for (var i = this.Rows.Count - 1; i >= 0; i--)
             {
-                this.Rows.AddRange(elementUsages.Select(x => new ElementUsageTreeRowViewModel(x)).OrderBy(x => x.ElementName));
+                if (!desiredIids.Contains(this.Rows[i].ElementBase.Iid))
+                {
+                    this.Rows.RemoveAt(i);
+                }
+            }
+
+            var existingIids = this.Rows.Select(r => r.ElementBase.Iid).ToHashSet();
+
+            var toAdd = containedElements
+                .Where(x => !existingIids.Contains(x.Iid))
+                .Select(x => new ElementUsageTreeRowViewModel(x))
+                .OrderBy(x => x.ElementName, StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (var newRow in toAdd)
+            {
+                var insertAt = 0;
+
+                while (insertAt < this.Rows.Count
+                       && string.Compare(this.Rows[insertAt].ElementName, newRow.ElementName, StringComparison.InvariantCultureIgnoreCase) < 0)
+                {
+                    insertAt++;
+                }
+
+                this.Rows.Insert(insertAt, newRow);
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
 #771 — Web-app-friendly delete for ElementDefinition / ElementUsage
  - Danger-styled Delete button in the details-panel action header (visible only with selection; disabled with tooltip when the selected element is the iteration's
  TopElement).
  - Reuses ConfirmCancelPopup with a uniform message — no reference-count warning (server cascades cleanup of referencing usages).
  - ModelEditorViewModel exposes SelectedElement, IsSelectedElementTopElement, IsOnDeletionMode, DeleteElementPopupViewModel, OpenDeleteElementPopup,
  DeleteSelectedElementAsync. Delete clones container + thing, calls SessionService.DeleteThingsWithNotification, clears selection on success, and finally-closes the popup
   so a thrown exception can no longer leave the dialog open. ILogger<ModelEditorViewModel> injected for error logging.


<!-- Thanks for contributing to COMET-WEB! -->

