### PR TITLE
 [Add] create and delete a ParameterSubscription from the Model Editor; fixes #779

### DIFF
--- a/COMET.Web.Common/Components/CardView/CardView.razor
+++ b/COMET.Web.Common/Components/CardView/CardView.razor
@@ -43,9 +43,9 @@
             <ItemContent>
                 <div class="col" style="padding-left:0px;margin-left:0px;height:@(this.ItemSize)px;">
                     <div class="card @(this.GetSelectedClass(@context))"
-                         style="min-width:@(this.MinWidth)px"
+                         style="min-width:@(this.MinWidth)px;height:100%;max-height:100%;overflow:hidden;"
                          @onclick="@(() => this.SelectItem(@context))">
-                        <div class="card-body" style="overflow-y:hidden;overflow-x:hidden">
+                        <div class="card-body" style="height:100%;max-height:100%;overflow:hidden;">
                             <CascadingValue Name="CardView" Value = "this">
                                 <CascadingValue Name="SearchTerm" Value="this.SearchTerm">
                                     @this.ItemTemplate(@context)

--- a/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
@@ -251,6 +251,157 @@ namespace COMETwebapp.Tests.Components.ModelEditor
         }
 
         [Test]
+        public void VerifySubscribeButtonRendersOnlyWhenCanSubscribeAndCallbackBound()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var currentDomain = BuildDomain("SYS");
+            var foreignDomain = BuildDomain("PWR");
+
+            var subscribableParameter = BuildParameterOwnedBy(foreignDomain);
+            var ownedParameter = BuildParameterOwnedBy(currentDomain);
+
+            var rowAllowingSubscribe = new ElementDefinitionDetailsRowViewModel(subscribableParameter, currentDomain);
+            var rowOwnedByCurrentDomain = new ElementDefinitionDetailsRowViewModel(ownedParameter, currentDomain);
+
+            this.viewModel.Setup(x => x.Rows).Returns(new List<ElementDefinitionDetailsRowViewModel> { rowAllowingSubscribe, rowOwnedByCurrentDomain });
+
+            Parameter capturedParameter = null;
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnCreateSubscription, EventCallback.Factory.Create<Parameter>(this, p => capturedParameter = p)));
+
+            var subscribeButtons = rendered.FindAll(".oi-bell");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rowAllowingSubscribe.CanSubscribe, Is.True);
+                Assert.That(rowOwnedByCurrentDomain.CanSubscribe, Is.False);
+                Assert.That(subscribeButtons.Count, Is.EqualTo(1),
+                    "Exactly one subscribe button must render — only on the row whose current domain can subscribe.");
+            });
+
+            subscribeButtons[0].Click();
+            Assert.That(capturedParameter, Is.SameAs(subscribableParameter));
+        }
+
+        [Test]
+        public void VerifyUnsubscribeButtonRendersOnlyWhenSubscribedAndCallbackBound()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var currentDomain = BuildDomain("SYS");
+            var foreignDomain = BuildDomain("PWR");
+
+            var subscribedParameter = BuildParameterOwnedBy(foreignDomain);
+
+            var subscription = new ParameterSubscription { Iid = Guid.NewGuid(), Owner = currentDomain };
+            subscribedParameter.ParameterSubscription.Add(subscription);
+
+            var rowSubscribed = new ElementDefinitionDetailsRowViewModel(subscribedParameter, currentDomain);
+            var rowSubscribable = new ElementDefinitionDetailsRowViewModel(BuildParameterOwnedBy(foreignDomain), currentDomain);
+
+            this.viewModel.Setup(x => x.Rows).Returns(new List<ElementDefinitionDetailsRowViewModel> { rowSubscribed, rowSubscribable });
+
+            ParameterSubscription capturedSubscription = null;
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnDeleteSubscription, EventCallback.Factory.Create<ParameterSubscription>(this, s => capturedSubscription = s)));
+
+            var bellButtons = rendered.FindAll(".oi-bell");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rowSubscribed.HasCurrentDomainSubscription, Is.True);
+                Assert.That(rowSubscribable.HasCurrentDomainSubscription, Is.False);
+                Assert.That(bellButtons.Count, Is.EqualTo(1),
+                    "Only the subscribed row must render an unsubscribe (bell) button when only OnDeleteSubscription is bound.");
+            });
+
+            bellButtons[0].Click();
+            Assert.That(capturedSubscription, Is.SameAs(subscription));
+        }
+
+        [Test]
+        public void VerifySubscribeAndUnsubscribeAreMutuallyExclusivePerCard()
+        {
+            var element = BuildElementDefinitionWithEverything();
+            this.viewModel.Setup(x => x.SelectedSystemNode).Returns(element);
+
+            var currentDomain = BuildDomain("SYS");
+            var foreignDomain = BuildDomain("PWR");
+
+            var subscribedParameter = BuildParameterOwnedBy(foreignDomain);
+            subscribedParameter.ParameterSubscription.Add(new ParameterSubscription { Iid = Guid.NewGuid(), Owner = currentDomain });
+
+            var rowSubscribed = new ElementDefinitionDetailsRowViewModel(subscribedParameter, currentDomain);
+
+            this.viewModel.Setup(x => x.Rows).Returns(new List<ElementDefinitionDetailsRowViewModel> { rowSubscribed });
+
+            var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.OnCreateSubscription, EventCallback.Factory.Create<Parameter>(this, _ => { }))
+                .Add(p => p.OnDeleteSubscription, EventCallback.Factory.Create<ParameterSubscription>(this, _ => { })));
+
+            var bellButtons = rendered.FindAll(".oi-bell");
+
+            Assert.That(bellButtons.Count, Is.EqualTo(1),
+                "Subscribe and unsubscribe affordances must never both render on the same card — the if/else if branch enforces this.");
+        }
+
+        /// <summary>
+        /// Builds a <see cref="DomainOfExpertise" /> with the supplied short name.
+        /// </summary>
+        private static DomainOfExpertise BuildDomain(string shortName)
+        {
+            return new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = shortName, Name = shortName };
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Parameter" /> owned by the supplied <see cref="DomainOfExpertise" />. The
+        /// parameter is placed inside a fresh <see cref="ElementDefinition" /> container because
+        /// <see cref="Parameter.ModelCode" /> requires a container to be set.
+        /// </summary>
+        private static Parameter BuildParameterOwnedBy(DomainOfExpertise owner)
+        {
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Mass", ShortName = "m" };
+
+            var parameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = owner,
+                ParameterType = parameterType
+            };
+
+            parameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new CDP4Common.Types.ValueArray<string>(["1"]),
+                Computed = new CDP4Common.Types.ValueArray<string>(["1"]),
+                Reference = new CDP4Common.Types.ValueArray<string>(["-"]),
+                Formula = new CDP4Common.Types.ValueArray<string>(["-"]),
+                Published = new CDP4Common.Types.ValueArray<string>(["1"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            var containingDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Container",
+                ShortName = "CONT",
+                Owner = owner
+            };
+
+            containingDefinition.Parameter.Add(parameter);
+
+            return parameter;
+        }
+
+        [Test]
         public void VerifyElementUsageInheritsCategoriesFromDefinition()
         {
             var owner = new DomainOfExpertise { ShortName = "SYS", Name = "System" };

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -25,6 +25,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
 
@@ -90,6 +91,25 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
         private Parameter parameter;
 
         /// <summary>
+        /// The currently logged-in <see cref="DomainOfExpertise" /> against which the view model is
+        /// evaluated. Returned by the mocked <see cref="ISessionService.GetDomainOfExpertise" />.
+        /// </summary>
+        private DomainOfExpertise currentDomain;
+
+        /// <summary>
+        /// A foreign <see cref="DomainOfExpertise" /> — the owner of <see cref="foreignParameter" /> — used
+        /// to exercise the subscribe / unsubscribe flows from the perspective of
+        /// <see cref="currentDomain" />.
+        /// </summary>
+        private DomainOfExpertise foreignDomain;
+
+        /// <summary>
+        /// A <see cref="Parameter" /> owned by <see cref="foreignDomain" /> used to exercise the
+        /// subscription create flow.
+        /// </summary>
+        private Parameter foreignParameter;
+
+        /// <summary>
         /// Builds the iteration graph (TopElement, a referenced ElementDefinition, and a usage) and the
         /// view model with mocked dependencies.
         /// </summary>
@@ -105,9 +125,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
 
             var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.currentDomain = domain;
+            this.foreignDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "PWR", Name = "Power" };
+            this.sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(domain);
             var rdl = new SiteReferenceDataLibrary { ShortName = "siteRdl", Name = "Site RDL" };
-            var siteDirectory = new SiteDirectory { Domain = { domain }, SiteReferenceDataLibrary = { rdl } };
-            var modelSetup = new EngineeringModelSetup { Name = "ModelName", ShortName = "ModelShortName", ActiveDomain = { domain }, RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } } };
+            var siteDirectory = new SiteDirectory { Domain = { domain, this.foreignDomain }, SiteReferenceDataLibrary = { rdl } };
+            var modelSetup = new EngineeringModelSetup { Name = "ModelName", ShortName = "ModelShortName", ActiveDomain = { domain, this.foreignDomain }, RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } } };
             siteDirectory.Model.Add(modelSetup);
             var iterationSetup = new IterationSetup { IterationNumber = 1 };
             modelSetup.IterationSetup.Add(iterationSetup);
@@ -141,6 +164,26 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             };
 
             this.referencedElementDefinition.Parameter.Add(this.parameter);
+
+            this.foreignParameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.foreignDomain,
+                ParameterType = parameterType
+            };
+
+            this.foreignParameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(["1"]),
+                Computed = new ValueArray<string>(["1"]),
+                Reference = new ValueArray<string>(["-"]),
+                Formula = new ValueArray<string>(["-"]),
+                Published = new ValueArray<string>(["1"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            this.referencedElementDefinition.Parameter.Add(this.foreignParameter);
 
             this.elementUsage = new ElementUsage
             {
@@ -547,6 +590,159 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             await this.viewModel.EditElementDefinitionAsync();
 
             Assert.That(this.viewModel.IsOnEditMode, Is.False);
+        }
+
+        [Test]
+        public void VerifyOpenCreateSubscriptionPopupComposesContent()
+        {
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenCreateSubscriptionPopup(this.foreignParameter);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.IsVisible, Is.True);
+                Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.ContentText, Does.Contain(this.foreignParameter.ParameterType.Name));
+                Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.ContentText, Does.Contain(this.referencedElementDefinition.Name));
+                Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.ContentText, Does.Contain(this.currentDomain.ShortName));
+            });
+        }
+
+        [Test]
+        public void VerifyOpenCreateSubscriptionPopupNullParameterIsNoOp()
+        {
+            this.viewModel.OpenCreateSubscriptionPopup(null);
+
+            Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.IsVisible, Is.False);
+        }
+
+        [Test]
+        public void VerifyOpenCreateSubscriptionPopupForOwnedParameterIsNoOp()
+        {
+            this.viewModel.OpenCreateSubscriptionPopup(this.parameter);
+
+            Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.IsVisible, Is.False,
+                "Subscribing to a Parameter the current domain already owns is meaningless and must not open the popup.");
+        }
+
+        [Test]
+        public async Task VerifyCreateSubscriptionCallsSessionServiceWithExpectedPayload()
+        {
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+            this.viewModel.OpenCreateSubscriptionPopup(this.foreignParameter);
+            await this.viewModel.CreateSubscriptionAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(
+                    It.Is<Thing>(t => t is Parameter && t.Iid == this.foreignParameter.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c =>
+                        c.OfType<Parameter>().Any(p => p.Iid == this.foreignParameter.Iid)
+                        && c.OfType<ParameterSubscription>().Any(s => s.Owner != null && s.Owner.Iid == this.currentDomain.Iid)
+                        && c.OfType<ParameterSubscriptionValueSet>().Count() == this.foreignParameter.ValueSet.Count),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+
+            Assert.That(this.viewModel.CreateSubscriptionPopupViewModel.IsVisible, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyCreateSubscriptionWithoutTargetIsNoOp()
+        {
+            await this.viewModel.CreateSubscriptionAsync();
+
+            this.sessionService.Verify(
+                x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
+                Times.Never);
+        }
+
+        [Test]
+        public void VerifyOpenDeleteSubscriptionPopupComposesContent()
+        {
+            var subscription = new ParameterSubscription
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain
+            };
+
+            this.foreignParameter.ParameterSubscription.Add(subscription);
+
+            this.viewModel.OpenDeleteSubscriptionPopup(subscription);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.IsVisible, Is.True);
+                Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.ContentText, Does.Contain(this.foreignParameter.ParameterType.Name));
+                Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.ContentText, Does.Contain("not be removed"),
+                    "Popup must make it explicit that the parent Parameter is preserved.");
+            });
+        }
+
+        [Test]
+        public void VerifyOpenDeleteSubscriptionPopupNullIsNoOp()
+        {
+            this.viewModel.OpenDeleteSubscriptionPopup(null);
+
+            Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.IsVisible, Is.False);
+        }
+
+        [Test]
+        public void VerifyOpenDeleteSubscriptionPopupOrphanIsNoOp()
+        {
+            var orphanSubscription = new ParameterSubscription
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain
+            };
+
+            this.viewModel.OpenDeleteSubscriptionPopup(orphanSubscription);
+
+            Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.IsVisible, Is.False,
+                "A subscription whose Container is not a Parameter cannot be safely deleted from this flow.");
+        }
+
+        [Test]
+        public async Task VerifyDeleteSubscriptionDoesNotIncludeParentParameterInDeleteList()
+        {
+            var subscription = new ParameterSubscription
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain
+            };
+
+            this.foreignParameter.ParameterSubscription.Add(subscription);
+
+            this.sessionService
+                .Setup(x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.OpenDeleteSubscriptionPopup(subscription);
+            await this.viewModel.DeleteSelectedSubscriptionAsync();
+
+            this.sessionService.Verify(
+                x => x.DeleteThingsWithNotification(
+                    It.Is<Thing>(t => t is Parameter && t.Iid == this.foreignParameter.Iid),
+                    It.Is<IReadOnlyCollection<Thing>>(c =>
+                        c.Count == 1
+                        && c.Single() is ParameterSubscription
+                        && c.Single().Iid == subscription.Iid
+                        && !c.OfType<Parameter>().Any()),
+                    It.IsAny<NotificationDescription>()),
+                Times.Once);
+
+            Assert.That(this.viewModel.DeleteSubscriptionPopupViewModel.IsVisible, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyDeleteSubscriptionWithoutTargetIsNoOp()
+        {
+            await this.viewModel.DeleteSelectedSubscriptionAsync();
+
+            this.sessionService.Verify(
+                x => x.DeleteThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()),
+                Times.Never);
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/Rows/ElementDefinitionDetailsRowViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/Rows/ElementDefinitionDetailsRowViewModelTestFixture.cs
@@ -1,0 +1,171 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ElementDefinitionDetailsRowViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation.Rows
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ElementDefinitionDetailsRowViewModelTestFixture
+    {
+        /// <summary>
+        /// The currently logged-in <see cref="DomainOfExpertise" /> used to evaluate subscription state.
+        /// </summary>
+        private DomainOfExpertise currentDomain;
+
+        /// <summary>
+        /// A foreign <see cref="DomainOfExpertise" /> — owner of <see cref="parameter" />.
+        /// </summary>
+        private DomainOfExpertise foreignDomain;
+
+        /// <summary>
+        /// A <see cref="Parameter" /> owned by <see cref="foreignDomain" /> with one
+        /// <see cref="ParameterValueSet" />, used by the row VM under test.
+        /// </summary>
+        private Parameter parameter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.currentDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.foreignDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "PWR", Name = "Power" };
+
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Mass", ShortName = "m" };
+
+            this.parameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.foreignDomain,
+                ParameterType = parameterType
+            };
+
+            this.parameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(["1"]),
+                Computed = new ValueArray<string>(["1"]),
+                Reference = new ValueArray<string>(["-"]),
+                Formula = new ValueArray<string>(["-"]),
+                Published = new ValueArray<string>(["1"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            // Parameter.ModelCode() requires the parameter to live inside an ElementDefinition; satisfy that
+            // contract once at fixture level so individual tests don't have to.
+            var containingDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Container",
+                ShortName = "CONT",
+                Owner = this.foreignDomain
+            };
+
+            containingDefinition.Parameter.Add(this.parameter);
+        }
+
+        [Test]
+        public void VerifyCanSubscribeWhenForeignAndUnsubscribed()
+        {
+            var row = new ElementDefinitionDetailsRowViewModel(this.parameter, this.currentDomain);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(row.IsOwnedByCurrentDomain, Is.False);
+                Assert.That(row.HasCurrentDomainSubscription, Is.False);
+                Assert.That(row.CurrentDomainSubscription, Is.Null);
+                Assert.That(row.CanSubscribe, Is.True);
+                Assert.That(row.Owner, Is.EqualTo(this.foreignDomain.ShortName),
+                    "Owner pill must show only the parameter owner when no subscription exists.");
+            });
+        }
+
+        [Test]
+        public void VerifyCannotSubscribeWhenOwnedByCurrentDomain()
+        {
+            this.parameter.Owner = this.currentDomain;
+
+            var row = new ElementDefinitionDetailsRowViewModel(this.parameter, this.currentDomain);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(row.IsOwnedByCurrentDomain, Is.True);
+                Assert.That(row.CanSubscribe, Is.False);
+            });
+        }
+
+        [Test]
+        public void VerifySubscriptionStateWhenAlreadySubscribed()
+        {
+            var sourceValueSet = this.parameter.ValueSet[0];
+
+            var subscription = new ParameterSubscription
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain
+            };
+
+            subscription.ValueSet.Add(new ParameterSubscriptionValueSet
+            {
+                Iid = Guid.NewGuid(),
+                SubscribedValueSet = sourceValueSet,
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                Manual = new ValueArray<string>(["42"])
+            });
+
+            this.parameter.ParameterSubscription.Add(subscription);
+
+            var row = new ElementDefinitionDetailsRowViewModel(this.parameter, this.currentDomain);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(row.HasCurrentDomainSubscription, Is.True);
+                Assert.That(row.CurrentDomainSubscription, Is.SameAs(subscription));
+                Assert.That(row.CanSubscribe, Is.False);
+                Assert.That(row.Owner, Is.EqualTo(this.foreignDomain.ShortName),
+                    "Owner pill must stay compact even when subscribed; the subscription state is conveyed by the unsubscribe button, not extra text in the Owner pill (longer text wraps and breaks the fixed-size CardView slot).");
+                Assert.That(row.ActualValue, Does.Contain("42"),
+                    "ActualValue must come from the subscription value set when the current domain is subscribed.");
+            });
+        }
+
+        [Test]
+        public void VerifyNullCurrentDomainKeepsBackwardsCompatibleDisplay()
+        {
+            var row = new ElementDefinitionDetailsRowViewModel(this.parameter);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(row.IsOwnedByCurrentDomain, Is.False);
+                Assert.That(row.HasCurrentDomainSubscription, Is.False);
+                Assert.That(row.CanSubscribe, Is.False,
+                    "Without a known current domain the row must not invite a subscribe action.");
+                Assert.That(row.Owner, Is.EqualTo(this.foreignDomain.ShortName));
+            });
+        }
+    }
+}

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -89,18 +89,39 @@
 
     <CardView ScrollableAreaCssClass="cardview-detailspanel-scrollarea" Items="this.ViewModel.Rows" ItemSize="150" MinWidth="280">
         <ItemTemplate>
-            <div class="row">
-                <div class="col-8">
-                    <h6 title="@context.ParameterTypeName" style="overflow:hidden;text-overflow: ellipsis;white-space: nowrap;"><CardField Context="@context" FieldName="ParameterTypeName"/></h6>
+            <div class="row flex-nowrap align-items-center" style="margin-bottom:2px;">
+                <div class="col-7" style="min-width:0;">
+                    <h6 title="@context.ParameterTypeName" style="overflow:hidden;text-overflow: ellipsis;white-space: nowrap;margin-bottom:0;"><CardField Context="@context" FieldName="ParameterTypeName"/></h6>
                 </div>
-                <div class="col-4" align="right">
-                    <button class="starion-pill" title="Owning Domain Of Expertise: @context.Owner"><CardField Context="@context" FieldName="Owner" /></button>
+                <div class="col-5 d-flex align-items-center justify-content-end flex-nowrap" style="min-width:0;overflow:hidden;">
+                    <button class="starion-pill"
+                            title="Owning Domain Of Expertise: @context.Owner"
+                            style="min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:1;">
+                        <CardField Context="@context" FieldName="Owner" />
+                    </button>
+                    @if (this.OnCreateSubscription.HasDelegate && context.CanSubscribe)
+                    {
+                        <DxButton IconCssClass="oi oi-bell"
+                                  RenderStyleMode="ButtonRenderStyleMode.Text"
+                                  CssClass="ms-1 flex-shrink-0"
+                                  Click="@(() => this.OnCreateSubscription.InvokeAsync(context.Parameter))"
+                                  title="Subscribe to this Parameter as the current Domain of Expertise"/>
+                    }
+                    else if (this.OnDeleteSubscription.HasDelegate && context.HasCurrentDomainSubscription)
+                    {
+                        <DxButton IconCssClass="oi oi-bell"
+                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyleMode="ButtonRenderStyleMode.Text"
+                                  CssClass="ms-1 flex-shrink-0"
+                                  Click="@(() => this.OnDeleteSubscription.InvokeAsync(context.CurrentDomainSubscription))"
+                                  title="Remove this Domain's subscription to the Parameter (the Parameter itself is kept)"/>
+                    }
                     @if (this.OnDeleteParameter.HasDelegate)
                     {
                         <DxButton IconCssClass="oi oi-trash"
                                   RenderStyle="ButtonRenderStyle.Danger"
                                   RenderStyleMode="ButtonRenderStyleMode.Text"
-                                  CssClass="ms-1"
+                                  CssClass="ms-1 flex-shrink-0"
                                   Click="@(() => this.OnDeleteParameter.InvokeAsync(context.Parameter))"
                                   title="Delete this parameter"/>
                     }

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
@@ -50,6 +50,24 @@ namespace COMETwebapp.Components.ModelEditor
 		public EventCallback<Parameter> OnDeleteParameter { get; set; }
 
 		/// <summary>
+		///     Optional callback invoked when the user clicks the per-card subscribe affordance for a
+		///     <see cref="Parameter" /> not owned by the currently logged-in
+		///     <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" /> and not yet subscribed to by it.
+		///     When unset, the subscribe affordance is not rendered.
+		/// </summary>
+		[Parameter]
+		public EventCallback<Parameter> OnCreateSubscription { get; set; }
+
+		/// <summary>
+		///     Optional callback invoked when the user clicks the per-card unsubscribe affordance to remove
+		///     an existing <see cref="ParameterSubscription" /> belonging to the currently logged-in
+		///     <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />. When unset, the unsubscribe
+		///     affordance is not rendered.
+		/// </summary>
+		[Parameter]
+		public EventCallback<ParameterSubscription> OnDeleteSubscription { get; set; }
+
+		/// <summary>
 		///     Optional callback invoked when the user clicks the Edit affordance on the summary card.
 		///     When unset, the Edit button is not rendered.
 		/// </summary>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -106,6 +106,8 @@
                 </div>
                 <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"
                                     OnDeleteParameter="@(parameter => this.ViewModel.OpenDeleteParameterPopup(parameter))"
+                                    OnCreateSubscription="@(parameter => this.ViewModel.OpenCreateSubscriptionPopup(parameter))"
+                                    OnDeleteSubscription="@(subscription => this.ViewModel.OpenDeleteSubscriptionPopup(subscription))"
                                     OnEditElement="@this.ViewModel.OpenEditElementPopup"
                                     OnDeleteElement="@this.ViewModel.OpenDeleteElementPopup"
                                     DisableDelete="@this.ViewModel.IsSelectedElementTopElement"/>
@@ -133,6 +135,10 @@
     <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteElementPopupViewModel"/>
 
     <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteParameterPopupViewModel"/>
+
+    <ConfirmCancelPopup ViewModel="@this.ViewModel.CreateSubscriptionPopupViewModel"/>
+
+    <ConfirmCancelPopup ViewModel="@this.ViewModel.DeleteSubscriptionPopupViewModel"/>
 
     <DxPopup CloseOnOutsideClick="false"
              HeaderText="@(this.ViewModel.SelectedElement is ElementUsage ? "Edit Element Usage" : "Edit Element Definition")"

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
@@ -197,6 +197,54 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         Task DeleteSelectedParameterAsync();
 
         /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> driving the create-confirmation popup for a
+        /// new <see cref="ParameterSubscription" /> by the currently logged-in
+        /// <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />.
+        /// </summary>
+        IConfirmCancelPopupViewModel CreateSubscriptionPopupViewModel { get; }
+
+        /// <summary>
+        /// Opens the create-confirmation popup for a <see cref="ParameterSubscription" />. Composes a content
+        /// message that names the parameter and the current domain. No-op when no current domain is known
+        /// or the parameter is already owned by the current domain.
+        /// </summary>
+        /// <param name="parameter">The <see cref="Parameter" /> the user wants to subscribe to.</param>
+        void OpenCreateSubscriptionPopup(Parameter parameter);
+
+        /// <summary>
+        /// Performs the creation of the <see cref="ParameterSubscription" /> previously captured by
+        /// <see cref="OpenCreateSubscriptionPopup" /> via the session service. Always closes the popup.
+        /// The visible card refresh is driven by the existing message-bus end-update / session-refreshed
+        /// pipeline, not by mutating the rows here.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous create operation.</returns>
+        Task CreateSubscriptionAsync();
+
+        /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> driving the delete-confirmation popup for a
+        /// <see cref="ParameterSubscription" /> belonging to the currently logged-in
+        /// <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />.
+        /// </summary>
+        IConfirmCancelPopupViewModel DeleteSubscriptionPopupViewModel { get; }
+
+        /// <summary>
+        /// Opens the delete-confirmation popup for a <see cref="ParameterSubscription" />. Composes a content
+        /// message that makes it explicit only the subscription is removed — the parent
+        /// <see cref="Parameter" /> is kept.
+        /// </summary>
+        /// <param name="subscription">The <see cref="ParameterSubscription" /> the user wants to delete.</param>
+        void OpenDeleteSubscriptionPopup(ParameterSubscription subscription);
+
+        /// <summary>
+        /// Performs the deletion of the <see cref="ParameterSubscription" /> previously captured by
+        /// <see cref="OpenDeleteSubscriptionPopup" /> via the session service. The parent
+        /// <see cref="Parameter" /> is used as the operation top container but is never included in the
+        /// things-to-delete collection, so the parameter itself stays. Always closes the popup.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous delete operation.</returns>
+        Task DeleteSelectedSubscriptionAsync();
+
+        /// <summary>
         /// Gets the <see cref="IEditElementDefinitionViewModel" /> driving the edit-Element-Definition popup.
         /// </summary>
         IEditElementDefinitionViewModel EditElementDefinitionViewModel { get; }

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -25,6 +25,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -129,6 +130,20 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         private Parameter selectedParameterToDelete;
 
         /// <summary>
+        /// The <see cref="Parameter" /> the user requested to subscribe to, captured when
+        /// <see cref="OpenCreateSubscriptionPopup" /> is invoked and consumed by
+        /// <see cref="CreateSubscriptionAsync" />.
+        /// </summary>
+        private Parameter selectedParameterToSubscribe;
+
+        /// <summary>
+        /// The <see cref="ParameterSubscription" /> the user requested to delete, captured when
+        /// <see cref="OpenDeleteSubscriptionPopup" /> is invoked and consumed by
+        /// <see cref="DeleteSelectedSubscriptionAsync" />.
+        /// </summary>
+        private ParameterSubscription selectedSubscriptionToDelete;
+
+        /// <summary>
         /// Creates a new instance of <see cref="ModelEditorViewModel" />
         /// </summary>
         /// <param name="sessionService">the <see cref="ISessionService" /></param>
@@ -173,6 +188,24 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 CancelRenderStyle = ButtonRenderStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteParameterCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedParameterAsync)
+            };
+
+            this.CreateSubscriptionPopupViewModel = new ConfirmCancelPopupViewModel
+            {
+                HeaderText = "Create Parameter Subscription",
+                ConfirmRenderStyle = ButtonRenderStyle.Primary,
+                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                OnCancel = eventCallbackFactory.Create(this, this.OnCreateSubscriptionCancelled),
+                OnConfirm = eventCallbackFactory.Create(this, this.CreateSubscriptionAsync)
+            };
+
+            this.DeleteSubscriptionPopupViewModel = new ConfirmCancelPopupViewModel
+            {
+                HeaderText = "Delete Parameter Subscription",
+                ConfirmRenderStyle = ButtonRenderStyle.Danger,
+                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                OnCancel = eventCallbackFactory.Create(this, this.OnDeleteSubscriptionCancelled),
+                OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedSubscriptionAsync)
             };
 
             this.EditElementDefinitionViewModel = new EditElementDefinitionViewModel.EditElementDefinitionViewModel(sessionService, messageBus)
@@ -315,7 +348,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 _ => null
             };
 
-            this.ElementDefinitionDetailsViewModel.Rows = this.SelectedElementDefinition?.Parameter.Select(x => new ElementDefinitionDetailsRowViewModel(x)).ToList();
+            this.ElementDefinitionDetailsViewModel.Rows = this.SelectedElementDefinition?.Parameter.Select(x => new ElementDefinitionDetailsRowViewModel(x, this.CurrentDomain)).ToList();
             this.AddParameterViewModel.SetSelectedElementDefinition(this.SelectedElementDefinition);
         }
 
@@ -530,7 +563,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 {
                     this.ElementDefinitionDetailsViewModel.Rows = this.SelectedElementDefinition.Parameter
                         .Where(x => x.Iid != parameter.Iid)
-                        .Select(x => new ElementDefinitionDetailsRowViewModel(x))
+                        .Select(x => new ElementDefinitionDetailsRowViewModel(x, this.CurrentDomain))
                         .ToList();
                 }
             }
@@ -577,6 +610,251 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
             {
                 OnSuccess = $"Parameter '{label}' deleted",
                 OnError = $"Failed to delete Parameter '{label}'"
+            };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> driving the create-confirmation popup for a
+        /// new <see cref="ParameterSubscription" /> by the currently logged-in
+        /// <see cref="DomainOfExpertise" />.
+        /// </summary>
+        public IConfirmCancelPopupViewModel CreateSubscriptionPopupViewModel { get; }
+
+        /// <summary>
+        /// Opens the create-confirmation popup for the supplied <see cref="Parameter" />, captures the
+        /// parameter as the subscription target, and composes a content message that names the parameter,
+        /// its containing <see cref="ElementDefinition" /> and the current <see cref="DomainOfExpertise" />.
+        /// No-op when there is no current domain or when the parameter is already owned by the current
+        /// domain — neither case admits a subscription.
+        /// </summary>
+        /// <param name="parameter">The <see cref="Parameter" /> the user requested to subscribe to.</param>
+        public void OpenCreateSubscriptionPopup(Parameter parameter)
+        {
+            if (parameter is null || this.CurrentDomain is null)
+            {
+                return;
+            }
+
+            if (parameter.Owner != null && parameter.Owner.Iid == this.CurrentDomain.Iid)
+            {
+                return;
+            }
+
+            this.selectedParameterToSubscribe = parameter;
+
+            var parameterTypeName = parameter.ParameterType?.Name ?? "Parameter";
+            var containerName = parameter.Container is ElementDefinition containing ? containing.Name : null;
+
+            this.CreateSubscriptionPopupViewModel.ContentText = string.IsNullOrWhiteSpace(containerName)
+                ? $"You are about to subscribe to Parameter '{parameterTypeName}' as Domain '{this.CurrentDomain.ShortName}'."
+                : $"You are about to subscribe to Parameter '{parameterTypeName}' on Element Definition '{containerName}' as Domain '{this.CurrentDomain.ShortName}'.";
+
+            this.CreateSubscriptionPopupViewModel.IsVisible = true;
+        }
+
+        /// <summary>
+        /// Performs the creation of a new <see cref="ParameterSubscription" /> for the parameter captured by
+        /// <see cref="OpenCreateSubscriptionPopup" /> using
+        /// <see cref="ISessionService.CreateOrUpdateThingsWithNotification" />. The cloned parent
+        /// <see cref="Parameter" /> is the operation top container; the new subscription and a
+        /// <see cref="ParameterSubscriptionValueSet" /> per source <see cref="ParameterValueSet" /> are
+        /// included as things-to-create. The visible card refresh is driven by the existing
+        /// <see cref="ICDPMessageBus" /> end-update / session-refreshed pipeline that already reaches
+        /// <see cref="OnSessionRefreshed" />.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous create operation.</returns>
+        public async Task CreateSubscriptionAsync()
+        {
+            var parameter = this.selectedParameterToSubscribe;
+
+            if (parameter is null || this.CurrentDomain is null)
+            {
+                this.CloseCreateSubscriptionPopup();
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                var clonedParameter = parameter.Clone(false);
+
+                var subscription = new ParameterSubscription
+                {
+                    Iid = Guid.NewGuid(),
+                    Owner = this.CurrentDomain
+                };
+
+                var thingsToCreate = new List<Thing> { clonedParameter, subscription };
+
+                foreach (var sourceValueSet in parameter.ValueSet)
+                {
+                    var subscriptionValueSet = new ParameterSubscriptionValueSet
+                    {
+                        Iid = Guid.NewGuid(),
+                        SubscribedValueSet = sourceValueSet,
+                        ValueSwitch = sourceValueSet.ValueSwitch,
+                        Manual = new ValueArray<string>(["-"])
+                    };
+
+                    subscription.ValueSet.Add(subscriptionValueSet);
+                    thingsToCreate.Add(subscriptionValueSet);
+                }
+
+                clonedParameter.ParameterSubscription.Add(subscription);
+
+                await this.sessionService.CreateOrUpdateThingsWithNotification(clonedParameter, thingsToCreate, GetSubscriptionCreationNotificationDescription(parameter));
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error occurred while creating a ParameterSubscription on the Parameter with iid {Iid}", parameter.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+                this.CloseCreateSubscriptionPopup();
+            }
+        }
+
+        /// <summary>
+        /// Closes the create-subscription popup and clears the captured target.
+        /// </summary>
+        private void CloseCreateSubscriptionPopup()
+        {
+            this.CreateSubscriptionPopupViewModel.IsVisible = false;
+            this.selectedParameterToSubscribe = null;
+        }
+
+        /// <summary>
+        /// Cancellation handler bound to <see cref="CreateSubscriptionPopupViewModel" />'s
+        /// <see cref="IConfirmCancelPopupViewModel.OnCancel" />.
+        /// </summary>
+        private void OnCreateSubscriptionCancelled()
+        {
+            this.CloseCreateSubscriptionPopup();
+        }
+
+        /// <summary>
+        /// Builds a <see cref="NotificationDescription" /> used to surface the success / failure of a
+        /// <see cref="ParameterSubscription" /> creation through the existing notification pipeline.
+        /// </summary>
+        /// <param name="parameter">The <see cref="Parameter" /> being subscribed to.</param>
+        /// <returns>The <see cref="NotificationDescription" /> describing the operation.</returns>
+        private static NotificationDescription GetSubscriptionCreationNotificationDescription(Parameter parameter)
+        {
+            var label = parameter.ParameterType?.Name ?? "Parameter";
+
+            return new NotificationDescription
+            {
+                OnSuccess = $"Subscribed to Parameter '{label}'",
+                OnError = $"Failed to subscribe to Parameter '{label}'"
+            };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IConfirmCancelPopupViewModel" /> driving the delete-confirmation popup for a
+        /// <see cref="ParameterSubscription" /> belonging to the currently logged-in
+        /// <see cref="DomainOfExpertise" />.
+        /// </summary>
+        public IConfirmCancelPopupViewModel DeleteSubscriptionPopupViewModel { get; }
+
+        /// <summary>
+        /// Opens the delete-confirmation popup for the supplied <see cref="ParameterSubscription" />,
+        /// captures the subscription as the deletion target, and composes a content message that makes it
+        /// explicit only the subscription is removed — the parent <see cref="Parameter" /> is kept. No-op
+        /// when the subscription is null or its container is not a <see cref="Parameter" />.
+        /// </summary>
+        /// <param name="subscription">The <see cref="ParameterSubscription" /> the user requested to delete.</param>
+        public void OpenDeleteSubscriptionPopup(ParameterSubscription subscription)
+        {
+            if (subscription is null || subscription.Container is not Parameter parentParameter)
+            {
+                return;
+            }
+
+            this.selectedSubscriptionToDelete = subscription;
+
+            var parameterTypeName = parentParameter.ParameterType?.Name ?? "Parameter";
+
+            this.DeleteSubscriptionPopupViewModel.ContentText =
+                $"You are about to delete your subscription to Parameter '{parameterTypeName}'. The Parameter itself will not be removed.";
+
+            this.DeleteSubscriptionPopupViewModel.IsVisible = true;
+        }
+
+        /// <summary>
+        /// Performs the deletion of the <see cref="ParameterSubscription" /> captured by
+        /// <see cref="OpenDeleteSubscriptionPopup" /> using
+        /// <see cref="ISessionService.DeleteThingsWithNotification" />. The cloned parent
+        /// <see cref="Parameter" /> is the operation top container but is intentionally kept out of the
+        /// things-to-delete collection — only the cloned subscription is deleted, so the parameter itself
+        /// remains. The visible card refresh is driven by the existing message-bus end-update pipeline.
+        /// </summary>
+        /// <returns>A <see cref="Task" /> representing the asynchronous delete operation.</returns>
+        public async Task DeleteSelectedSubscriptionAsync()
+        {
+            var subscription = this.selectedSubscriptionToDelete;
+
+            if (subscription is null || subscription.Container is not Parameter parentParameter)
+            {
+                this.CloseDeleteSubscriptionPopup();
+                return;
+            }
+
+            try
+            {
+                this.IsLoading = true;
+
+                var clonedParameter = parentParameter.Clone(false);
+                var clonedSubscription = subscription.Clone(false);
+
+                await this.sessionService.DeleteThingsWithNotification(clonedParameter, new[] { (Thing)clonedSubscription }, GetSubscriptionDeletionNotificationDescription(subscription));
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error occurred while deleting the ParameterSubscription with iid {Iid}", subscription.Iid);
+            }
+            finally
+            {
+                this.IsLoading = false;
+                this.CloseDeleteSubscriptionPopup();
+            }
+        }
+
+        /// <summary>
+        /// Closes the delete-subscription popup and clears the captured target.
+        /// </summary>
+        private void CloseDeleteSubscriptionPopup()
+        {
+            this.DeleteSubscriptionPopupViewModel.IsVisible = false;
+            this.selectedSubscriptionToDelete = null;
+        }
+
+        /// <summary>
+        /// Cancellation handler bound to <see cref="DeleteSubscriptionPopupViewModel" />'s
+        /// <see cref="IConfirmCancelPopupViewModel.OnCancel" />.
+        /// </summary>
+        private void OnDeleteSubscriptionCancelled()
+        {
+            this.CloseDeleteSubscriptionPopup();
+        }
+
+        /// <summary>
+        /// Builds a <see cref="NotificationDescription" /> used to surface the success / failure of a
+        /// <see cref="ParameterSubscription" /> deletion through the existing notification pipeline.
+        /// </summary>
+        /// <param name="subscription">The <see cref="ParameterSubscription" /> being deleted.</param>
+        /// <returns>The <see cref="NotificationDescription" /> describing the operation.</returns>
+        private static NotificationDescription GetSubscriptionDeletionNotificationDescription(ParameterSubscription subscription)
+        {
+            var label = subscription.Container is Parameter parentParameter
+                ? parentParameter.ParameterType?.Name ?? "Parameter"
+                : "Parameter";
+
+            return new NotificationDescription
+            {
+                OnSuccess = $"Subscription to Parameter '{label}' deleted",
+                OnError = $"Failed to delete subscription to Parameter '{label}'"
             };
         }
 

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/Rows/ElementDefinitionDetailsRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/Rows/ElementDefinitionDetailsRowViewModel.cs
@@ -1,20 +1,20 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ElementDefinitionDetailsRowViewModel.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
 //     This file is part of CDP4-COMET WEB Community Edition
 //     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-// 
+//
 //     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
-// 
+//
 //     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Affero General Public License for more details.
-// 
+//
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //  </copyright>
@@ -75,22 +75,66 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation.Rows
         private Parameter parameter;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ElementDefinitionDetailsRowViewModel" /> class.
+        /// Initializes a new instance of the <see cref="ElementDefinitionDetailsRowViewModel" /> class without
+        /// any subscription awareness. Used by callers that do not need to expose subscribe/unsubscribe
+        /// affordances on the rendered card.
         /// </summary>
-        public ElementDefinitionDetailsRowViewModel(Parameter parameter)
+        /// <param name="parameter">The <see cref="Parameter" /> to project as a row.</param>
+        public ElementDefinitionDetailsRowViewModel(Parameter parameter) : this(parameter, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElementDefinitionDetailsRowViewModel" /> class for the
+        /// supplied <see cref="Parameter" />, computing subscription-related flags relative to
+        /// <paramref name="currentDomain" />.
+        /// </summary>
+        /// <param name="parameter">The <see cref="Parameter" /> to project as a row.</param>
+        /// <param name="currentDomain">
+        /// The currently logged-in <see cref="DomainOfExpertise" />, or <c>null</c> when subscription
+        /// awareness is not required by the caller.
+        /// </param>
+        public ElementDefinitionDetailsRowViewModel(Parameter parameter, DomainOfExpertise currentDomain)
         {
             this.ParameterTypeName = parameter.ParameterType.Name;
             this.ShortName = parameter.ParameterType.ShortName;
 
-            this.ActualValue = parameter.ValueSet.FirstOrDefault()?.ActualValue.AsCommaSeparated();
-            this.PublishedValue = parameter.ValueSet.FirstOrDefault()?.Published.AsCommaSeparated();
+            this.IsOwnedByCurrentDomain = currentDomain != null && parameter.Owner != null && parameter.Owner.Iid == currentDomain.Iid;
+            this.CurrentDomainSubscription = currentDomain == null
+                ? null
+                : parameter.ParameterSubscription.FirstOrDefault(ps => ps.Owner != null && ps.Owner.Iid == currentDomain.Iid);
+            this.HasCurrentDomainSubscription = this.CurrentDomainSubscription != null;
+            this.CanSubscribe = currentDomain != null && !this.IsOwnedByCurrentDomain && !this.HasCurrentDomainSubscription;
 
-            if (parameter.ValueSet.FirstOrDefault()?.ActualValue.Count > 1)
+            var sourceValueSet = parameter.ValueSet.FirstOrDefault();
+            var subscriptionValueSet = this.HasCurrentDomainSubscription
+                ? this.CurrentDomainSubscription.ValueSet.FirstOrDefault()
+                : null;
+
+            if (subscriptionValueSet != null)
             {
-                this.ActualValue = "{" + this.ActualValue + "}";
+                this.ActualValue = subscriptionValueSet.ActualValue.AsCommaSeparated();
+                this.SwitchValue = subscriptionValueSet.ValueSwitch.ToString();
+
+                if (subscriptionValueSet.ActualValue.Count > 1)
+                {
+                    this.ActualValue = "{" + this.ActualValue + "}";
+                }
+            }
+            else
+            {
+                this.ActualValue = sourceValueSet?.ActualValue.AsCommaSeparated() ?? string.Empty;
+                this.SwitchValue = sourceValueSet?.ValueSwitch.ToString() ?? string.Empty;
+
+                if (sourceValueSet?.ActualValue.Count > 1)
+                {
+                    this.ActualValue = "{" + this.ActualValue + "}";
+                }
             }
 
-            if (parameter.ValueSet.FirstOrDefault()?.Published.Count > 1)
+            this.PublishedValue = sourceValueSet?.Published.AsCommaSeparated() ?? string.Empty;
+
+            if (sourceValueSet?.Published.Count > 1)
             {
                 this.PublishedValue = "{" + this.PublishedValue + "}";
             }
@@ -102,7 +146,7 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation.Rows
             }
 
             this.Owner = parameter.Owner.ShortName;
-            this.SwitchValue = parameter.ValueSet.FirstOrDefault()?.ValueSwitch.ToString();
+
             this.ModelCode = parameter.ModelCode();
             this.Parameter = parameter;
         }
@@ -178,5 +222,32 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation.Rows
             get => this.parameter;
             set => this.RaiseAndSetIfChanged(ref this.parameter, value);
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the underlying <see cref="Parameter" /> is owned by the currently
+        /// logged-in <see cref="DomainOfExpertise" />.
+        /// </summary>
+        public bool IsOwnedByCurrentDomain { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ParameterSubscription" /> on the underlying <see cref="Parameter" /> whose
+        /// owner is the currently logged-in <see cref="DomainOfExpertise" />, or <c>null</c> when no such
+        /// subscription exists. Surfaced so the rendering component can hand it to a delete-subscription
+        /// callback.
+        /// </summary>
+        public ParameterSubscription CurrentDomainSubscription { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the currently logged-in <see cref="DomainOfExpertise" /> already
+        /// has a <see cref="ParameterSubscription" /> on the underlying <see cref="Parameter" />.
+        /// </summary>
+        public bool HasCurrentDomainSubscription { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the currently logged-in <see cref="DomainOfExpertise" /> can
+        /// subscribe to the underlying <see cref="Parameter" /> — i.e. a current domain is known, the
+        /// parameter is owned by another domain, and no subscription already exists for the current domain.
+        /// </summary>
+        public bool CanSubscribe { get; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

  - New subscribe button on each parameter card in the Model Editor whose owner is a different `DomainOfExpertise` than the current one;  opens a confirm popup and creates a `ParameterSubscription` (with one `ParameterSubscriptionValueSet` per source `ParameterValueSet`)  for the current domain.
  - New unsubscribe button on cards where the current domain already has a subscription; opens a confirm popup and deletes only the  `ParameterSubscription` — the parent `Parameter` is preserved.
  - Card refresh after either action relies on the existing `OnEndUpdate` → `OnSessionRefreshed` → `SelectElement` message-bus chain (no manual row mutation), so the card automatically rebuilds with the post-server state — including subscription-aware `ActualValue` from  the matching `ParameterSubscriptionValueSet`.

layout is sub-optimal, we'll redesign the page in a separate issue and PR

<!-- Thanks for contributing to COMET-WEB! -->

