### PR TITLE
[Add] self-service "Edit my profile" in the Session menu; fixes #722

### DIFF
--- a/COMET.Web.Common.Tests/Shared/TopMenuTestFixture.cs
+++ b/COMET.Web.Common.Tests/Shared/TopMenuTestFixture.cs
@@ -43,6 +43,7 @@ namespace COMET.Web.Common.Tests.Shared
     using COMET.Web.Common.Shared.TopMenuEntry;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Shared.TopMenuEntry;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
 
     using DevExpress.Blazor;
 
@@ -106,6 +107,7 @@ namespace COMET.Web.Common.Tests.Shared
             this.context.Services.AddSingleton(this.sessionService.Object);
             this.context.Services.AddSingleton(this.authenticationService.Object);
             this.context.Services.AddSingleton(this.autoRefreshService.Object);
+            this.context.Services.AddSingleton<IPersonEditViewModel>(new Mock<IPersonEditViewModel>().Object);
             this.context.Services.AddSingleton<ISessionMenuViewModel, SessionMenuViewModel>();
             this.context.Services.AddSingleton<IModelMenuViewModel, ModelMenuViewModel>();
             this.context.Services.AddSingleton<IAuthorizedMenuEntryViewModel, AuthorizedMenuEntryViewModel>();

--- a/COMET.Web.Common.Tests/ViewModels/Shared/TopMenuEntry/PersonEdit/PersonEditViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Shared/TopMenuEntry/PersonEdit/PersonEditViewModelTestFixture.cs
@@ -1,0 +1,338 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="PersonEditViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry.PersonEdit
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Model;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
+
+    using FluentResults;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PersonEditViewModelTestFixture
+    {
+        /// <summary>
+        /// The mocked session service used to provide the SiteDirectory and capture write calls.
+        /// </summary>
+        private Mock<ISessionService> sessionService;
+
+        /// <summary>
+        /// The active <see cref="Person" /> used as the editable target.
+        /// </summary>
+        private Person activePerson;
+
+        /// <summary>
+        /// The <see cref="SiteDirectory" /> hosting the active person.
+        /// </summary>
+        private SiteDirectory siteDirectory;
+
+        /// <summary>
+        /// The pre-existing <see cref="EmailAddress" /> on the active person.
+        /// </summary>
+        private EmailAddress existingEmail;
+
+        /// <summary>
+        /// The pre-existing <see cref="TelephoneNumber" /> on the active person.
+        /// </summary>
+        private TelephoneNumber existingTelephone;
+
+        /// <summary>
+        /// The view model under test.
+        /// </summary>
+        private PersonEditViewModel viewModel;
+
+        /// <summary>
+        /// Builds a SiteDirectory with one Person carrying one e-mail and one telephone, configures the
+        /// session-service mock to return the SiteDirectory and to succeed on writes, and constructs
+        /// the view model.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.existingEmail = new EmailAddress { Iid = Guid.NewGuid(), Value = "alice@example.com", VcardType = VcardEmailAddressKind.WORK };
+            this.existingTelephone = new TelephoneNumber { Iid = Guid.NewGuid(), Value = "+31 6 12345678" };
+            this.existingTelephone.VcardType.Add(VcardTelephoneNumberKind.WORK);
+
+            this.activePerson = new Person { Iid = Guid.NewGuid(), GivenName = "Alice", Surname = "Smith", OrganizationalUnit = "Systems" };
+            this.activePerson.EmailAddress.Add(this.existingEmail);
+            this.activePerson.TelephoneNumber.Add(this.existingTelephone);
+            this.activePerson.DefaultEmailAddress = this.existingEmail;
+            this.activePerson.DefaultTelephoneNumber = this.existingTelephone;
+
+            this.siteDirectory = new SiteDirectory { Iid = Guid.NewGuid() };
+            this.siteDirectory.Person.Add(this.activePerson);
+
+            this.sessionService = new Mock<ISessionService>();
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(this.siteDirectory);
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            var logger = new Mock<ILogger<PersonEditViewModel>>();
+
+            this.viewModel = new PersonEditViewModel(this.sessionService.Object, logger.Object);
+        }
+
+        /// <summary>
+        /// Disposes of the view model.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyInitializeFromActivePerson()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.CurrentPerson, Is.SameAs(this.activePerson));
+                Assert.That(this.viewModel.GivenName, Is.EqualTo(this.activePerson.GivenName));
+                Assert.That(this.viewModel.Surname, Is.EqualTo(this.activePerson.Surname));
+                Assert.That(this.viewModel.OrganizationalUnit, Is.EqualTo(this.activePerson.OrganizationalUnit));
+                Assert.That(this.viewModel.EmailAddresses, Has.Count.EqualTo(1));
+                Assert.That(this.viewModel.EmailAddresses[0].Original, Is.SameAs(this.existingEmail));
+                Assert.That(this.viewModel.EmailAddresses[0].IsDefault, Is.True);
+                Assert.That(this.viewModel.TelephoneNumbers, Has.Count.EqualTo(1));
+                Assert.That(this.viewModel.TelephoneNumbers[0].Original, Is.SameAs(this.existingTelephone));
+                Assert.That(this.viewModel.TelephoneNumbers[0].IsDefault, Is.True);
+                Assert.That(this.viewModel.IsPasswordEditEnabled, Is.False);
+                Assert.That(this.viewModel.Password, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyIsValidRequiresGivenAndSurname()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            Assert.That(this.viewModel.IsValid, Is.True);
+
+            this.viewModel.GivenName = string.Empty;
+            Assert.That(this.viewModel.IsValid, Is.False, "Empty GivenName must invalidate the form.");
+
+            this.viewModel.GivenName = "Alice";
+            this.viewModel.Surname = string.Empty;
+            Assert.That(this.viewModel.IsValid, Is.False, "Empty Surname must invalidate the form.");
+        }
+
+        [Test]
+        public void VerifyIsValidRequiresMatchingPasswordWhenEnabled()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            this.viewModel.IsPasswordEditEnabled = true;
+            Assert.That(this.viewModel.IsValid, Is.False, "Empty new password must invalidate.");
+
+            this.viewModel.Password = "newSecret";
+            this.viewModel.PasswordConfirmation = "different";
+            Assert.That(this.viewModel.IsValid, Is.False, "Mismatched confirmation must invalidate.");
+
+            this.viewModel.PasswordConfirmation = "newSecret";
+            Assert.That(this.viewModel.IsValid, Is.True);
+        }
+
+        [Test]
+        public void VerifyIsValidRequiresEmailValuePresent()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            this.viewModel.AddEmail();
+            Assert.That(this.viewModel.IsValid, Is.False, "An empty newly added e-mail row must invalidate the form.");
+
+            this.viewModel.EmailAddresses[^1].Value = "second@example.com";
+            Assert.That(this.viewModel.IsValid, Is.True);
+        }
+
+        [Test]
+        public async Task VerifySaveCallsSessionServiceWithCorrectContainerAndAppliedFields()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            this.viewModel.GivenName = "Alicia";
+            this.viewModel.Surname = "Smithee";
+            this.viewModel.OrganizationalUnit = "Newer Org";
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.Is<Thing>(t => t is SiteDirectory && t.Iid == this.siteDirectory.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<Person>().Any(p => p.Iid == this.activePerson.Iid && p.GivenName == "Alicia" && p.Surname == "Smithee" && p.OrganizationalUnit == "Newer Org")),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySavePersistsPasswordOnlyWhenEnabled()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<Person>().Any(p => p.Password == this.activePerson.Password)),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+
+            this.viewModel.IsPasswordEditEnabled = true;
+            this.viewModel.Password = "newSecret";
+            this.viewModel.PasswordConfirmation = "newSecret";
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<Person>().Any(p => p.Password == "newSecret")),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySaveAddsNewEmailIntoCollectionAndThings()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            this.viewModel.AddEmail();
+            this.viewModel.EmailAddresses[^1].Value = "second@example.com";
+            this.viewModel.EmailAddresses[^1].VcardType = VcardEmailAddressKind.HOME;
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<EmailAddress>().Any(e => e.Value == "second@example.com" && e.VcardType == VcardEmailAddressKind.HOME)
+                                                          && c.OfType<Person>().Any(p => p.EmailAddress.Any(e => e.Value == "second@example.com"))),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySaveSetsDefaultEmailWhenIsDefault()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            this.viewModel.EmailAddresses[0].IsDefault = false;
+            this.viewModel.AddEmail();
+            this.viewModel.EmailAddresses[^1].Value = "second@example.com";
+            this.viewModel.EmailAddresses[^1].IsDefault = true;
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<Person>().Any(p => p.DefaultEmailAddress != null && p.DefaultEmailAddress.Value == "second@example.com")),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySaveAddsNewTelephoneIntoCollectionAndThings()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            this.viewModel.AddTelephone();
+            this.viewModel.TelephoneNumbers[^1].Value = "+31 6 99999999";
+            this.viewModel.TelephoneNumbers[^1].VcardType = new[] { VcardTelephoneNumberKind.HOME };
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<TelephoneNumber>().Any(t => t.Value == "+31 6 99999999" && t.VcardType.Contains(VcardTelephoneNumberKind.HOME))
+                                                          && c.OfType<Person>().Any(p => p.TelephoneNumber.Any(t => t.Value == "+31 6 99999999"))),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySaveFiresOnSavedOnSuccess()
+        {
+            this.viewModel.Initialize(this.activePerson);
+
+            var fired = false;
+            this.viewModel.OnSaved = EventCallback.Factory.Create(this, () => fired = true);
+
+            await this.viewModel.SaveAsync();
+
+            Assert.That(fired, Is.True);
+        }
+
+        [Test]
+        public async Task VerifySaveDoesNotFireOnSavedOnFailure()
+        {
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Fail("write failed"));
+
+            this.viewModel.Initialize(this.activePerson);
+
+            var fired = false;
+            this.viewModel.OnSaved = EventCallback.Factory.Create(this, () => fired = true);
+
+            await this.viewModel.SaveAsync();
+
+            Assert.That(fired, Is.False);
+        }
+
+        [Test]
+        public async Task VerifySaveIsNoOpWhenInvalid()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            this.viewModel.GivenName = string.Empty;
+
+            await this.viewModel.SaveAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
+                Times.Never);
+        }
+
+        [Test]
+        public void VerifyRemoveEmailDropsRowAndRemembersOriginal()
+        {
+            this.viewModel.Initialize(this.activePerson);
+            var row = this.viewModel.EmailAddresses[0];
+
+            this.viewModel.RemoveEmail(row);
+
+            Assert.That(this.viewModel.EmailAddresses, Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/ViewModels/Shared/TopMenuEntry/SessionMenuViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Shared/TopMenuEntry/SessionMenuViewModelTestFixture.cs
@@ -23,11 +23,14 @@
 
 namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry
 {
+    using CDP4Common.SiteDirectoryData;
+
     using CDP4Dal;
 
     using COMET.Web.Common.Services.NotificationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.ViewModels.Shared.TopMenuEntry;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
 
     using Moq;
 
@@ -40,6 +43,7 @@ namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry
         private Mock<ISessionService> sessionService;
         private Mock<IAutoRefreshService> autoRefreshService;
         private Mock<INotificationService> notificationService;
+        private Mock<IPersonEditViewModel> personEditViewModel;
         private CDPMessageBus messageBus;
 
         [SetUp]
@@ -48,9 +52,11 @@ namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry
             this.sessionService = new Mock<ISessionService>();
             this.autoRefreshService = new Mock<IAutoRefreshService>();
             this.notificationService = new Mock<INotificationService>();
+            this.personEditViewModel = new Mock<IPersonEditViewModel>();
+            this.personEditViewModel.SetupAllProperties();
             this.messageBus = new CDPMessageBus();
 
-            this.viewModel = new SessionMenuViewModel(this.sessionService.Object, this.autoRefreshService.Object, this.notificationService.Object, this.messageBus);
+            this.viewModel = new SessionMenuViewModel(this.sessionService.Object, this.autoRefreshService.Object, this.notificationService.Object, this.messageBus, this.personEditViewModel.Object);
         }
 
         [TearDown]
@@ -68,6 +74,8 @@ namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry
                 Assert.That(this.viewModel.AutoRefreshService, Is.EqualTo(this.autoRefreshService.Object));
                 Assert.That(this.viewModel.SessionService, Is.EqualTo(this.sessionService.Object));
                 Assert.That(this.viewModel.NotificationService, Is.EqualTo(this.notificationService.Object));
+                Assert.That(this.viewModel.PersonEditViewModel, Is.EqualTo(this.personEditViewModel.Object));
+                Assert.That(this.viewModel.IsOnEditPersonMode, Is.False);
             });
         }
 
@@ -76,6 +84,40 @@ namespace COMET.Web.Common.Tests.ViewModels.Shared.TopMenuEntry
         {
             await this.viewModel.RefreshSession();
             this.sessionService.Verify(x => x.RefreshSession(), Times.Once);
+        }
+
+        [Test]
+        public void VerifyOpenEditPersonPopupInitializesFromActivePerson()
+        {
+            var activePerson = new Person { Iid = Guid.NewGuid(), GivenName = "Alice", Surname = "Smith" };
+
+            var session = new Mock<ISession>();
+            session.Setup(x => x.ActivePerson).Returns(activePerson);
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+
+            this.viewModel.OpenEditPersonPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnEditPersonMode, Is.True);
+                this.personEditViewModel.Verify(x => x.Initialize(activePerson), Times.Once);
+            });
+        }
+
+        [Test]
+        public void VerifyOpenEditPersonPopupNoActivePersonIsNoOp()
+        {
+            var session = new Mock<ISession>();
+            session.Setup(x => x.ActivePerson).Returns((Person)null);
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+
+            this.viewModel.OpenEditPersonPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnEditPersonMode, Is.False);
+                this.personEditViewModel.Verify(x => x.Initialize(It.IsAny<Person>()), Times.Never);
+            });
         }
     }
 }

--- a/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
+++ b/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
@@ -1,0 +1,144 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Shared.PersonEdit
+@using CDP4Common.SiteDirectoryData
+@using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit
+@inherits DisposableComponent
+
+@if (this.ViewModel is not null)
+{
+    <DxFormLayout CssClass="w-100">
+        <DxFormLayoutTabPages>
+            <DxFormLayoutTabPage Caption="Basic">
+                <DxFormLayoutItem Caption="Given Name:" ColSpanMd="10">
+                    <DxTextBox Id="givenNameInput"
+                               Text="@(this.ViewModel.GivenName)"
+                               TextChanged="@((string newValue) => this.ViewModel.GivenName = newValue)"
+                               BindValueMode="BindValueMode.OnInput"/>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Surname:" ColSpanMd="10">
+                    <DxTextBox Id="surnameInput"
+                               Text="@(this.ViewModel.Surname)"
+                               TextChanged="@((string newValue) => this.ViewModel.Surname = newValue)"
+                               BindValueMode="BindValueMode.OnInput"/>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Organizational Unit:" ColSpanMd="10">
+                    <DxTextBox Id="organizationalUnitInput"
+                               Text="@(this.ViewModel.OrganizationalUnit)"
+                               TextChanged="@((string newValue) => this.ViewModel.OrganizationalUnit = newValue)"
+                               BindValueMode="BindValueMode.OnInput"/>
+                </DxFormLayoutItem>
+            </DxFormLayoutTabPage>
+            <DxFormLayoutTabPage Caption="E-Mail">
+                @foreach (var email in this.ViewModel.EmailAddresses)
+                {
+                    <DxFormLayoutItem ColSpanMd="4" Caption="Kind:">
+                        <DxComboBox Data="@(Enum.GetValues(typeof(VcardEmailAddressKind)).Cast<VcardEmailAddressKind>())"
+                                    @bind-Value="@(email.VcardType)"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="5" Caption="E-mail:">
+                        <DxTextBox @bind-Text="@(email.Value)"
+                                   BindValueMode="BindValueMode.OnInput"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="2" Caption="Default:">
+                        <DxCheckBox @bind-Checked="@(email.IsDefault)"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="1">
+                        <DxButton IconCssClass="oi oi-trash"
+                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyleMode="ButtonRenderStyleMode.Text"
+                                  Click="@(() => this.ViewModel.RemoveEmail(email))"
+                                  title="Remove this e-mail"/>
+                    </DxFormLayoutItem>
+                }
+                <DxFormLayoutItem ColSpanMd="12">
+                    <DxButton Id="addEmailButton"
+                              Text="Add e-mail"
+                              IconCssClass="oi oi-plus"
+                              Click="@(this.ViewModel.AddEmail)"/>
+                </DxFormLayoutItem>
+            </DxFormLayoutTabPage>
+            <DxFormLayoutTabPage Caption="Telephone Number">
+                @foreach (var telephone in this.ViewModel.TelephoneNumbers)
+                {
+                    <DxFormLayoutItem ColSpanMd="4" Caption="Kinds:">
+                        <DxTagBox Data="@(Enum.GetValues(typeof(VcardTelephoneNumberKind)).Cast<VcardTelephoneNumberKind>())"
+                                  @bind-Values="@(telephone.VcardType)"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="5" Caption="Number:">
+                        <DxTextBox @bind-Text="@(telephone.Value)"
+                                   BindValueMode="BindValueMode.OnInput"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="2" Caption="Default:">
+                        <DxCheckBox @bind-Checked="@(telephone.IsDefault)"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem ColSpanMd="1">
+                        <DxButton IconCssClass="oi oi-trash"
+                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyleMode="ButtonRenderStyleMode.Text"
+                                  Click="@(() => this.ViewModel.RemoveTelephone(telephone))"
+                                  title="Remove this telephone"/>
+                    </DxFormLayoutItem>
+                }
+                <DxFormLayoutItem ColSpanMd="12">
+                    <DxButton Id="addTelephoneButton"
+                              Text="Add telephone"
+                              IconCssClass="oi oi-plus"
+                              Click="@(this.ViewModel.AddTelephone)"/>
+                </DxFormLayoutItem>
+            </DxFormLayoutTabPage>
+            <DxFormLayoutTabPage Caption="Password">
+                <DxFormLayoutItem Caption="Change my password:" ColSpanMd="10">
+                    <DxCheckBox Id="changePasswordCheckBox"
+                                @bind-Checked="@(this.ViewModel.IsPasswordEditEnabled)"/>
+                </DxFormLayoutItem>
+                @if (this.ViewModel.IsPasswordEditEnabled)
+                {
+                    <DxFormLayoutItem Caption="New password:" ColSpanMd="10">
+                        <DxTextBox Id="passwordInput"
+                                   Text="@(this.ViewModel.Password)"
+                                   TextChanged="@((string newValue) => this.ViewModel.Password = newValue)"
+                                   BindValueMode="BindValueMode.OnInput"
+                                   Password="true"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Confirm password:" ColSpanMd="10">
+                        <DxTextBox Id="passwordConfirmationInput"
+                                   Text="@(this.ViewModel.PasswordConfirmation)"
+                                   TextChanged="@((string newValue) => this.ViewModel.PasswordConfirmation = newValue)"
+                                   BindValueMode="BindValueMode.OnInput"
+                                   Password="true"/>
+                    </DxFormLayoutItem>
+                }
+            </DxFormLayoutTabPage>
+        </DxFormLayoutTabPages>
+    </DxFormLayout>
+    <div class="modal-footer">
+        <DxButton Id="cancelPersonEdit"
+                  Text="Cancel"
+                  RenderStyle="ButtonRenderStyle.Secondary"
+                  Click="@(this.OnCancel)"
+                  Enabled="@(!this.ViewModel.IsLoading)"/>
+        <DxButton Id="savePersonEdit"
+                  Text="Save"
+                  RenderStyle="ButtonRenderStyle.Primary"
+                  Click="@(this.ViewModel.SaveAsync)"
+                  Enabled="@(this.ViewModel.IsValid && !this.ViewModel.IsLoading)"/>
+    </div>
+}

--- a/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor.cs
+++ b/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor.cs
@@ -1,0 +1,106 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="PersonEditForm.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Shared.PersonEdit
+{
+    using System.Collections.Specialized;
+
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
+
+    using Microsoft.AspNetCore.Components;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Code-behind for <see cref="PersonEditForm" />, the self-service profile editor surfaced from the
+    /// session menu. Hosts a tabbed <c>DxFormLayout</c> bound to a <see cref="IPersonEditViewModel" />
+    /// and re-renders whenever the underlying VM signals a change worth showing.
+    /// </summary>
+    public partial class PersonEditForm : DisposableComponent
+    {
+        /// <summary>
+        /// Gets or sets the view model driving the form.
+        /// </summary>
+        [Parameter]
+        public IPersonEditViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked when the user clicks Cancel. Bound by the host popup so it
+        /// can close itself.
+        /// </summary>
+        [Parameter]
+        public EventCallback OnCancel { get; set; }
+
+        /// <summary>
+        /// Subscribes to the VM properties that influence the form's enabled / disabled state and the
+        /// row collections so additions / removals re-render the e-mail and telephone tabs.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            if (this.ViewModel is null)
+            {
+                return;
+            }
+
+            this.Disposables.Add(this.WhenAnyValue(
+                    x => x.ViewModel.IsValid,
+                    x => x.ViewModel.IsLoading,
+                    x => x.ViewModel.IsPasswordEditEnabled,
+                    x => x.ViewModel.GivenName,
+                    x => x.ViewModel.Surname)
+                .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+            this.ViewModel.EmailAddresses.CollectionChanged += this.OnRowCollectionChanged;
+            this.ViewModel.TelephoneNumbers.CollectionChanged += this.OnRowCollectionChanged;
+        }
+
+        /// <summary>
+        /// Detaches the row-collection handlers so the component does not leak event subscriptions when
+        /// the popup is recycled.
+        /// </summary>
+        /// <param name="disposing">Whether managed resources should be disposed.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && this.ViewModel is not null)
+            {
+                this.ViewModel.EmailAddresses.CollectionChanged -= this.OnRowCollectionChanged;
+                this.ViewModel.TelephoneNumbers.CollectionChanged -= this.OnRowCollectionChanged;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Re-renders the form when the user adds or removes a contact row.
+        /// </summary>
+        /// <param name="sender">The originating collection.</param>
+        /// <param name="args">The change arguments.</param>
+        private void OnRowCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+        {
+            this.InvokeAsync(this.StateHasChanged);
+        }
+    }
+}

--- a/COMET.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/COMET.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ namespace COMET.Web.Common.Extensions
     using COMET.Web.Common.ViewModels.Components.Publications;
     using COMET.Web.Common.ViewModels.Components.Selectors;
     using COMET.Web.Common.ViewModels.Shared.TopMenuEntry;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
 
     using DevExpress.Blazor;
 
@@ -111,6 +112,7 @@ namespace COMET.Web.Common.Extensions
             serviceProvider.AddTransient<IIndexViewModel, IndexViewModel>();
             serviceProvider.AddScoped<IAuthorizedMenuEntryViewModel, AuthorizedMenuEntryViewModel>();
             serviceProvider.AddScoped<ISessionMenuViewModel, SessionMenuViewModel>();
+            serviceProvider.AddTransient<IPersonEditViewModel, PersonEditViewModel>();
             serviceProvider.AddScoped<IModelMenuViewModel, ModelMenuViewModel>();
             serviceProvider.AddTransient<IIterationSelectorViewModel, IterationSelectorViewModel>();
             serviceProvider.AddTransient<IEngineeringModelSelectorViewModel, EngineeringModelSelectorViewModel>();

--- a/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
+++ b/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
@@ -18,6 +18,7 @@
 //   limitations under the License.
 ------------------------------------------------------------------------------->
 @namespace COMET.Web.Common.Shared.TopMenuEntry
+@using COMET.Web.Common.Components.Shared.PersonEdit
 @inherits AuthorizedMenuEntry
 
 <DxMenuItem Name="session-entry" Text="Session" IconCssClass="icon icon-database" Enabled="@this.AuthorizedMenuEntryViewModel.IsAuthenticated" @bind-Expanded="@this.Expanded">
@@ -60,10 +61,25 @@
                 sec
             </div>
             <div class="session__buttons">
-                <DxButton Id="refresh-button" CssClass="btn btn-connect right-margin" Text="@this.RefreshButtonText" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
-                <DxButton Id="logout-button" CssClass="btn btn-connect left-margin" Text="Log out" Click="@this.Logout"/>
+                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" Text="Edit my profile" IconCssClass="oi oi-person" Click="@(this.OnEditProfileClick)"/>
+            </div>
+
+            <div class="session__buttons session__buttons--secondary">
+                <DxButton Id="refresh-button" CssClass="btn btn-connect" Text="@this.RefreshButtonText" IconCssClass="oi oi-reload" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
+                <DxButton Id="logout-button" CssClass="btn btn-connect" Text="Log out" IconCssClass="oi oi-account-logout" Click="@this.Logout"/>
             </div>
         </div>
     </SubMenuTemplate>
 </DxMenuItem>
+
+<DxPopup @bind-Visible="@this.ViewModel.IsOnEditPersonMode"
+         CloseOnOutsideClick="false"
+         HeaderText="Edit my profile"
+         Width="50vw"
+         ShowCloseButton="true">
+    <BodyContentTemplate>
+        <PersonEditForm ViewModel="@this.ViewModel.PersonEditViewModel"
+                        OnCancel="@(() => this.ViewModel.IsOnEditPersonMode = false)"/>
+    </BodyContentTemplate>
+</DxPopup>
 

--- a/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor.cs
+++ b/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor.cs
@@ -73,6 +73,15 @@ namespace COMET.Web.Common.Shared.TopMenuEntry
         }
 
         /// <summary>
+        /// Closes the dropdown and asks the view model to open the self-service "Edit my profile" popup.
+        /// </summary>
+        public void OnEditProfileClick()
+        {
+            this.Expanded = false;
+            this.ViewModel.OpenEditPersonPopup();
+        }
+
+        /// <summary>
         /// Method executed everytime the refresh button is clicked
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ISessionMenuViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ISessionMenuViewModel.cs
@@ -28,6 +28,7 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
     using COMET.Web.Common.Services.NotificationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.DisposableObject;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
 
     /// <summary>
     /// View model that handles the menu entry related to the <see cref="ISession" />
@@ -54,5 +55,26 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
         Task RefreshSession();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the self-service "Edit my profile" popup is open.
+        /// Bound to the <see cref="DevExpress.Blazor.DxPopup" /> visibility from
+        /// <see cref="Shared.TopMenuEntry.SessionMenu" />.
+        /// </summary>
+        bool IsOnEditPersonMode { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IPersonEditViewModel" /> driving the self-service "Edit my profile"
+        /// dialog. Initialized from the active session's <see cref="CDP4Common.SiteDirectoryData.Person" />
+        /// every time <see cref="OpenEditPersonPopup" /> is invoked.
+        /// </summary>
+        IPersonEditViewModel PersonEditViewModel { get; }
+
+        /// <summary>
+        /// Initializes <see cref="PersonEditViewModel" /> from
+        /// <c>SessionService.Session.ActivePerson</c> and opens the popup. No-op when there is no
+        /// active person (e.g. the session is not yet authenticated).
+        /// </summary>
+        void OpenEditPersonPopup();
     }
 }

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/EmailAddressRowViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/EmailAddressRowViewModel.cs
@@ -1,0 +1,114 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EmailAddressRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Editable row representing a single <see cref="EmailAddress" /> belonging to the active
+    /// <see cref="Person" />. Carries the editable fields plus a reference to the original SDK instance
+    /// (or <c>null</c> when the row was added in the form) so that <see cref="PersonEditViewModel" />
+    /// can decide whether the change is a create, update, or no-op when persisting.
+    /// </summary>
+    public class EmailAddressRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="VcardType" />.
+        /// </summary>
+        private VcardEmailAddressKind vcardType;
+
+        /// <summary>
+        /// Backing field for <see cref="Value" />.
+        /// </summary>
+        private string value;
+
+        /// <summary>
+        /// Backing field for <see cref="IsDefault" />.
+        /// </summary>
+        private bool isDefault;
+
+        /// <summary>
+        /// Initializes a new <see cref="EmailAddressRowViewModel" /> wrapping an existing SDK
+        /// <see cref="EmailAddress" />.
+        /// </summary>
+        /// <param name="original">The original SDK <see cref="EmailAddress" /> being wrapped.</param>
+        /// <param name="isDefault">Whether this email is the active person's <see cref="Person.DefaultEmailAddress" />.</param>
+        public EmailAddressRowViewModel(EmailAddress original, bool isDefault)
+        {
+            this.Original = original;
+            this.vcardType = original.VcardType;
+            this.value = original.Value;
+            this.isDefault = isDefault;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="EmailAddressRowViewModel" /> representing an empty entry the user
+        /// is about to fill in. <see cref="Original" /> stays <c>null</c> so the save pipeline knows to
+        /// create a brand-new <see cref="EmailAddress" /> on persist.
+        /// </summary>
+        public EmailAddressRowViewModel()
+        {
+            this.vcardType = VcardEmailAddressKind.WORK;
+            this.value = string.Empty;
+            this.isDefault = false;
+        }
+
+        /// <summary>
+        /// Gets the original SDK <see cref="EmailAddress" /> wrapped by this row, or <c>null</c> when the
+        /// row was added in the form and has not yet been persisted.
+        /// </summary>
+        public EmailAddress Original { get; }
+
+        /// <summary>
+        /// Gets or sets the editable <see cref="VcardEmailAddressKind" /> displayed by the form.
+        /// </summary>
+        public VcardEmailAddressKind VcardType
+        {
+            get => this.vcardType;
+            set => this.RaiseAndSetIfChanged(ref this.vcardType, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the editable e-mail value displayed by the form.
+        /// </summary>
+        public string Value
+        {
+            get => this.value;
+            set => this.RaiseAndSetIfChanged(ref this.value, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this row is the default e-mail of the active person.
+        /// Setting this to <c>true</c> in the form does not automatically clear the flag on the other
+        /// rows — <see cref="PersonEditViewModel" /> takes responsibility for that during persist.
+        /// </summary>
+        public bool IsDefault
+        {
+            get => this.isDefault;
+            set => this.RaiseAndSetIfChanged(ref this.isDefault, value);
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/IPersonEditViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/IPersonEditViewModel.cs
@@ -1,0 +1,155 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IPersonEditViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit
+{
+    using System.Collections.ObjectModel;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Utilities.DisposableObject;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// View model driving the self-service "Edit my profile" dialog. Wraps the active
+    /// <see cref="Person" /> and exposes the editable surface (identity, contact information, password)
+    /// plus a save pipeline that writes the changes back through the existing session-service write API.
+    /// </summary>
+    public interface IPersonEditViewModel : IDisposableObject
+    {
+        /// <summary>
+        /// Gets the live <see cref="Person" /> currently bound to the form, captured by
+        /// <see cref="Initialize" />. <c>null</c> until <see cref="Initialize" /> is called.
+        /// </summary>
+        Person CurrentPerson { get; }
+
+        /// <summary>
+        /// Gets or sets the editable Given Name. Initialized from <see cref="CurrentPerson" /> by
+        /// <see cref="Initialize" /> and applied to the cloned person on save.
+        /// </summary>
+        string GivenName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the editable Surname. Initialized from <see cref="CurrentPerson" /> by
+        /// <see cref="Initialize" /> and applied to the cloned person on save.
+        /// </summary>
+        string Surname { get; set; }
+
+        /// <summary>
+        /// Gets or sets the editable Organizational Unit. Initialized from <see cref="CurrentPerson" />
+        /// by <see cref="Initialize" /> and applied to the cloned person on save.
+        /// </summary>
+        string OrganizationalUnit { get; set; }
+
+        /// <summary>
+        /// Gets the editable e-mail rows. Each row preserves a reference to its underlying SDK
+        /// <see cref="EmailAddress" /> when one exists; rows added in the form have <c>null</c>
+        /// originals and are persisted as new entries.
+        /// </summary>
+        ObservableCollection<EmailAddressRowViewModel> EmailAddresses { get; }
+
+        /// <summary>
+        /// Gets the editable telephone rows.
+        /// </summary>
+        ObservableCollection<TelephoneNumberRowViewModel> TelephoneNumbers { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user has opted in to changing the password during
+        /// this save. When <c>false</c>, the cloned person's <see cref="Person.Password" /> is left
+        /// untouched.
+        /// </summary>
+        bool IsPasswordEditEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new password to apply when <see cref="IsPasswordEditEnabled" /> is <c>true</c>.
+        /// </summary>
+        string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password confirmation. Must equal <see cref="Password" /> for
+        /// <see cref="IsValid" /> to be <c>true</c> when the password is being changed.
+        /// </summary>
+        string PasswordConfirmation { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the form's combined state is acceptable for persistence:
+        /// <see cref="GivenName" /> and <see cref="Surname" /> non-empty, no contact row has an empty
+        /// value, and — if the password is being changed — the password and confirmation match.
+        /// </summary>
+        bool IsValid { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a save operation is currently in flight. Bound by the form's
+        /// loading indicator and used to disable the Save button while the SDK call runs.
+        /// </summary>
+        bool IsLoading { get; }
+
+        /// <summary>
+        /// Gets or sets the callback fired after a successful save so the host (the SessionMenu popup)
+        /// can close itself.
+        /// </summary>
+        EventCallback OnSaved { get; set; }
+
+        /// <summary>
+        /// Captures the supplied <see cref="Person" /> as <see cref="CurrentPerson" />, projects its
+        /// identity / contact fields into the editable properties, resets the password state, and
+        /// repopulates the row collections from the person's existing emails and telephone numbers.
+        /// </summary>
+        /// <param name="person">The active session's <see cref="Person" /> the form should edit.</param>
+        void Initialize(Person person);
+
+        /// <summary>
+        /// Adds an empty editable e-mail row so the user can fill in a new entry. The row's
+        /// <see cref="EmailAddressRowViewModel.Original" /> is <c>null</c>, marking it as a create on save.
+        /// </summary>
+        void AddEmail();
+
+        /// <summary>
+        /// Removes the supplied row. New rows (those with no <see cref="EmailAddressRowViewModel.Original" />)
+        /// are simply dropped from the collection; existing rows are remembered so the save pipeline can
+        /// also delete them on the server.
+        /// </summary>
+        /// <param name="row">The row to remove.</param>
+        void RemoveEmail(EmailAddressRowViewModel row);
+
+        /// <summary>
+        /// Telephone counterpart of <see cref="AddEmail" />.
+        /// </summary>
+        void AddTelephone();
+
+        /// <summary>
+        /// Telephone counterpart of <see cref="RemoveEmail" />.
+        /// </summary>
+        /// <param name="row">The row to remove.</param>
+        void RemoveTelephone(TelephoneNumberRowViewModel row);
+
+        /// <summary>
+        /// Persists the edits via <c>ISessionService.CreateOrUpdateThingsWithNotification</c>. On success
+        /// fires <see cref="OnSaved" /> and clears the password fields. Exceptions are logged and never
+        /// propagated so the host popup is always restored to a sane state.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> that completes when the save attempt has finished.</returns>
+        Task SaveAsync();
+    }
+}

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/PersonEditViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/PersonEditViewModel.cs
@@ -1,0 +1,540 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="PersonEditViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit
+{
+    using System.Collections.ObjectModel;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Model;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Logging;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View model implementation backing the self-service "Edit my profile" dialog. Persists changes
+    /// through <see cref="ISessionService.CreateOrUpdateThingsWithNotification(Thing, IReadOnlyCollection{Thing}, NotificationDescription)" />
+    /// using the same clone-then-write pattern as <c>UserManagementTableViewModel</c> in the admin flow.
+    /// </summary>
+    public class PersonEditViewModel : DisposableObject, IPersonEditViewModel
+    {
+        /// <summary>
+        /// The <see cref="ISessionService" /> used to load the SiteDirectory and submit writes.
+        /// </summary>
+        private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// The <see cref="ILogger{T}" /> used to record any exception thrown by the save pipeline so the
+        /// host popup is always restored to a sane state.
+        /// </summary>
+        private readonly ILogger<PersonEditViewModel> logger;
+
+        /// <summary>
+        /// Existing <see cref="EmailAddress" /> entries the user has marked for removal during the
+        /// current edit session. Cleared on every <see cref="Initialize" /> call.
+        /// </summary>
+        private readonly List<EmailAddress> removedEmails = new();
+
+        /// <summary>
+        /// Existing <see cref="TelephoneNumber" /> entries the user has marked for removal during the
+        /// current edit session. Cleared on every <see cref="Initialize" /> call.
+        /// </summary>
+        private readonly List<TelephoneNumber> removedTelephones = new();
+
+        /// <summary>
+        /// Backing field for <see cref="GivenName" />.
+        /// </summary>
+        private string givenName;
+
+        /// <summary>
+        /// Backing field for <see cref="Surname" />.
+        /// </summary>
+        private string surname;
+
+        /// <summary>
+        /// Backing field for <see cref="OrganizationalUnit" />.
+        /// </summary>
+        private string organizationalUnit;
+
+        /// <summary>
+        /// Backing field for <see cref="IsPasswordEditEnabled" />.
+        /// </summary>
+        private bool isPasswordEditEnabled;
+
+        /// <summary>
+        /// Backing field for <see cref="Password" />.
+        /// </summary>
+        private string password = string.Empty;
+
+        /// <summary>
+        /// Backing field for <see cref="PasswordConfirmation" />.
+        /// </summary>
+        private string passwordConfirmation = string.Empty;
+
+        /// <summary>
+        /// Backing field for <see cref="CurrentPerson" />.
+        /// </summary>
+        private Person currentPerson;
+
+        /// <summary>
+        /// Backing field for <see cref="IsLoading" />.
+        /// </summary>
+        private bool isLoading;
+
+        /// <summary>
+        /// Initializes a new <see cref="PersonEditViewModel" />.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /> used to load and persist.</param>
+        /// <param name="logger">The <see cref="ILogger{T}" /> used to log save-pipeline exceptions.</param>
+        public PersonEditViewModel(ISessionService sessionService, ILogger<PersonEditViewModel> logger)
+        {
+            this.sessionService = sessionService;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the live <see cref="Person" /> currently bound to the form.
+        /// </summary>
+        public Person CurrentPerson
+        {
+            get => this.currentPerson;
+            private set => this.RaiseAndSetIfChanged(ref this.currentPerson, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the editable Given Name.
+        /// </summary>
+        public string GivenName
+        {
+            get => this.givenName;
+            set => this.RaiseAndSetIfChanged(ref this.givenName, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the editable Surname.
+        /// </summary>
+        public string Surname
+        {
+            get => this.surname;
+            set => this.RaiseAndSetIfChanged(ref this.surname, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the editable Organizational Unit.
+        /// </summary>
+        public string OrganizationalUnit
+        {
+            get => this.organizationalUnit;
+            set => this.RaiseAndSetIfChanged(ref this.organizationalUnit, value);
+        }
+
+        /// <summary>
+        /// Gets the editable e-mail rows.
+        /// </summary>
+        public ObservableCollection<EmailAddressRowViewModel> EmailAddresses { get; } = new();
+
+        /// <summary>
+        /// Gets the editable telephone rows.
+        /// </summary>
+        public ObservableCollection<TelephoneNumberRowViewModel> TelephoneNumbers { get; } = new();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the password should be changed during this save.
+        /// </summary>
+        public bool IsPasswordEditEnabled
+        {
+            get => this.isPasswordEditEnabled;
+            set => this.RaiseAndSetIfChanged(ref this.isPasswordEditEnabled, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the new password to apply when <see cref="IsPasswordEditEnabled" /> is <c>true</c>.
+        /// </summary>
+        public string Password
+        {
+            get => this.password;
+            set => this.RaiseAndSetIfChanged(ref this.password, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the password confirmation.
+        /// </summary>
+        public string PasswordConfirmation
+        {
+            get => this.passwordConfirmation;
+            set => this.RaiseAndSetIfChanged(ref this.passwordConfirmation, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether a save operation is currently in flight.
+        /// </summary>
+        public bool IsLoading
+        {
+            get => this.isLoading;
+            private set => this.RaiseAndSetIfChanged(ref this.isLoading, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the form is in a saveable state.
+        /// </summary>
+        public bool IsValid
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(this.GivenName) || string.IsNullOrWhiteSpace(this.Surname))
+                {
+                    return false;
+                }
+
+                if (this.IsPasswordEditEnabled && (string.IsNullOrEmpty(this.Password) || this.Password != this.PasswordConfirmation))
+                {
+                    return false;
+                }
+
+                return this.EmailAddresses.All(x => !string.IsNullOrWhiteSpace(x.Value))
+                       && this.TelephoneNumbers.All(x => !string.IsNullOrWhiteSpace(x.Value));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the callback fired after a successful save.
+        /// </summary>
+        public EventCallback OnSaved { get; set; }
+
+        /// <summary>
+        /// Captures the supplied <see cref="Person" /> and projects its fields into the form state.
+        /// </summary>
+        /// <param name="person">The <see cref="Person" /> to edit.</param>
+        public void Initialize(Person person)
+        {
+            this.CurrentPerson = person;
+
+            this.GivenName = person?.GivenName;
+            this.Surname = person?.Surname;
+            this.OrganizationalUnit = person?.OrganizationalUnit;
+
+            this.removedEmails.Clear();
+            this.removedTelephones.Clear();
+
+            this.EmailAddresses.Clear();
+            this.TelephoneNumbers.Clear();
+
+            if (person is null)
+            {
+                this.IsPasswordEditEnabled = false;
+                this.Password = string.Empty;
+                this.PasswordConfirmation = string.Empty;
+                return;
+            }
+
+            foreach (var email in person.EmailAddress)
+            {
+                this.EmailAddresses.Add(new EmailAddressRowViewModel(email, person.DefaultEmailAddress == email));
+            }
+
+            foreach (var telephone in person.TelephoneNumber)
+            {
+                this.TelephoneNumbers.Add(new TelephoneNumberRowViewModel(telephone, person.DefaultTelephoneNumber == telephone));
+            }
+
+            this.IsPasswordEditEnabled = false;
+            this.Password = string.Empty;
+            this.PasswordConfirmation = string.Empty;
+        }
+
+        /// <summary>
+        /// Adds an empty editable e-mail row.
+        /// </summary>
+        public void AddEmail()
+        {
+            this.EmailAddresses.Add(new EmailAddressRowViewModel());
+        }
+
+        /// <summary>
+        /// Removes the supplied e-mail row, marking the original entry for deletion when applicable.
+        /// </summary>
+        /// <param name="row">The row to remove.</param>
+        public void RemoveEmail(EmailAddressRowViewModel row)
+        {
+            if (row is null)
+            {
+                return;
+            }
+
+            if (row.Original is not null)
+            {
+                this.removedEmails.Add(row.Original);
+            }
+
+            this.EmailAddresses.Remove(row);
+        }
+
+        /// <summary>
+        /// Adds an empty editable telephone row.
+        /// </summary>
+        public void AddTelephone()
+        {
+            this.TelephoneNumbers.Add(new TelephoneNumberRowViewModel());
+        }
+
+        /// <summary>
+        /// Removes the supplied telephone row, marking the original entry for deletion when applicable.
+        /// </summary>
+        /// <param name="row">The row to remove.</param>
+        public void RemoveTelephone(TelephoneNumberRowViewModel row)
+        {
+            if (row is null)
+            {
+                return;
+            }
+
+            if (row.Original is not null)
+            {
+                this.removedTelephones.Add(row.Original);
+            }
+
+            this.TelephoneNumbers.Remove(row);
+        }
+
+        /// <summary>
+        /// Persists the edits.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous save.</returns>
+        public async Task SaveAsync()
+        {
+            if (!this.IsValid || this.CurrentPerson is null)
+            {
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                var siteDirectoryClone = this.sessionService.GetSiteDirectory().Clone(false);
+                var personClone = this.CurrentPerson.Clone(false);
+
+                personClone.GivenName = this.GivenName;
+                personClone.Surname = this.Surname;
+                personClone.OrganizationalUnit = this.OrganizationalUnit;
+
+                if (this.IsPasswordEditEnabled)
+                {
+                    personClone.Password = this.Password;
+                }
+
+                var thingsToWrite = new List<Thing> { personClone };
+
+                this.ApplyEmailEdits(personClone, thingsToWrite);
+                this.ApplyTelephoneEdits(personClone, thingsToWrite);
+
+                var result = await this.sessionService.CreateOrUpdateThingsWithNotification(siteDirectoryClone, thingsToWrite, GetNotificationDescription());
+
+                if (result.IsSuccess)
+                {
+                    this.IsPasswordEditEnabled = false;
+                    this.Password = string.Empty;
+                    this.PasswordConfirmation = string.Empty;
+                    await this.OnSaved.InvokeAsync();
+                }
+            }
+            catch (Exception exception)
+            {
+                this.logger?.LogError(exception, "An error occurred while updating the active Person with iid {Iid}", this.CurrentPerson.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+            }
+        }
+
+        /// <summary>
+        /// Applies the editable e-mail rows to the supplied <paramref name="personClone" />, adding new
+        /// entries and edited clones to <paramref name="thingsToWrite" />, dropping removed originals from
+        /// the cloned collection, and restoring <see cref="Person.DefaultEmailAddress" /> when one row is
+        /// flagged as the default.
+        /// </summary>
+        /// <param name="personClone">The cloned <see cref="Person" /> being mutated for write.</param>
+        /// <param name="thingsToWrite">The growing list of Things passed to the session-service write.</param>
+        private void ApplyEmailEdits(Person personClone, ICollection<Thing> thingsToWrite)
+        {
+            foreach (var removed in this.removedEmails)
+            {
+                personClone.EmailAddress.Remove(removed);
+                if (personClone.DefaultEmailAddress == removed)
+                {
+                    personClone.DefaultEmailAddress = null;
+                }
+            }
+
+            EmailAddress newDefault = null;
+
+            foreach (var row in this.EmailAddresses)
+            {
+                EmailAddress targetForDefault;
+
+                if (row.Original is null)
+                {
+                    var created = new EmailAddress
+                    {
+                        Iid = Guid.NewGuid(),
+                        VcardType = row.VcardType,
+                        Value = row.Value
+                    };
+
+                    personClone.EmailAddress.Add(created);
+                    thingsToWrite.Add(created);
+                    targetForDefault = created;
+                }
+                else
+                {
+                    var changed = row.Original.VcardType != row.VcardType || row.Original.Value != row.Value;
+
+                    if (changed)
+                    {
+                        var clone = row.Original.Clone(false);
+                        clone.VcardType = row.VcardType;
+                        clone.Value = row.Value;
+
+                        var existing = personClone.EmailAddress.FirstOrDefault(x => x.Iid == row.Original.Iid);
+                        if (existing is not null)
+                        {
+                            personClone.EmailAddress.Remove(existing);
+                        }
+
+                        personClone.EmailAddress.Add(clone);
+                        thingsToWrite.Add(clone);
+                        targetForDefault = clone;
+                    }
+                    else
+                    {
+                        targetForDefault = row.Original;
+                    }
+                }
+
+                if (row.IsDefault)
+                {
+                    newDefault = targetForDefault;
+                }
+            }
+
+            if (newDefault is not null)
+            {
+                personClone.DefaultEmailAddress = newDefault;
+            }
+        }
+
+        /// <summary>
+        /// Telephone counterpart of <see cref="ApplyEmailEdits" />.
+        /// </summary>
+        /// <param name="personClone">The cloned <see cref="Person" /> being mutated for write.</param>
+        /// <param name="thingsToWrite">The growing list of Things passed to the session-service write.</param>
+        private void ApplyTelephoneEdits(Person personClone, ICollection<Thing> thingsToWrite)
+        {
+            foreach (var removed in this.removedTelephones)
+            {
+                personClone.TelephoneNumber.Remove(removed);
+                if (personClone.DefaultTelephoneNumber == removed)
+                {
+                    personClone.DefaultTelephoneNumber = null;
+                }
+            }
+
+            TelephoneNumber newDefault = null;
+
+            foreach (var row in this.TelephoneNumbers)
+            {
+                TelephoneNumber targetForDefault;
+
+                if (row.Original is null)
+                {
+                    var created = new TelephoneNumber
+                    {
+                        Iid = Guid.NewGuid(),
+                        Value = row.Value
+                    };
+
+                    created.VcardType.AddRange(row.VcardType);
+                    personClone.TelephoneNumber.Add(created);
+                    thingsToWrite.Add(created);
+                    targetForDefault = created;
+                }
+                else
+                {
+                    var changed = !row.Original.VcardType.SequenceEqual(row.VcardType) || row.Original.Value != row.Value;
+
+                    if (changed)
+                    {
+                        var clone = row.Original.Clone(false);
+                        clone.VcardType.Clear();
+                        clone.VcardType.AddRange(row.VcardType);
+                        clone.Value = row.Value;
+
+                        var existing = personClone.TelephoneNumber.FirstOrDefault(x => x.Iid == row.Original.Iid);
+                        if (existing is not null)
+                        {
+                            personClone.TelephoneNumber.Remove(existing);
+                        }
+
+                        personClone.TelephoneNumber.Add(clone);
+                        thingsToWrite.Add(clone);
+                        targetForDefault = clone;
+                    }
+                    else
+                    {
+                        targetForDefault = row.Original;
+                    }
+                }
+
+                if (row.IsDefault)
+                {
+                    newDefault = targetForDefault;
+                }
+            }
+
+            if (newDefault is not null)
+            {
+                personClone.DefaultTelephoneNumber = newDefault;
+            }
+        }
+
+        /// <summary>
+        /// Builds the success / error <see cref="NotificationDescription" /> shown after the save attempt.
+        /// </summary>
+        /// <returns>The <see cref="NotificationDescription" /> describing the outcome.</returns>
+        private static NotificationDescription GetNotificationDescription()
+        {
+            return new NotificationDescription
+            {
+                OnSuccess = "Profile updated",
+                OnError = "Failed to update profile"
+            };
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/TelephoneNumberRowViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/PersonEdit/TelephoneNumberRowViewModel.cs
@@ -1,0 +1,115 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TelephoneNumberRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Editable row representing a single <see cref="TelephoneNumber" /> belonging to the active
+    /// <see cref="Person" />. Mirrors <see cref="EmailAddressRowViewModel" /> for telephone entries.
+    /// </summary>
+    public class TelephoneNumberRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="VcardType" />.
+        /// </summary>
+        private IEnumerable<VcardTelephoneNumberKind> vcardType;
+
+        /// <summary>
+        /// Backing field for <see cref="Value" />.
+        /// </summary>
+        private string value;
+
+        /// <summary>
+        /// Backing field for <see cref="IsDefault" />.
+        /// </summary>
+        private bool isDefault;
+
+        /// <summary>
+        /// Initializes a new <see cref="TelephoneNumberRowViewModel" /> wrapping an existing SDK
+        /// <see cref="TelephoneNumber" />.
+        /// </summary>
+        /// <param name="original">The original SDK <see cref="TelephoneNumber" /> being wrapped.</param>
+        /// <param name="isDefault">Whether this number is the active person's <see cref="Person.DefaultTelephoneNumber" />.</param>
+        public TelephoneNumberRowViewModel(TelephoneNumber original, bool isDefault)
+        {
+            this.Original = original;
+            this.vcardType = new List<VcardTelephoneNumberKind>(original.VcardType);
+            this.value = original.Value;
+            this.isDefault = isDefault;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="TelephoneNumberRowViewModel" /> representing an empty entry the
+        /// user is about to fill in. <see cref="Original" /> stays <c>null</c> so the save pipeline knows
+        /// to create a brand-new <see cref="TelephoneNumber" /> on persist.
+        /// </summary>
+        public TelephoneNumberRowViewModel()
+        {
+            this.vcardType = new List<VcardTelephoneNumberKind> { VcardTelephoneNumberKind.WORK };
+            this.value = string.Empty;
+            this.isDefault = false;
+        }
+
+        /// <summary>
+        /// Gets the original SDK <see cref="TelephoneNumber" /> wrapped by this row, or <c>null</c> when
+        /// the row was added in the form and has not yet been persisted.
+        /// </summary>
+        public TelephoneNumber Original { get; }
+
+        /// <summary>
+        /// Gets or sets the editable list of <see cref="VcardTelephoneNumberKind" /> displayed by the
+        /// form. The vCard standard allows several kinds per number (e.g. WORK + VOICE) which is why
+        /// this is a collection rather than a single value. Exposed as <see cref="IEnumerable{T}" /> so
+        /// it can be bound to <c>DxTagBox.Values</c>, which expects that signature.
+        /// </summary>
+        public IEnumerable<VcardTelephoneNumberKind> VcardType
+        {
+            get => this.vcardType;
+            set => this.RaiseAndSetIfChanged(ref this.vcardType, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the editable telephone value displayed by the form.
+        /// </summary>
+        public string Value
+        {
+            get => this.value;
+            set => this.RaiseAndSetIfChanged(ref this.value, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this row is the default telephone number of the active
+        /// person. Setting this to <c>true</c> in the form does not automatically clear the flag on the
+        /// other rows — <see cref="PersonEditViewModel" /> takes responsibility for that during persist.
+        /// </summary>
+        public bool IsDefault
+        {
+            get => this.isDefault;
+            set => this.RaiseAndSetIfChanged(ref this.isDefault, value);
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/SessionMenuViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/SessionMenuViewModel.cs
@@ -28,6 +28,11 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
     using COMET.Web.Common.Services.NotificationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.DisposableObject;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
+
+    using Microsoft.AspNetCore.Components;
+
+    using ReactiveUI;
 
     /// <summary>
     /// View model that handles the menu entry related to the <see cref="ISession" />
@@ -35,17 +40,25 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
     public class SessionMenuViewModel : DisposableObject, ISessionMenuViewModel
     {
         /// <summary>
+        /// Backing field for <see cref="IsOnEditPersonMode" />.
+        /// </summary>
+        private bool isOnEditPersonMode;
+
+        /// <summary>
         /// Initializes a <see cref="SessionMenuViewModel" />
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionMenuViewModel" /></param>
         /// <param name="autoRefreshService">The <see cref="IAutoRefreshService" /></param>
         /// <param name="notificationService">The <see cref="INotificationService" /></param>
         /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
-        public SessionMenuViewModel(ISessionService sessionService, IAutoRefreshService autoRefreshService, INotificationService notificationService, ICDPMessageBus messageBus)
+        /// <param name="personEditViewModel">The <see cref="IPersonEditViewModel" /> driving the self-service profile dialog.</param>
+        public SessionMenuViewModel(ISessionService sessionService, IAutoRefreshService autoRefreshService, INotificationService notificationService, ICDPMessageBus messageBus, IPersonEditViewModel personEditViewModel)
         {
             this.SessionService = sessionService;
             this.AutoRefreshService = autoRefreshService;
             this.NotificationService = notificationService;
+            this.PersonEditViewModel = personEditViewModel;
+            this.PersonEditViewModel.OnSaved = EventCallback.Factory.Create(this, () => this.IsOnEditPersonMode = false);
         }
 
         /// <summary>
@@ -70,6 +83,38 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
         public Task RefreshSession()
         {
             return this.SessionService.RefreshSession();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the self-service "Edit my profile" popup is open.
+        /// </summary>
+        public bool IsOnEditPersonMode
+        {
+            get => this.isOnEditPersonMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnEditPersonMode, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IPersonEditViewModel" /> driving the "Edit my profile" dialog.
+        /// </summary>
+        public IPersonEditViewModel PersonEditViewModel { get; }
+
+        /// <summary>
+        /// Initializes <see cref="PersonEditViewModel" /> from the active session's
+        /// <see cref="CDP4Common.SiteDirectoryData.Person" /> and opens the popup. No-op when no
+        /// person is active (the session is unauthenticated or the SDK has not yet populated it).
+        /// </summary>
+        public void OpenEditPersonPopup()
+        {
+            var activePerson = this.SessionService?.Session?.ActivePerson;
+
+            if (activePerson is null)
+            {
+                return;
+            }
+
+            this.PersonEditViewModel.Initialize(activePerson);
+            this.IsOnEditPersonMode = true;
         }
     }
 }

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -421,43 +421,50 @@
 
 .session__header {
     background: lightgray;
-    padding: 5px;
+    padding: 12px 16px;
     width: 100%;
     overflow: hidden;
 }
 
 .session_content {
     font-size: 12px;
-    display: table;
-    margin: 0 auto !important;
+    width: 280px;
+    padding-top: 4px;
 }
 
 .content__autorefresh {
     display: flex;
+    align-items: center;
     line-height: 30px;
-    margin: 20px;
-    text-indent: 5px;
-    width: max-content;
+    padding: 12px 16px 4px;
+    gap: 6px;
 }
 
 .content__spin {
     max-width: 85px;
     max-height: 30px;
-    margin-left: 5px;
 }
 
 .session__buttons {
-    margin: 0 auto !important;
-    display: table;
-    padding-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 16px 0;
 }
 
-.right-margin {
-    margin-right: 2px !important;
+.session__buttons:last-of-type {
+    padding-bottom: 16px;
 }
 
-.left-margin {
-    margin-left: 2px !important;
+.session__buttons--secondary {
+    margin-top: 14px;
+    padding-top: 16px;
+    border-top: 1px solid #d0d0d0;
+}
+
+.session__buttons .btn-connect {
+    width: 100%;
+    margin: 0 !important;
 }
 
 .notification {

--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -42,6 +42,7 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
     using COMET.Web.Common.Shared.TopMenuEntry;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Shared.TopMenuEntry;
+    using COMET.Web.Common.ViewModels.Shared.TopMenuEntry.PersonEdit;
 
     using COMETwebapp.Model;
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
@@ -133,6 +134,7 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
             this.context.Services.AddSingleton(this.autoRefreshService.Object);
             this.context.Services.AddSingleton(this.autoRefreshService.Object);
             this.context.Services.AddSingleton(this.showHideDeprecatedThingsViewModel.Object);
+            this.context.Services.AddSingleton<IPersonEditViewModel>(new Mock<IPersonEditViewModel>().Object);
             this.context.Services.AddSingleton<ISessionMenuViewModel, SessionMenuViewModel>();
             this.context.Services.AddSingleton<IModelMenuViewModel, ModelMenuViewModel>();
             this.context.Services.AddSingleton(this.authorizedMenuEntryViewModel.Object);

--- a/COMETwebapp/Shared/SideBarEntry/SessionSideBar.razor
+++ b/COMETwebapp/Shared/SideBarEntry/SessionSideBar.razor
@@ -18,6 +18,7 @@
 //   limitations under the License.
 ------------------------------------------------------------------------------->
 @namespace COMETwebapp.Shared.SideBarEntry
+@using COMET.Web.Common.Components.Shared.PersonEdit
 @inherits COMET.Web.Common.Shared.TopMenuEntry.SessionMenu
 
 <SideBarItem Text="Session"
@@ -56,9 +57,24 @@
                 sec
             </div>
             <div class="session__buttons">
-                <DxButton Id="refresh-button" CssClass="btn btn-connect right-margin" Text="@(this.RefreshButtonText)" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
-                <DxButton Id="logout-button" CssClass="btn btn-connect left-margin" Text="Log out" Click="@(this.Logout)"/>
+                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" Text="Edit my profile" IconCssClass="oi oi-person" Click="@(this.OnEditProfileClick)"/>
+            </div>
+
+            <div class="session__buttons session__buttons--secondary">
+                <DxButton Id="refresh-button" CssClass="btn btn-connect" Text="@(this.RefreshButtonText)" IconCssClass="oi oi-reload" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
+                <DxButton Id="logout-button" CssClass="btn btn-connect" Text="Log out" IconCssClass="oi oi-account-logout" Click="@(this.Logout)"/>
             </div>
         </div>
     </BodyContentTemplate>
 </DxDropDown>
+
+<DxPopup @bind-Visible="@this.ViewModel.IsOnEditPersonMode"
+         CloseOnOutsideClick="false"
+         HeaderText="Edit my profile"
+         Width="50vw"
+         ShowCloseButton="true">
+    <BodyContentTemplate>
+        <PersonEditForm ViewModel="@this.ViewModel.PersonEditViewModel"
+                        OnCancel="@(() => this.ViewModel.IsOnEditPersonMode = false)"/>
+    </BodyContentTemplate>
+</DxPopup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Adds an **Edit my profile** entry to the Session dropdown that opens a tabbed popup populated from `Session.ActivePerson`:

  - **Basic** — GivenName, Surname, OrganizationalUnit
  - **E-Mail** / **Telephone Number** — list of existing entries with add/remove and default selection
  - **Password** — opt-in checkbox; password + confirmation, save disabled until they match

  Save goes through the existing `ISessionService.CreateOrUpdateThingsWithNotification` pipeline, so success/error toasts and the SDK  write path are reused. Admin-only fields (PersonRole, Organization, IsActive, IsDeprecated) are deliberately not surfaced.

  ## Implementation notes

  - New `PersonEditForm` + `PersonEditViewModel` (and contact row VMs) live in `COMET.Web.Common` so the Session menu can reach them without inverting the project dependency into the admin `UserManagementForm`.
  - `ISessionMenuViewModel` gains `IsOnEditPersonMode`, `PersonEditViewModel`, `OpenEditPersonPopup()`, with auto-close on save.
  - The button + popup are added to both `SessionMenu.razor` (top-bar) and `SessionSideBar.razor` (sidebar — the variant the running app uses; inherits `SessionMenu`'s code but not its markup).
  - `.session__buttons` restyled into two stacked groups separated by a `border-top` so the profile action is visually grouped apart  from Refresh / Log out.

  ## Risks

  - **Self-locking on password change** — a user changing their own password may need to re-auth on next request; surfaced via  `NotificationDescription.OnError`. Auto-relogin is a follow-up.
  - **Removing existing emails/phones** — relies on the COMET server treating absence-on-update as a delete, same as the admin form.

  ## Test plan

  - [ ] `dotnet build COMETwebapp.sln --no-restore`
  - [ ] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 652 / 652 passing baseline
  - [ ] Manual smoke against `cdp4services-public.cdp4.org`: open Edit my profile → edit name → Save → reopen and verify; add a second e-mail set as default → reopen and verify; change password (mismatch disables Save) → Save → success toast; Cancel performs no write.


<!-- Thanks for contributing to COMET-WEB! -->

