### PR TITLE
[Implement] edit elementDefinition and ElementUsage from Model Editor; fixes #770 and #777

### DIFF
--- a/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
@@ -34,6 +34,8 @@ namespace COMETwebapp.Tests.Components.ModelEditor
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
     using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows;
 
+    using Microsoft.AspNetCore.Components;
+
     using Moq;
 
     using NUnit.Framework;
@@ -168,6 +170,83 @@ namespace COMETwebapp.Tests.Components.ModelEditor
             {
                 Assert.That(markup, Does.Contain("cardview-detailspanel-summary"), "Summary card must still render.");
                 Assert.That(markup, Does.Not.Contain("border-top:1px dotted darkgray"), "Definition row marker must not appear when Definition is empty.");
+            });
+        }
+
+        [Test]
+        public void VerifyEditButtonRendersWhenCallbackBound()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var editInvoked = false;
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnEditElement, EventCallback.Factory.Create(this, () => editInvoked = true)));
+
+            Assert.That(rendered.Markup, Does.Contain("oi-pencil"), "Edit button must render when OnEditElement is bound.");
+
+            rendered.Find("#editElement").Click();
+            Assert.That(editInvoked, Is.True, "Clicking Edit must invoke the OnEditElement callback.");
+        }
+
+        [Test]
+        public void VerifyDeleteButtonRendersWhenCallbackBound()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var deleteInvoked = false;
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnDeleteElement, EventCallback.Factory.Create(this, () => deleteInvoked = true)));
+
+            Assert.That(rendered.Markup, Does.Contain("oi-trash"), "Delete button must render when OnDeleteElement is bound.");
+
+            rendered.Find("#deleteElement").Click();
+            Assert.That(deleteInvoked, Is.True, "Clicking Delete must invoke the OnDeleteElement callback.");
+        }
+
+        [Test]
+        public void VerifyDeleteButtonDisabledWhenDisableDeleteTrue()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var deleteInvoked = false;
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnDeleteElement, EventCallback.Factory.Create(this, () => deleteInvoked = true))
+                .Add(p => p.DisableDelete, true));
+
+            var deleteButton = rendered.Find("#deleteElement");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(deleteButton.GetAttribute("disabled"), Is.Not.Null,
+                    "Delete button must render disabled when DisableDelete is true (e.g. selection is the top element).");
+                Assert.That(deleteButton.GetAttribute("title"), Does.Contain("top element"),
+                    "Tooltip must mention the top-element rule when delete is disabled.");
+            });
+
+            Assert.That(deleteInvoked, Is.False, "Disabled Delete button must not invoke the callback even if rendered.");
+        }
+
+        [Test]
+        public void VerifyEditAndDeleteButtonsHiddenWhenCallbacksUnbound()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters.Add(p => p.ViewModel, this.viewModel.Object));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rendered.Markup, Does.Not.Contain("oi-pencil"), "Edit button must not render when OnEditElement is unbound.");
+                Assert.That(rendered.Markup, Does.Not.Contain("id=\"deleteElement\""), "Delete button must not render when OnDeleteElement is unbound.");
             });
         }
 

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementDefinitionViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementDefinitionViewModelTestFixture.cs
@@ -1,0 +1,207 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditElementDefinitionViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel;
+
+    using DynamicData;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class EditElementDefinitionViewModelTestFixture
+    {
+        private EditElementDefinitionViewModel viewModel;
+        private Mock<ISessionService> sessionService;
+        private CDPMessageBus messageBus;
+        private DomainOfExpertise domain;
+        private DomainOfExpertise otherDomain;
+        private SiteReferenceDataLibrary rdl;
+        private Iteration iteration;
+        private ElementDefinition topElement;
+        private ElementDefinition elementDefinition;
+        private Category structureCategory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.messageBus = new CDPMessageBus();
+            this.sessionService = new Mock<ISessionService>();
+
+            var session = new Mock<ISession>();
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            this.domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.otherDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "PWR", Name = "Power" };
+
+            this.structureCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Structure",
+                ShortName = "STR",
+                PermissibleClass = { ClassKind.ElementDefinition }
+            };
+
+            this.rdl = new SiteReferenceDataLibrary
+            {
+                ShortName = "siteRdl",
+                Name = "Site RDL",
+                DefinedCategory = { this.structureCategory }
+            };
+
+            var siteDirectory = new SiteDirectory
+            {
+                Domain = { this.domain, this.otherDomain },
+                SiteReferenceDataLibrary = { this.rdl }
+            };
+
+            var modelSetup = new EngineeringModelSetup
+            {
+                Name = "ModelName",
+                ShortName = "ModelShortName",
+                ActiveDomain = { this.domain, this.otherDomain },
+                RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = this.rdl } }
+            };
+
+            siteDirectory.Model.Add(modelSetup);
+            var iterationSetup = new IterationSetup { IterationNumber = 1 };
+            modelSetup.IterationSetup.Add(iterationSetup);
+
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+
+            this.topElement = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Container",
+                ShortName = "CONT",
+                Owner = this.domain
+            };
+
+            this.elementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.domain,
+                Category = { this.structureCategory }
+            };
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                Element = { this.topElement, this.elementDefinition },
+                TopElement = this.topElement,
+                IterationSetup = iterationSetup,
+                Container = new EngineeringModel { EngineeringModelSetup = modelSetup }
+            };
+
+            this.viewModel = new EditElementDefinitionViewModel(this.sessionService.Object, this.messageBus);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.messageBus.ClearSubscriptions();
+        }
+
+        [Test]
+        public void VerifyInitializeViewModelSeedsFormFromTarget()
+        {
+            this.viewModel.InitializeViewModel(this.elementDefinition, this.iteration);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ElementDefinition, Is.SameAs(this.elementDefinition));
+                Assert.That(this.viewModel.Iteration, Is.SameAs(this.iteration));
+                Assert.That(this.viewModel.SelectedCategories, Is.EquivalentTo(new[] { this.structureCategory }));
+                Assert.That(this.viewModel.IsTopElement, Is.False, "The seeded ED is not the iteration's top element.");
+                Assert.That(this.viewModel.AvailableCategories, Does.Contain(this.structureCategory));
+                Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise, Is.EquivalentTo(new[] { this.domain, this.otherDomain }));
+                Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise, Is.EqualTo(this.domain));
+            });
+        }
+
+        [Test]
+        public void VerifyInitializeViewModelFlagsTopElement()
+        {
+            this.viewModel.InitializeViewModel(this.topElement, this.iteration);
+
+            Assert.That(this.viewModel.IsTopElement, Is.True);
+        }
+
+        [Test]
+        public void VerifyInitializeViewModelRejectsNullArguments()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.viewModel.InitializeViewModel(null, this.iteration), Throws.ArgumentNullException);
+                Assert.That(() => this.viewModel.InitializeViewModel(this.elementDefinition, null), Throws.ArgumentNullException);
+            });
+        }
+
+        [Test]
+        public void VerifyAvailableCategoriesFiltersByPermissibleClass()
+        {
+            var unrelatedCategory = new Category
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Sensor",
+                ShortName = "SEN",
+                PermissibleClass = { ClassKind.Parameter }
+            };
+
+            this.rdl.DefinedCategory.Add(unrelatedCategory);
+
+            this.viewModel.InitializeViewModel(this.elementDefinition, this.iteration);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableCategories, Does.Contain(this.structureCategory));
+                Assert.That(this.viewModel.AvailableCategories, Does.Not.Contain(unrelatedCategory),
+                    "Categories whose PermissibleClass excludes ElementDefinition must not be offered.");
+            });
+        }
+
+        [Test]
+        public void VerifyOwnerAssignmentWiresThroughSelectorChange()
+        {
+            this.viewModel.InitializeViewModel(this.elementDefinition, this.iteration);
+
+            this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise = this.otherDomain;
+
+            Assert.That(this.viewModel.ElementDefinition.Owner, Is.EqualTo(this.otherDomain));
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementUsageViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementUsageViewModelTestFixture.cs
@@ -1,0 +1,148 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditElementUsageViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel;
+
+    using DynamicData;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class EditElementUsageViewModelTestFixture
+    {
+        private EditElementUsageViewModel viewModel;
+        private Mock<ISessionService> sessionService;
+        private CDPMessageBus messageBus;
+        private DomainOfExpertise domain;
+        private DomainOfExpertise otherDomain;
+        private Iteration iteration;
+        private ElementDefinition referencedDefinition;
+        private ElementUsage elementUsage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.messageBus = new CDPMessageBus();
+            this.sessionService = new Mock<ISessionService>();
+
+            var session = new Mock<ISession>();
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            this.domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.otherDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "PWR", Name = "Power" };
+
+            var rdl = new SiteReferenceDataLibrary { ShortName = "siteRdl", Name = "Site RDL" };
+            var siteDirectory = new SiteDirectory { Domain = { this.domain, this.otherDomain }, SiteReferenceDataLibrary = { rdl } };
+
+            var modelSetup = new EngineeringModelSetup
+            {
+                Name = "ModelName",
+                ShortName = "ModelShortName",
+                ActiveDomain = { this.domain, this.otherDomain },
+                RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } }
+            };
+
+            siteDirectory.Model.Add(modelSetup);
+            var iterationSetup = new IterationSetup { IterationNumber = 1 };
+            modelSetup.IterationSetup.Add(iterationSetup);
+
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+
+            var topElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Container", ShortName = "CONT", Owner = this.domain };
+            this.referencedDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Box", ShortName = "BOX", Owner = this.domain };
+
+            this.elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = this.referencedDefinition,
+                Owner = this.domain
+            };
+
+            topElement.ContainedElement.Add(this.elementUsage);
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                Element = { topElement, this.referencedDefinition },
+                TopElement = topElement,
+                IterationSetup = iterationSetup,
+                Container = new EngineeringModel { EngineeringModelSetup = modelSetup }
+            };
+
+            this.viewModel = new EditElementUsageViewModel(this.sessionService.Object, this.messageBus);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.messageBus.ClearSubscriptions();
+        }
+
+        [Test]
+        public void VerifyInitializeViewModelSeedsForm()
+        {
+            this.viewModel.InitializeViewModel(this.elementUsage, this.iteration);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ElementUsage, Is.SameAs(this.elementUsage));
+                Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise, Is.EqualTo(this.domain));
+                Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise, Is.EquivalentTo(new[] { this.domain, this.otherDomain }));
+            });
+        }
+
+        [Test]
+        public void VerifyInitializeViewModelRejectsNullArguments()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => this.viewModel.InitializeViewModel(null, this.iteration), Throws.ArgumentNullException);
+                Assert.That(() => this.viewModel.InitializeViewModel(this.elementUsage, null), Throws.ArgumentNullException);
+            });
+        }
+
+        [Test]
+        public void VerifyOwnerAssignmentWiresThroughSelectorChange()
+        {
+            this.viewModel.InitializeViewModel(this.elementUsage, this.iteration);
+
+            this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise = this.otherDomain;
+
+            Assert.That(this.viewModel.ElementUsage.Owner, Is.EqualTo(this.otherDomain));
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -353,5 +353,200 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
                 x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
                 Times.Never);
         }
+
+        [Test]
+        public void VerifyOpenEditElementPopupForDefinitionInitialisesEditViewModel()
+        {
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnEditMode, Is.True);
+                Assert.That(this.viewModel.EditElementDefinitionViewModel.ElementDefinition, Is.Not.Null);
+                Assert.That(this.viewModel.EditElementDefinitionViewModel.ElementDefinition, Is.Not.SameAs(this.referencedElementDefinition),
+                    "OpenEditElementPopup must hand the form a clone, not the cached domain instance.");
+                Assert.That(this.viewModel.EditElementDefinitionViewModel.ElementDefinition.Iid, Is.EqualTo(this.referencedElementDefinition.Iid));
+                Assert.That(this.viewModel.EditElementDefinitionViewModel.IsTopElement, Is.False);
+            });
+        }
+
+        [Test]
+        public void VerifyOpenEditElementPopupForTopElementMarksTopElementFlag()
+        {
+            this.viewModel.SelectElement(this.topElement);
+            this.viewModel.OpenEditElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnEditMode, Is.True);
+                Assert.That(this.viewModel.EditElementDefinitionViewModel.IsTopElement, Is.True);
+            });
+        }
+
+        [Test]
+        public void VerifyOpenEditElementPopupForUsageInitialisesUsageViewModel()
+        {
+            this.viewModel.SelectElement(this.elementUsage);
+            this.viewModel.OpenEditElementPopup();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsOnEditMode, Is.True);
+                Assert.That(this.viewModel.EditElementUsageViewModel.ElementUsage, Is.Not.Null);
+                Assert.That(this.viewModel.EditElementUsageViewModel.ElementUsage, Is.Not.SameAs(this.elementUsage),
+                    "OpenEditElementPopup must hand the form a clone, not the cached domain instance.");
+                Assert.That(this.viewModel.EditElementUsageViewModel.ElementUsage.Iid, Is.EqualTo(this.elementUsage.Iid));
+            });
+        }
+
+        [Test]
+        public void VerifyOpenEditElementPopupWithNoSelectionIsNoOp()
+        {
+            this.viewModel.OpenEditElementPopup();
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyEditElementDefinitionPromotesToTopElementWhenRequested()
+        {
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+            this.viewModel.EditElementDefinitionViewModel.IsTopElement = true;
+
+            await this.viewModel.EditElementDefinitionAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.Is<Thing>(t => t is Iteration && ((Iteration)t).TopElement != null && ((Iteration)t).TopElement.Iid == this.referencedElementDefinition.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<Iteration>().Any() && c.OfType<ElementDefinition>().Any(d => d.Iid == this.referencedElementDefinition.Iid)),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyEditElementDefinitionAppliesSelectedCategories()
+        {
+            var newCategory = new Category { Iid = Guid.NewGuid(), Name = "Sensor", ShortName = "SEN", PermissibleClass = { ClassKind.ElementDefinition } };
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+            this.viewModel.EditElementDefinitionViewModel.SelectedCategories = new[] { newCategory };
+
+            await this.viewModel.EditElementDefinitionAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.OfType<ElementDefinition>().Any(d => d.Iid == this.referencedElementDefinition.Iid && d.Category.Contains(newCategory))),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyEditElementUsageCallsSessionServiceWithCorrectContainer()
+        {
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.elementUsage);
+            this.viewModel.OpenEditElementPopup();
+
+            await this.viewModel.EditElementUsageAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.Is<Thing>(t => t is ElementDefinition && t.Iid == this.topElement.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c => c.Count == 1 && c.Single() is ElementUsage && c.Single().Iid == this.elementUsage.Iid),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyEditElementDefinitionWithoutTargetIsNoOp()
+        {
+            await this.viewModel.EditElementDefinitionAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
+                Times.Never);
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyEditElementUsageWithoutTargetIsNoOp()
+        {
+            await this.viewModel.EditElementUsageAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
+                Times.Never);
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public void VerifyOpenEditElementPopupHoldsOriginalIterationForSelectorResolution()
+        {
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+
+            Assert.That(this.viewModel.EditElementDefinitionViewModel.Iteration, Is.SameAs(this.iteration),
+                "OpenEditElementPopup must hand the edit VM the original iteration. Cloning here breaks DomainOfExpertiseSelectorViewModel which resolves the iteration through the open session.");
+        }
+
+        [Test]
+        public async Task VerifyEditElementDefinitionClonesIterationAtSubmit()
+        {
+            Iteration capturedTopContainer = null;
+
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback<Thing, IReadOnlyCollection<Thing>, NotificationDescription>((top, _, _) => capturedTopContainer = top as Iteration)
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+
+            await this.viewModel.EditElementDefinitionAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(capturedTopContainer, Is.Not.Null);
+                Assert.That(capturedTopContainer, Is.Not.SameAs(this.iteration),
+                    "EditElementDefinitionAsync must clone the iteration at submit time, not commit the cached instance.");
+                Assert.That(capturedTopContainer.Iid, Is.EqualTo(this.iteration.Iid));
+            });
+        }
+
+        [Test]
+        public async Task VerifyEditElementDefinitionExceptionIsCaughtAndPopupClosed()
+        {
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ThrowsAsync(new InvalidOperationException("boom"));
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenEditElementPopup();
+
+            await this.viewModel.EditElementDefinitionAsync();
+
+            Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
     }
 }

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -24,18 +24,38 @@
 {
     <div class="card cardview-detailspanel-summary mb-2" style="padding:8px;">
         <div class="row" style="margin-bottom:4px;">
-            <div class="col-9">
+            <div class="col-7">
                 <h6 title="@this.ViewModel.SelectedSystemNode.Name"
                     style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:0;">
                     @this.ViewModel.SelectedSystemNode.Name
                 </h6>
                 <small class="text-muted">@this.ViewModel.SelectedSystemNode.ShortName</small>
             </div>
-            <div class="col-3" align="right">
+            <div class="col-5" align="right">
                 <button class="starion-pill"
                         title="Owning Domain Of Expertise: @this.ViewModel.SelectedSystemNode.Owner.ShortName">
                     @this.ViewModel.SelectedSystemNode.Owner.ShortName
                 </button>
+                @if (this.OnEditElement.HasDelegate)
+                {
+                    <DxButton Id="editElement"
+                              IconCssClass="oi oi-pencil"
+                              RenderStyleMode="ButtonRenderStyleMode.Text"
+                              CssClass="ms-1"
+                              Click="@(() => this.OnEditElement.InvokeAsync())"
+                              title="Edit the selected element"/>
+                }
+                @if (this.OnDeleteElement.HasDelegate)
+                {
+                    <DxButton Id="deleteElement"
+                              IconCssClass="oi oi-trash"
+                              RenderStyle="ButtonRenderStyle.Danger"
+                              RenderStyleMode="ButtonRenderStyleMode.Text"
+                              CssClass="ms-1"
+                              Enabled="@(!this.DisableDelete)"
+                              Click="@(() => this.OnDeleteElement.InvokeAsync())"
+                              title="@(this.DisableDelete ? "The top element of the iteration cannot be deleted" : "Delete the selected element")"/>
+                }
             </div>
         </div>
         @{

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
@@ -50,6 +50,28 @@ namespace COMETwebapp.Components.ModelEditor
 		public EventCallback<Parameter> OnDeleteParameter { get; set; }
 
 		/// <summary>
+		///     Optional callback invoked when the user clicks the Edit affordance on the summary card.
+		///     When unset, the Edit button is not rendered.
+		/// </summary>
+		[Parameter]
+		public EventCallback OnEditElement { get; set; }
+
+		/// <summary>
+		///     Optional callback invoked when the user clicks the Delete affordance on the summary card.
+		///     When unset, the Delete button is not rendered.
+		/// </summary>
+		[Parameter]
+		public EventCallback OnDeleteElement { get; set; }
+
+		/// <summary>
+		///     Disables the Delete button on the summary card. Set by the parent when the selected element
+		///     is the iteration's <see cref="Iteration.TopElement" /> — which the application forbids from
+		///     being deleted.
+		/// </summary>
+		[Parameter]
+		public bool DisableDelete { get; set; }
+
+		/// <summary>
 		///     Method invoked when the component is ready to start, having received its
 		///     initial parameters from its parent in the render tree.
 		///     Override this method if you will perform an asynchronous operation and

--- a/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
+++ b/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
@@ -1,0 +1,62 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@using CDP4Common.SiteDirectoryData;
+
+@if (this.ViewModel.ElementDefinition is not null)
+{
+    <EditForm Context="EditFormContext" Model="@this.ViewModel.ElementDefinition" OnValidSubmit="@this.ViewModel.OnValidSubmit">
+        <DxFormLayout CssClass="w-100">
+            <DxFormLayoutTabPages>
+                <DxFormLayoutTabPage Caption="Basic">
+                    <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
+                        <DxTextBox @bind-Text="@this.ViewModel.ElementDefinition.ShortName" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
+                        <DxTextBox @bind-Text="@this.ViewModel.ElementDefinition.Name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Owner:" ColSpanMd="10">
+                        <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)"
+                                                   DisplayText="@(string.Empty)"/>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Is Top Element:" ColSpanMd="6">
+                        <DxCheckBox @bind-Checked="@this.ViewModel.IsTopElement" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutTabPage>
+
+                <DxFormLayoutTabPage Caption="Category">
+                    <DxFormLayoutItem Caption="Select the Categories:" ColSpanMd="10" CaptionPosition="CaptionPosition.Vertical">
+                        <DxListBox Data="@this.ViewModel.AvailableCategories.OrderBy(x => x.Name)"
+                                   @bind-Values="@this.ViewModel.SelectedCategories"
+                                   SelectionMode="ListBoxSelectionMode.Multiple"
+                                   TextFieldName="@nameof(Category.Name)"
+                                   ShowCheckboxes="true"/>
+                    </DxFormLayoutItem>
+                </DxFormLayoutTabPage>
+
+                <DxFormLayoutTabPage Caption="Definition">
+                    <DefinitionsTable Thing="@this.ViewModel.ElementDefinition"/>
+                </DxFormLayoutTabPage>
+            </DxFormLayoutTabPages>
+        </DxFormLayout>
+        <div class="modal-footer m-top-10px">
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true" />
+        </div>
+    </EditForm>
+}

--- a/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor.cs
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EditElementDefinition.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.ModelEditor
+{
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Partial class for the <see cref="EditElementDefinition" /> component.
+    /// </summary>
+    public partial class EditElementDefinition
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IEditElementDefinitionViewModel" /> driving the form.
+        /// </summary>
+        [Parameter]
+        public IEditElementDefinitionViewModel ViewModel { get; set; }
+    }
+}

--- a/COMETwebapp/Components/ModelEditor/EditElementUsage.razor
+++ b/COMETwebapp/Components/ModelEditor/EditElementUsage.razor
@@ -1,0 +1,40 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+
+@if (this.ViewModel.ElementUsage is not null)
+{
+    <EditForm Context="EditFormContext" Model="@this.ViewModel.ElementUsage" OnValidSubmit="@this.ViewModel.OnValidSubmit">
+        <DxFormLayout CssClass="w-100">
+            <DxFormLayoutItem Caption="Shortname:" ColSpanMd="10">
+                <DxTextBox @bind-Text="@this.ViewModel.ElementUsage.ShortName" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Name:" ColSpanMd="10">
+                <DxTextBox @bind-Text="@this.ViewModel.ElementUsage.Name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Owner:" ColSpanMd="10">
+                <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)"
+                                           DisplayText="@(string.Empty)"/>
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        <div class="modal-footer m-top-10px">
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true" />
+        </div>
+    </EditForm>
+}

--- a/COMETwebapp/Components/ModelEditor/EditElementUsage.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/EditElementUsage.razor.cs
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EditElementUsage.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.ModelEditor
+{
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Partial class for the <see cref="EditElementUsage" /> component.
+    /// </summary>
+    public partial class EditElementUsage
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IEditElementUsageViewModel" /> driving the form.
+        /// </summary>
+        [Parameter]
+        public IEditElementUsageViewModel ViewModel { get; set; }
+    }
+}

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -102,21 +102,13 @@
                         }
 
                         <DxButton Id="addElementDefinition" Text="Add Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
-
-                        @if (this.ViewModel.SelectedElement is not null)
-                        {
-                            <DxButton Id="deleteElement"
-                                      Text="Delete"
-                                      IconCssClass="oi oi-trash"
-                                      RenderStyle="ButtonRenderStyle.Danger"
-                                      Click="@this.ViewModel.OpenDeleteElementPopup"
-                                      Enabled="@(!this.ViewModel.IsSelectedElementTopElement)"
-                                      title="@(this.ViewModel.IsSelectedElementTopElement ? "The top element of the iteration cannot be deleted" : "Delete the selected element")"/>
-                        }
                     </div>
                 </div>
                 <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"
-                                    OnDeleteParameter="@(parameter => this.ViewModel.OpenDeleteParameterPopup(parameter))"/>
+                                    OnDeleteParameter="@(parameter => this.ViewModel.OpenDeleteParameterPopup(parameter))"
+                                    OnEditElement="@this.ViewModel.OpenEditElementPopup"
+                                    OnDeleteElement="@this.ViewModel.OpenDeleteElementPopup"
+                                    DisableDelete="@this.ViewModel.IsSelectedElementTopElement"/>
             </DataItemDetailsComponent>
         </div>
     </div>
@@ -141,5 +133,21 @@
     <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteElementPopupViewModel"/>
 
     <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteParameterPopupViewModel"/>
+
+    <DxPopup CloseOnOutsideClick="false"
+             HeaderText="@(this.ViewModel.SelectedElement is ElementUsage ? "Edit Element Usage" : "Edit Element Definition")"
+             @bind-Visible="@this.ViewModel.IsOnEditMode"
+             Width="40vw">
+        <BodyContentTemplate>
+            @if (this.ViewModel.SelectedElement is ElementUsage)
+            {
+                <EditElementUsage ViewModel="@this.ViewModel.EditElementUsageViewModel"/>
+            }
+            else if (this.ViewModel.SelectedElement is ElementDefinition)
+            {
+                <EditElementDefinition ViewModel="@this.ViewModel.EditElementDefinitionViewModel"/>
+            }
+        </BodyContentTemplate>
+    </DxPopup>
 
 </LoadingComponent>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -73,6 +73,7 @@ namespace COMETwebapp.Components.ModelEditor
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnCreationMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnAddingParameterMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnCopySettingsMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnEditMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsSourceModelSameAsTargetModel).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
 
             this.Disposables.Add(this.WhenAnyValue(x => x.SourceTree.ViewModel.Iteration).SubscribeAsync(x =>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
@@ -1,0 +1,163 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditElementDefinitionViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// View model driving the edit-Element-Definition popup. Holds a working clone of the target
+    /// <see cref="ElementDefinition" /> so the form can mutate state without leaking changes back into
+    /// the cached domain graph until the surrounding commit succeeds. The containing
+    /// <see cref="Iteration" /> is held uncloned so the domain-of-expertise selector can resolve it
+    /// through the open <see cref="ISession" />; it is cloned at submit time when a
+    /// <see cref="Iteration.TopElement" /> change must be persisted.
+    /// </summary>
+    public class EditElementDefinitionViewModel : IEditElementDefinitionViewModel
+    {
+        /// <summary>
+        /// The <see cref="ISessionService" /> queried for the available
+        /// <see cref="DefinedThing.Definition" /> categories.
+        /// </summary>
+        private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditElementDefinitionViewModel" /> class.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /> used to look up reference data libraries.</param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus" /> used by the domain selector.</param>
+        public EditElementDefinitionViewModel(ISessionService sessionService, ICDPMessageBus messageBus)
+        {
+            this.sessionService = sessionService;
+
+            this.DomainOfExpertiseSelectorViewModel = new DomainOfExpertiseSelectorViewModel(sessionService, messageBus)
+            {
+                OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner =>
+                {
+                    if (this.ElementDefinition is not null)
+                    {
+                        this.ElementDefinition.Owner = selectedOwner;
+                    }
+                })
+            };
+        }
+
+        /// <summary>
+        /// Gets the working clone of the <see cref="ElementDefinition" /> bound to the form. Set by
+        /// <see cref="InitializeViewModel" />.
+        /// </summary>
+        public ElementDefinition ElementDefinition { get; private set; }
+
+        /// <summary>
+        /// Gets the original <see cref="Iteration" /> containing <see cref="ElementDefinition" />. Held
+        /// uncloned so that the domain-of-expertise selector — which queries the session for the active
+        /// domain — can resolve the iteration in <see cref="ISession.OpenIterations" />. The iteration is
+        /// cloned at submit time when an <see cref="Iteration.TopElement" /> change must be persisted.
+        /// </summary>
+        public Iteration Iteration { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the categories selected by the user on the form.
+        /// </summary>
+        public IEnumerable<Category> SelectedCategories { get; set; } = new List<Category>();
+
+        /// <summary>
+        /// Gets the categories permitted on an <see cref="ElementDefinition" /> across all open
+        /// reference data libraries. Recomputed on every <see cref="InitializeViewModel" /> call so the
+        /// list reflects the currently-open RDLs.
+        /// </summary>
+        public IEnumerable<Category> AvailableCategories { get; private set; } = new List<Category>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the edited <see cref="ElementDefinition" /> should be
+        /// promoted to <see cref="Iteration.TopElement" /> on save. Initialized to the iteration's current
+        /// top-element identity.
+        /// </summary>
+        public bool IsTopElement { get; set; }
+
+        /// <summary>
+        /// Gets the selector view model used by the form to pick the owning
+        /// <see cref="DomainOfExpertise" />.
+        /// </summary>
+        public IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked by the form when the user submits a valid edit. Wired by the
+        /// owning <see cref="ModelEditorViewModel" /> to the actual save handler.
+        /// </summary>
+        public EventCallback OnValidSubmit { get; set; }
+
+        /// <summary>
+        /// Initializes the view model with a clone of the <see cref="ElementDefinition" /> to edit and the
+        /// original <see cref="Iteration" /> that contains it. The iteration must be the original — the
+        /// one registered in <see cref="ISession.OpenIterations" /> — because
+        /// <see cref="DomainOfExpertiseSelectorViewModel" /> resolves the active domain through the
+        /// session, which only knows about open iterations. The iteration is cloned later, only when the
+        /// edit is committed (so an optional <see cref="Iteration.TopElement" /> change can be persisted).
+        /// </summary>
+        /// <param name="elementDefinition">A clone of the <see cref="ElementDefinition" /> to edit.</param>
+        /// <param name="iteration">The original <see cref="Iteration" /> containing the element definition.</param>
+        public void InitializeViewModel(ElementDefinition elementDefinition, Iteration iteration)
+        {
+            ArgumentNullException.ThrowIfNull(elementDefinition);
+            ArgumentNullException.ThrowIfNull(iteration);
+
+            this.ElementDefinition = elementDefinition;
+            this.Iteration = iteration;
+            this.SelectedCategories = elementDefinition.Category.ToList();
+            this.IsTopElement = iteration.TopElement?.Iid == elementDefinition.Iid;
+
+            this.DomainOfExpertiseSelectorViewModel.CurrentIteration = iteration;
+            this.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise = ((EngineeringModel)iteration.Container).EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
+            this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(elementDefinition.Owner is null, elementDefinition.Owner);
+
+            this.AvailableCategories = this.GetAvailableCategories();
+        }
+
+        /// <summary>
+        /// Builds the union of categories that permit <see cref="ClassKind.ElementDefinition" /> across
+        /// every reference data library currently available on the open <see cref="ISession" />.
+        /// </summary>
+        /// <returns>The flattened, distinct list of permissible categories.</returns>
+        private List<Category> GetAvailableCategories()
+        {
+            var categories = new List<Category>();
+
+            foreach (var referenceDataLibrary in this.sessionService.Session.RetrieveSiteDirectory().AvailableReferenceDataLibraries())
+            {
+                categories.AddRange(referenceDataLibrary.DefinedCategory.Where(category => category.PermissibleClass.Contains(ClassKind.ElementDefinition)));
+            }
+
+            return categories.Distinct().ToList();
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/IEditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/IEditElementDefinitionViewModel.cs
@@ -1,0 +1,91 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IEditElementDefinitionViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// View model contract driving the edit-Element-Definition popup.
+    /// </summary>
+    public interface IEditElementDefinitionViewModel
+    {
+        /// <summary>
+        /// Gets the working clone of the <see cref="ElementDefinition" /> bound to the form. The clone is
+        /// mutated by the form fields (and by <see cref="COMETwebapp.Components.Common.DefinitionsTable" />
+        /// via its <see cref="DefinedThing.Definition" /> collection); the original is left untouched until
+        /// the surrounding service successfully commits the operation.
+        /// </summary>
+        ElementDefinition ElementDefinition { get; }
+
+        /// <summary>
+        /// Gets the original <see cref="Iteration" /> containing <see cref="ElementDefinition" />. Held
+        /// uncloned so the domain-of-expertise selector can resolve the iteration through the open
+        /// session. The iteration is cloned at submit time when an <see cref="Iteration.TopElement" />
+        /// change must be persisted.
+        /// </summary>
+        Iteration Iteration { get; }
+
+        /// <summary>
+        /// Gets or sets the categories selected on the form.
+        /// </summary>
+        IEnumerable<Category> SelectedCategories { get; set; }
+
+        /// <summary>
+        /// Gets the categories permitted on an <see cref="ElementDefinition" /> across all open
+        /// reference data libraries.
+        /// </summary>
+        IEnumerable<Category> AvailableCategories { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the edited <see cref="ElementDefinition" /> should be
+        /// promoted to <see cref="Iteration.TopElement" /> on save.
+        /// </summary>
+        bool IsTopElement { get; set; }
+
+        /// <summary>
+        /// Gets the selector view model used by the form to pick the owning
+        /// <see cref="DomainOfExpertise" />.
+        /// </summary>
+        IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked by the form when the user submits a valid edit.
+        /// </summary>
+        EventCallback OnValidSubmit { get; set; }
+
+        /// <summary>
+        /// Initializes the view model with deep clones of the <see cref="ElementDefinition" /> and its
+        /// containing <see cref="Iteration" /> so the form can mutate state without leaking changes back
+        /// into the cached domain graph until the commit succeeds.
+        /// </summary>
+        /// <param name="elementDefinition">The <see cref="ElementDefinition" /> the user is editing.</param>
+        /// <param name="iteration">The <see cref="Iteration" /> containing the element definition.</param>
+        void InitializeViewModel(ElementDefinition elementDefinition, Iteration iteration);
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
@@ -1,0 +1,97 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditElementUsageViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// View model driving the edit-Element-Usage popup. Holds a working clone of the target
+    /// <see cref="ElementUsage" /> so the form can mutate state without leaking changes back into the
+    /// cached domain graph until the surrounding commit succeeds.
+    /// </summary>
+    public class EditElementUsageViewModel : IEditElementUsageViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditElementUsageViewModel" /> class.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /> used by the domain selector.</param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus" /> used by the domain selector.</param>
+        public EditElementUsageViewModel(ISessionService sessionService, ICDPMessageBus messageBus)
+        {
+            this.DomainOfExpertiseSelectorViewModel = new DomainOfExpertiseSelectorViewModel(sessionService, messageBus)
+            {
+                OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner =>
+                {
+                    if (this.ElementUsage is not null)
+                    {
+                        this.ElementUsage.Owner = selectedOwner;
+                    }
+                })
+            };
+        }
+
+        /// <summary>
+        /// Gets the working clone of the <see cref="ElementUsage" /> bound to the form. Set by
+        /// <see cref="InitializeViewModel" />.
+        /// </summary>
+        public ElementUsage ElementUsage { get; private set; }
+
+        /// <summary>
+        /// Gets the selector view model used by the form to pick the owning
+        /// <see cref="DomainOfExpertise" />.
+        /// </summary>
+        public IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked by the form when the user submits a valid edit. Wired by the
+        /// owning <see cref="ModelEditorViewModel" /> to the actual save handler.
+        /// </summary>
+        public EventCallback OnValidSubmit { get; set; }
+
+        /// <summary>
+        /// Initializes the view model with the supplied clone of the <see cref="ElementUsage" /> and
+        /// refreshes the owning-domain selector so the form starts from a coherent baseline.
+        /// </summary>
+        /// <param name="elementUsage">A clone of the <see cref="ElementUsage" /> to edit.</param>
+        /// <param name="iteration">The <see cref="Iteration" /> containing the usage's element definition.</param>
+        public void InitializeViewModel(ElementUsage elementUsage, Iteration iteration)
+        {
+            ArgumentNullException.ThrowIfNull(elementUsage);
+            ArgumentNullException.ThrowIfNull(iteration);
+
+            this.ElementUsage = elementUsage;
+
+            this.DomainOfExpertiseSelectorViewModel.CurrentIteration = iteration;
+            this.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise = ((EngineeringModel)iteration.Container).EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
+            this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(elementUsage.Owner is null, elementUsage.Owner);
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/IEditElementUsageViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/IEditElementUsageViewModel.cs
@@ -1,0 +1,63 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IEditElementUsageViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// View model contract driving the edit-Element-Usage popup.
+    /// </summary>
+    public interface IEditElementUsageViewModel
+    {
+        /// <summary>
+        /// Gets the working clone of the <see cref="ElementUsage" /> bound to the form. The clone is
+        /// mutated by the form fields; the original is left untouched until the surrounding service
+        /// successfully commits the operation.
+        /// </summary>
+        ElementUsage ElementUsage { get; }
+
+        /// <summary>
+        /// Gets the selector view model used by the form to pick the owning
+        /// <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />.
+        /// </summary>
+        IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked by the form when the user submits a valid edit.
+        /// </summary>
+        EventCallback OnValidSubmit { get; set; }
+
+        /// <summary>
+        /// Initializes the view model with a clone of the <see cref="ElementUsage" /> so the form can
+        /// mutate state without leaking changes back into the cached domain graph until the commit
+        /// succeeds.
+        /// </summary>
+        /// <param name="elementUsage">The <see cref="ElementUsage" /> the user is editing.</param>
+        /// <param name="iteration">The <see cref="Iteration" /> containing the usage's element definition.</param>
+        void InitializeViewModel(ElementUsage elementUsage, Iteration iteration);
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
@@ -31,6 +31,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     using COMETwebapp.Components.ModelEditor;
     using COMETwebapp.ViewModels.Components.ModelEditor.AddParameterViewModel;
     using COMETwebapp.ViewModels.Components.ModelEditor.CopySettings;
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel;
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel;
     using COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreationViewModel;
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
 
@@ -193,5 +195,41 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// </summary>
         /// <returns>A <see cref="Task" /> representing the asynchronous delete operation.</returns>
         Task DeleteSelectedParameterAsync();
+
+        /// <summary>
+        /// Gets the <see cref="IEditElementDefinitionViewModel" /> driving the edit-Element-Definition popup.
+        /// </summary>
+        IEditElementDefinitionViewModel EditElementDefinitionViewModel { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IEditElementUsageViewModel" /> driving the edit-Element-Usage popup.
+        /// </summary>
+        IEditElementUsageViewModel EditElementUsageViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user is currently editing
+        /// <see cref="SelectedElement" /> through the edit-Element popup.
+        /// </summary>
+        bool IsOnEditMode { get; set; }
+
+        /// <summary>
+        /// Opens the edit-Element popup for <see cref="SelectedElement" />, initializing whichever child
+        /// view model corresponds to the kind of selection.
+        /// </summary>
+        void OpenEditElementPopup();
+
+        /// <summary>
+        /// Performs the edit of the selected <see cref="ElementDefinition" /> via the session service.
+        /// Always closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous edit operation.</returns>
+        Task EditElementDefinitionAsync();
+
+        /// <summary>
+        /// Performs the edit of the selected <see cref="ElementUsage" /> via the session service. Always
+        /// closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous edit operation.</returns>
+        Task EditElementUsageAsync();
     }
 }

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -42,6 +42,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     using COMETwebapp.Components.ModelEditor;
     using COMETwebapp.ViewModels.Components.ModelEditor.AddParameterViewModel;
     using COMETwebapp.ViewModels.Components.ModelEditor.CopySettings;
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionViewModel;
+    using COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewModel;
     using COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreationViewModel;
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
     using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows;
@@ -115,6 +117,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         private bool isOnDeletionMode;
 
         /// <summary>
+        /// Backing field for <see cref="IsOnEditMode" />.
+        /// </summary>
+        private bool isOnEditMode;
+
+        /// <summary>
         /// The <see cref="Parameter" /> the user requested to delete, captured when
         /// <see cref="OpenDeleteParameterPopup" /> is invoked and consumed by
         /// <see cref="DeleteSelectedParameterAsync" />.
@@ -168,6 +175,16 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedParameterAsync)
             };
 
+            this.EditElementDefinitionViewModel = new EditElementDefinitionViewModel.EditElementDefinitionViewModel(sessionService, messageBus)
+            {
+                OnValidSubmit = eventCallbackFactory.Create(this, this.EditElementDefinitionAsync)
+            };
+
+            this.EditElementUsageViewModel = new EditElementUsageViewModel.EditElementUsageViewModel(sessionService, messageBus)
+            {
+                OnValidSubmit = eventCallbackFactory.Create(this, this.EditElementUsageAsync)
+            };
+
             this.InitializeSubscriptions([typeof(ElementBase)]);
 
             this.Disposables.Add(
@@ -197,6 +214,16 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// Gets the <see cref="IElementDefinitionCreationViewModel" />
         /// </summary>
         public IElementDefinitionCreationViewModel ElementDefinitionCreationViewModel { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IEditElementDefinitionViewModel" /> driving the edit-Element-Definition popup.
+        /// </summary>
+        public IEditElementDefinitionViewModel EditElementDefinitionViewModel { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IEditElementUsageViewModel" /> driving the edit-Element-Usage popup.
+        /// </summary>
+        public IEditElementUsageViewModel EditElementUsageViewModel { get; }
 
         /// <summary>
         /// Gets the <see cref="IAddParameterViewModel" />
@@ -310,6 +337,16 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         {
             get => this.isOnDeletionMode;
             set => this.RaiseAndSetIfChanged(ref this.isOnDeletionMode, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user is currently editing
+        /// <see cref="SelectedElement" /> through the edit-Element popup.
+        /// </summary>
+        public bool IsOnEditMode
+        {
+            get => this.isOnEditMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnEditMode, value);
         }
 
         /// <summary>
@@ -540,6 +577,152 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
             {
                 OnSuccess = $"Parameter '{label}' deleted",
                 OnError = $"Failed to delete Parameter '{label}'"
+            };
+        }
+
+        /// <summary>
+        /// Opens the edit-Element popup for <see cref="SelectedElement" />, initializing whichever child
+        /// view model corresponds to the kind of selection (<see cref="ElementDefinition" /> or
+        /// <see cref="ElementUsage" />) with deep clones of the target so the form mutates a private copy.
+        /// </summary>
+        public void OpenEditElementPopup()
+        {
+            switch (this.SelectedElement)
+            {
+                case ElementDefinition elementDefinition:
+                {
+                    var iteration = elementDefinition.GetContainerOfType<Iteration>();
+                    this.EditElementDefinitionViewModel.InitializeViewModel((ElementDefinition)elementDefinition.Clone(true), iteration);
+                    this.IsOnEditMode = true;
+                    break;
+                }
+
+                case ElementUsage elementUsage:
+                {
+                    var iteration = elementUsage.GetContainerOfType<Iteration>();
+                    this.EditElementUsageViewModel.InitializeViewModel((ElementUsage)elementUsage.Clone(false), iteration);
+                    this.IsOnEditMode = true;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs the edit of the selected <see cref="ElementDefinition" /> using the working clones held
+        /// by <see cref="EditElementDefinitionViewModel" />. Promotes the cloned definition to the
+        /// iteration's <see cref="Iteration.TopElement" /> when the user opted in via the popup. Always
+        /// closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous edit operation.</returns>
+        public async Task EditElementDefinitionAsync()
+        {
+            var clonedElementDefinition = this.EditElementDefinitionViewModel.ElementDefinition;
+            var originalIteration = this.EditElementDefinitionViewModel.Iteration;
+
+            if (clonedElementDefinition is null || originalIteration is null)
+            {
+                this.CloseEditElementPopup();
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                clonedElementDefinition.Category = this.EditElementDefinitionViewModel.SelectedCategories.ToList();
+
+                var clonedIteration = originalIteration.Clone(false);
+
+                if (this.EditElementDefinitionViewModel.IsTopElement && clonedIteration.TopElement?.Iid != clonedElementDefinition.Iid)
+                {
+                    clonedIteration.TopElement = clonedElementDefinition;
+                }
+
+                var thingsToUpdate = new List<Thing> { clonedIteration, clonedElementDefinition };
+                thingsToUpdate.AddRange(clonedElementDefinition.Definition);
+
+                await this.sessionService.CreateOrUpdateThingsWithNotification(clonedIteration, thingsToUpdate, GetElementDefinitionEditNotificationDescription(clonedElementDefinition));
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error occurred while editing the Element Definition with iid {Iid}", clonedElementDefinition.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+                this.CloseEditElementPopup();
+            }
+        }
+
+        /// <summary>
+        /// Performs the edit of the selected <see cref="ElementUsage" /> using the working clone held by
+        /// <see cref="EditElementUsageViewModel" />. Always closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous edit operation.</returns>
+        public async Task EditElementUsageAsync()
+        {
+            var clonedElementUsage = this.EditElementUsageViewModel.ElementUsage;
+
+            if (clonedElementUsage is null || this.SelectedElement is not ElementUsage originalElementUsage)
+            {
+                this.CloseEditElementPopup();
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                var clonedContainer = originalElementUsage.Container.Clone(false);
+
+                await this.sessionService.CreateOrUpdateThingsWithNotification(clonedContainer, new[] { (Thing)clonedElementUsage }, GetElementUsageEditNotificationDescription(clonedElementUsage));
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error occurred while editing the Element Usage with iid {Iid}", clonedElementUsage.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+                this.CloseEditElementPopup();
+            }
+        }
+
+        /// <summary>
+        /// Closes the edit-Element popup.
+        /// </summary>
+        private void CloseEditElementPopup()
+        {
+            this.IsOnEditMode = false;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="NotificationDescription" /> used to surface the success / failure of an
+        /// <see cref="ElementDefinition" /> edit through the existing notification pipeline.
+        /// </summary>
+        /// <param name="elementDefinition">The <see cref="ElementDefinition" /> being edited.</param>
+        /// <returns>The <see cref="NotificationDescription" /> describing the operation.</returns>
+        private static NotificationDescription GetElementDefinitionEditNotificationDescription(ElementDefinition elementDefinition)
+        {
+            return new NotificationDescription
+            {
+                OnSuccess = $"Element Definition '{elementDefinition.Name}' updated",
+                OnError = $"Failed to update Element Definition '{elementDefinition.Name}'"
+            };
+        }
+
+        /// <summary>
+        /// Builds a <see cref="NotificationDescription" /> used to surface the success / failure of an
+        /// <see cref="ElementUsage" /> edit through the existing notification pipeline.
+        /// </summary>
+        /// <param name="elementUsage">The <see cref="ElementUsage" /> being edited.</param>
+        /// <returns>The <see cref="NotificationDescription" /> describing the operation.</returns>
+        private static NotificationDescription GetElementUsageEditNotificationDescription(ElementUsage elementUsage)
+        {
+            return new NotificationDescription
+            {
+                OnSuccess = $"Element Usage '{elementUsage.Name}' updated",
+                OnError = $"Failed to update Element Usage '{elementUsage.Name}'"
             };
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- Adds an **Edit** for the currently-selected element in the Model Editor's right panel. The ElementDefinition form edits ShortName, Name, Owner, IsTopElement, Categories, and the multi-language Definition collection (via the existing `DefinitionsTable`). The ElementUsage form edits ShortName, Name, Owner. Both commit through `ISessionService.CreateOrUpdateThingsWithNotification`. Promoting `IsTopElement` updates the iteration's `TopElement` atomically; demoting the current top is silently ignored to mirror the delete-blocks-top rule.

<!-- Thanks for contributing to COMET-WEB! -->

