### PR TITLE
Feat/gh785 add requirements editor page view-only yet

### DIFF
--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
@@ -37,6 +37,7 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
     using COMET.Web.Common.Test.Helpers;
 
     using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -92,7 +93,7 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
             var configuration = new Mock<IConfigurationService>();
             configuration.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
 
-            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus)
+            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus, new ShowHideDeprecatedThingsService())
             {
                 CurrentThing = iteration
             };

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
@@ -1,0 +1,147 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsEditorBodyTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Permission;
+
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementsEditorBodyTestFixture
+    {
+        private BunitContext context;
+        private IRenderedComponent<RequirementsEditorBody> renderedComponent;
+        private CDPMessageBus messageBus;
+        private RequirementsEditorBodyViewModel viewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.messageBus = new CDPMessageBus();
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System Engineering" };
+            var category = new Category { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements" };
+
+            var group = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "OPERATE", Name = "Operate", Owner = domain };
+
+            var requirement = new Requirement
+            {
+                Iid = Guid.NewGuid(), ShortName = "R24", Name = "Provide user with sensor information", Owner = domain,
+                Definition = { new Definition { LanguageCode = "en", Content = "The USV SHALL provide sensor information." } },
+                Category = { category },
+                Group = group
+            };
+
+            var specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", Owner = domain };
+            specification.Group.Add(group);
+            specification.Requirement.Add(requirement);
+
+            var iteration = new Iteration { Iid = Guid.NewGuid() };
+            iteration.RequirementsSpecification.Add(specification);
+
+            var sessionService = new Mock<ISessionService>();
+            var session = new Mock<ISession>();
+            var permissionService = new Mock<IPermissionService>();
+            permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
+            session.Setup(x => x.PermissionService).Returns(permissionService.Object);
+            sessionService.Setup(x => x.Session).Returns(session.Object);
+            sessionService.Setup(x => x.GetDomainOfExpertise(iteration)).Returns(domain);
+
+            var configuration = new Mock<IConfigurationService>();
+            configuration.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
+
+            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus)
+            {
+                CurrentThing = iteration
+            };
+
+            this.context.Services.AddSingleton(configuration.Object);
+            this.context.Services.AddSingleton<IRequirementsEditorBodyViewModel>(this.viewModel);
+
+            this.renderedComponent = this.context.Render<RequirementsEditorBody>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+            this.viewModel.Dispose();
+            this.messageBus.ClearSubscriptions();
+            this.messageBus.Dispose();
+        }
+
+        [Test]
+        public void VerifyDocumentRenders()
+        {
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.viewModel.IsLoading, Is.False));
+
+            var tree = this.renderedComponent.FindComponent<RequirementsTree>();
+            var document = this.renderedComponent.FindComponent<RequirementsDocument>();
+            var markup = this.renderedComponent.Markup;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tree, Is.Not.Null);
+                Assert.That(document, Is.Not.Null);
+                Assert.That(markup, Does.Contain("R24"));
+                Assert.That(markup, Does.Contain("The USV SHALL provide sensor information."));
+                Assert.That(markup, Does.Contain("starion-pill"));
+                Assert.That(markup, Does.Contain("KUR"));
+            });
+        }
+
+        [Test]
+        public void VerifyDisplayModeChangesLayout()
+        {
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.viewModel.IsLoading, Is.False));
+
+            Assert.That(this.renderedComponent.Markup, Does.Contain("req-row-header"), "default mode shows the name on its own header line");
+
+            this.renderedComponent.InvokeAsync(() => this.viewModel.DisplayMode = RequirementRowDisplayMode.ShortNameAndDefinition);
+
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.renderedComponent.Markup, Does.Not.Contain("req-row-header")));
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
@@ -33,6 +33,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
 
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
 
     using Moq;
@@ -55,6 +56,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
         private DomainOfExpertise systemDomain;
         private DomainOfExpertise thermalDomain;
         private Category keyUserCategory;
+        private RequirementsSpecification deprecatedSpecification;
+        private Requirement deprecatedRequirement;
+        private ShowHideDeprecatedThingsService showHideService;
 
         [SetUp]
         public void SetUp()
@@ -90,22 +94,29 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
             this.operateRequirement.Group = this.operateGroup;
             this.c4iRequirement.Group = this.c4iGroup;
 
+            this.deprecatedRequirement = new Requirement
+            {
+                Iid = Guid.NewGuid(), ShortName = "R00", Name = "Retired requirement", Owner = this.systemDomain, IsDeprecated = true,
+                Definition = { new Definition { LanguageCode = "en", Content = "This requirement is retired." } }
+            };
+
             this.specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", Owner = this.systemDomain };
             this.specification.Group.Add(this.operateGroup);
-            this.specification.Requirement.AddRange([this.topRequirement, this.operateRequirement, this.c4iRequirement]);
+            this.specification.Requirement.AddRange([this.topRequirement, this.operateRequirement, this.c4iRequirement, this.deprecatedRequirement]);
 
-            var deprecatedSpecification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "OLD", Name = "Deprecated", Owner = this.systemDomain, IsDeprecated = true };
+            this.deprecatedSpecification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "OLD", Name = "Deprecated", Owner = this.systemDomain, IsDeprecated = true };
 
             this.iteration = new Iteration { Iid = Guid.NewGuid() };
-            this.iteration.RequirementsSpecification.AddRange([this.specification, deprecatedSpecification]);
+            this.iteration.RequirementsSpecification.AddRange([this.specification, this.deprecatedSpecification]);
 
             var sessionService = new Mock<ISessionService>();
             this.session = new Mock<ISession>();
             sessionService.Setup(x => x.Session).Returns(this.session.Object);
             sessionService.Setup(x => x.GetDomainOfExpertise(this.iteration)).Returns(this.systemDomain);
             this.messageBus = new CDPMessageBus();
+            this.showHideService = new ShowHideDeprecatedThingsService();
 
-            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus)
+            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus, this.showHideService)
             {
                 CurrentThing = this.iteration
             };
@@ -261,6 +272,36 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
 
             Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+        }
+
+        [Test]
+        public async Task VerifyIndentGroupsToggle()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.IndentGroups, Is.True);
+            this.viewModel.IndentGroups = false;
+            Assert.That(this.viewModel.IndentGroups, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyDeprecatedThingsRespectGlobalToggle()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableSpecifications, Does.Not.Contain(this.deprecatedSpecification));
+                Assert.That(this.viewModel.GetRequirements(this.specification), Does.Not.Contain(this.deprecatedRequirement));
+            });
+
+            this.showHideService.ShowDeprecatedThings = true;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableSpecifications, Does.Contain(this.deprecatedSpecification));
+                Assert.That(this.viewModel.GetRequirements(this.specification), Does.Contain(this.deprecatedRequirement));
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
@@ -1,0 +1,266 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsEditorBodyViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using CDP4Web.Enumerations;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementsEditorBodyViewModelTestFixture
+    {
+        private RequirementsEditorBodyViewModel viewModel;
+        private CDPMessageBus messageBus;
+        private Mock<ISession> session;
+        private Iteration iteration;
+        private RequirementsSpecification specification;
+        private RequirementsGroup operateGroup;
+        private RequirementsGroup c4iGroup;
+        private Requirement topRequirement;
+        private Requirement operateRequirement;
+        private Requirement c4iRequirement;
+        private DomainOfExpertise systemDomain;
+        private DomainOfExpertise thermalDomain;
+        private Category keyUserCategory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.systemDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System Engineering" };
+            this.thermalDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "THE", Name = "Thermal" };
+            var parentCategory = new Category { Iid = Guid.NewGuid(), ShortName = "REQ", Name = "Requirement" };
+            this.keyUserCategory = new Category { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", SuperCategory = { parentCategory } };
+
+            this.c4iGroup = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "C4I", Name = "C4I", Owner = this.systemDomain };
+            this.operateGroup = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "OPERATE", Name = "Operate", Owner = this.systemDomain };
+            this.operateGroup.Group.Add(this.c4iGroup);
+
+            this.topRequirement = new Requirement
+            {
+                Iid = Guid.NewGuid(), ShortName = "R01", Name = "Top level", Owner = this.thermalDomain,
+                Definition = { new Definition { LanguageCode = "en", Content = "The system shall exist." } }
+            };
+
+            this.operateRequirement = new Requirement
+            {
+                Iid = Guid.NewGuid(), ShortName = "R25", Name = "Minimize user cognitive load", Owner = this.systemDomain,
+                Definition = { new Definition { LanguageCode = "en", Content = "The USV SHALL have minimal user cognitive load." } }
+            };
+
+            this.c4iRequirement = new Requirement
+            {
+                Iid = Guid.NewGuid(), ShortName = "R24", Name = "Provide user with sensor information", Owner = this.systemDomain,
+                Definition = { new Definition { LanguageCode = "en", Content = "The USV SHALL provide the required sensor information." } },
+                Category = { this.keyUserCategory }
+            };
+
+            this.operateRequirement.Group = this.operateGroup;
+            this.c4iRequirement.Group = this.c4iGroup;
+
+            this.specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", Owner = this.systemDomain };
+            this.specification.Group.Add(this.operateGroup);
+            this.specification.Requirement.AddRange([this.topRequirement, this.operateRequirement, this.c4iRequirement]);
+
+            var deprecatedSpecification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "OLD", Name = "Deprecated", Owner = this.systemDomain, IsDeprecated = true };
+
+            this.iteration = new Iteration { Iid = Guid.NewGuid() };
+            this.iteration.RequirementsSpecification.AddRange([this.specification, deprecatedSpecification]);
+
+            var sessionService = new Mock<ISessionService>();
+            this.session = new Mock<ISession>();
+            sessionService.Setup(x => x.Session).Returns(this.session.Object);
+            sessionService.Setup(x => x.GetDomainOfExpertise(this.iteration)).Returns(this.systemDomain);
+            this.messageBus = new CDPMessageBus();
+
+            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus)
+            {
+                CurrentThing = this.iteration
+            };
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.viewModel.Dispose();
+            this.messageBus.ClearSubscriptions();
+            this.messageBus.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyInitialisation()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableSpecifications, Has.Exactly(1).Items);
+                Assert.That(this.viewModel.AvailableSpecifications, Does.Contain(this.specification));
+                Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+                Assert.That(this.viewModel.AvailableOwners, Is.EquivalentTo(new[] { this.systemDomain, this.thermalDomain }));
+                Assert.That(this.viewModel.AvailableCategories, Is.EquivalentTo(new[] { this.keyUserCategory }));
+                Assert.That(this.viewModel.DisplayMode, Is.EqualTo(RequirementRowDisplayMode.ShortNameNameAndDefinition));
+                Assert.That(this.viewModel.IsTocCollapsed, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task VerifyDocumentStructure()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetGroups(this.specification), Is.EqualTo(new[] { this.operateGroup }));
+                Assert.That(this.viewModel.GetGroups(this.operateGroup), Is.EqualTo(new[] { this.c4iGroup }));
+                Assert.That(this.viewModel.GetRequirements(this.specification), Is.EqualTo(new[] { this.topRequirement }));
+                Assert.That(this.viewModel.GetRequirements(this.operateGroup), Is.EqualTo(new[] { this.operateRequirement }));
+                Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Is.EqualTo(new[] { this.c4iRequirement }));
+            });
+        }
+
+        [Test]
+        public async Task VerifySearchFiltersOnDefinition()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.viewModel.SearchText = "cognitive";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetRequirements(this.operateGroup), Is.EqualTo(new[] { this.operateRequirement }));
+                Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Is.Empty);
+                Assert.That(this.viewModel.GetRequirements(this.specification), Is.Empty);
+                Assert.That(this.viewModel.ShouldDisplayGroup(this.c4iGroup), Is.False);
+                Assert.That(this.viewModel.GetGroups(this.operateGroup), Is.Empty);
+            });
+
+            this.viewModel.SearchText = string.Empty;
+            Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Is.EqualTo(new[] { this.c4iRequirement }));
+        }
+
+        [Test]
+        public async Task VerifyOwnerAndCategoryFilters()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.viewModel.SelectedOwners = [this.thermalDomain];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetRequirements(this.specification), Is.EqualTo(new[] { this.topRequirement }));
+                Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Is.Empty);
+            });
+
+            this.viewModel.SelectedOwners = [];
+            this.viewModel.SelectedCategories = [this.keyUserCategory];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Is.EqualTo(new[] { this.c4iRequirement }));
+                Assert.That(this.viewModel.GetRequirements(this.operateGroup), Is.Empty);
+                Assert.That(this.viewModel.ShouldDisplayGroup(this.operateGroup), Is.True);
+            });
+        }
+
+        [Test]
+        public async Task VerifyCollapseToggle()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.IsTocCollapsed, Is.False);
+            this.viewModel.IsTocCollapsed = true;
+            Assert.That(this.viewModel.IsTocCollapsed, Is.True);
+        }
+
+        [Test]
+        public async Task VerifyDirectCategoriesOnly()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            // KUR has super-category REQ; only the directly-assigned KUR must surface, not REQ.
+            Assert.That(this.viewModel.AvailableCategories.Select(x => x.ShortName), Is.EqualTo(new[] { "KUR" }));
+        }
+
+        [Test]
+        public async Task VerifyTogglesAndCollapseState()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ShowOwner, Is.True);
+                Assert.That(this.viewModel.ShowCategory, Is.True);
+                Assert.That(this.viewModel.IsTreeNodeCollapsed(this.operateGroup.Iid), Is.False);
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.False);
+            });
+
+            this.viewModel.ToggleTreeNode(this.operateGroup.Iid);
+            this.viewModel.ToggleDocumentGroup(this.operateGroup.Iid);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsTreeNodeCollapsed(this.operateGroup.Iid), Is.True);
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.True);
+            });
+
+            this.viewModel.ToggleTreeNode(this.operateGroup.Iid);
+            this.viewModel.ToggleDocumentGroup(this.operateGroup.Iid);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsTreeNodeCollapsed(this.operateGroup.Iid), Is.False);
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.False);
+            });
+        }
+
+        [Test]
+        public async Task VerifySessionRefreshPreservesOrResetsSelection()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.session.Object);
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+
+            this.viewModel.SelectedSpecification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "FOREIGN" };
+            this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.session.Object);
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -40,7 +40,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </span>;
 
     RenderFragment<Requirement> requirementRow = requirement =>
-        @<div class="req-row">
+        @<div class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
             <div class="req-row-main">
                 @switch (this.ViewModel.DisplayMode)
                 {
@@ -59,6 +59,10 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 }
             </div>
             <div class="req-row-pills">
+                @if (requirement.IsDeprecated)
+                {
+                    <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+                }
                 @pills((requirement.Owner, requirement.Category))
             </div>
         </div>;
@@ -72,9 +76,13 @@ else if (this.Container == null)
 {
     var specification = this.ViewModel.SelectedSpecification;
 
-    <div class="req-spec-title">
+    <div class="req-spec-title @(specification.IsDeprecated ? "req-row-deprecated" : string.Empty)">
         <span class="req-spec-id">@specification.ShortName</span>
         <span class="req-spec-name">@specification.Name</span>
+        @if (specification.IsDeprecated)
+        {
+            <span class="req-deprecated-badge" title="This specification is deprecated">Deprecated</span>
+        }
         @pills((specification.Owner, specification.Category))
     </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -1,0 +1,120 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using CDP4Common.EngineeringModelData
+@using CDP4Common.SiteDirectoryData
+@using COMETwebapp.Utilities
+@using COMETwebapp.ViewModels.Components.RequirementsEditor
+
+@{
+    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
+        @<span class="req-pills">
+            @if (this.ViewModel.ShowOwner && context.Owner != null)
+            {
+                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{context.Owner.ShortName}") !important;" title="Owner: @context.Owner.Name">@context.Owner.ShortName</span>
+            }
+            @if (this.ViewModel.ShowCategory)
+            {
+                @foreach (var category in context.Categories)
+                {
+                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                }
+            }
+        </span>;
+
+    RenderFragment<Requirement> requirementRow = requirement =>
+        @<div class="req-row">
+            <div class="req-row-main">
+                @switch (this.ViewModel.DisplayMode)
+                {
+                    case RequirementRowDisplayMode.ShortNameAndDefinition:
+                        <p class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @GetDefinition(requirement)</p>
+                        break;
+
+                    case RequirementRowDisplayMode.NameAndDefinition:
+                        <p class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @GetDefinition(requirement)</p>
+                        break;
+
+                    default:
+                        <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
+                        <p class="req-def">@GetDefinition(requirement)</p>
+                        break;
+                }
+            </div>
+            <div class="req-row-pills">
+                @pills((requirement.Owner, requirement.Category))
+            </div>
+        </div>;
+}
+
+@if (this.ViewModel.SelectedSpecification == null)
+{
+    <div class="req-empty">Select a specification to view its requirements.</div>
+}
+else if (this.Container == null)
+{
+    var specification = this.ViewModel.SelectedSpecification;
+
+    <div class="req-spec-title">
+        <span class="req-spec-id">@specification.ShortName</span>
+        <span class="req-spec-name">@specification.Name</span>
+        @pills((specification.Owner, specification.Category))
+    </div>
+
+    @foreach (var requirement in this.ViewModel.GetRequirements(specification))
+    {
+        @requirementRow(requirement)
+    }
+
+    @foreach (var childGroup in this.ViewModel.GetGroups(specification))
+    {
+        <RequirementsDocument ViewModel="@this.ViewModel" Container="@childGroup" Level="1" />
+    }
+}
+else
+{
+    var group = (RequirementsGroup)this.Container;
+    var collapsed = this.ViewModel.IsDocumentGroupCollapsed(group.Iid);
+
+    <section class="req-group">
+        <div id="@GroupAnchorId(group)" class="req-group-header req-group-level-@Math.Min(this.Level, 4)">
+            <button type="button" class="req-collapse-btn" title="@(collapsed ? "Expand group" : "Collapse group")"
+                    @onclick="@(() => this.ViewModel.ToggleDocumentGroup(group.Iid))">
+                <img src="@(collapsed ? "images/Collapsed.svg" : "images/Expanded.svg")" alt="" />
+            </button>
+            <span class="req-group-id">@group.ShortName</span>
+            <span class="req-group-name">@group.Name</span>
+            @pills((group.Owner, group.Category))
+        </div>
+
+        @if (!collapsed)
+        {
+            foreach (var requirement in this.ViewModel.GetRequirements(group))
+            {
+                @requirementRow(requirement)
+            }
+
+            foreach (var childGroup in this.ViewModel.GetGroups(group))
+            {
+                <RequirementsDocument ViewModel="@this.ViewModel" Container="@childGroup" Level="@(this.Level + 1)" />
+            }
+        }
+    </section>
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
@@ -1,0 +1,76 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsDocument.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders a <see cref="RequirementsSpecification" /> as a document: the specification header, its requirements,
+    /// and its <see cref="RequirementsGroup" /> hierarchy (recursively) with the requirements filed under each group.
+    /// </summary>
+    public partial class RequirementsDocument
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsContainer" /> rendered by this instance. When <c>null</c>, the
+        /// selected specification (the document root) is rendered.
+        /// </summary>
+        [Parameter]
+        public RequirementsContainer Container { get; set; }
+
+        /// <summary>
+        /// Gets or sets the nesting level of the current group, used to size its header (0 for the specification root).
+        /// </summary>
+        [Parameter]
+        public int Level { get; set; }
+
+        /// <summary>
+        /// Gets the HTML anchor id used to scroll to the given <paramref name="group" /> from the table of contents.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /></param>
+        /// <returns>The anchor id</returns>
+        public static string GroupAnchorId(RequirementsGroup group)
+        {
+            return $"req-group-{group.Iid}";
+        }
+
+        /// <summary>
+        /// Gets the definition text of the given <paramref name="requirement" />.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>The first definition's content, or an empty string</returns>
+        private static string GetDefinition(Requirement requirement)
+        {
+            return requirement.Definition.FirstOrDefault()?.Content ?? string.Empty;
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -68,6 +68,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </div>
 
             <div class="req-toolbar-group req-toolbar-right">
+                <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent</DxCheckBox>
                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
             </div>
@@ -77,7 +78,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <div class="req-toc">
                 <RequirementsTree ViewModel="@this.ViewModel" />
             </div>
-            <div class="req-document">
+            <div class="req-document @(this.ViewModel.IndentGroups ? string.Empty : "no-indent")">
                 <RequirementsDocument ViewModel="@this.ViewModel" />
             </div>
         </div>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -1,0 +1,85 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using CDP4Common.SiteDirectoryData
+@using COMETwebapp.Extensions
+@using COMETwebapp.Utilities
+@using COMETwebapp.ViewModels.Components.RequirementsEditor
+
+@inherits COMET.Web.Common.Components.Applications.SingleIterationApplicationBase<COMETwebapp.ViewModels.Components.RequirementsEditor.IRequirementsEditorBodyViewModel>
+
+<LoadingComponent IsVisible="@this.ViewModel.IsLoading">
+    <div id="@WebAppConstantValues.RequirementManagementPage.QueryPageBodyName()" class="req-editor">
+        <div class="req-toolbar">
+            <DxButton RenderStyle="ButtonRenderStyle.Light"
+                      Text="@(this.ViewModel.IsTocCollapsed ? "»" : "«")"
+                      title="Toggle table of contents"
+                      Click="@(() => this.ViewModel.IsTocCollapsed = !this.ViewModel.IsTocCollapsed)"
+                      CssClass="req-collapse-toggle" />
+
+            <DxTextBox @bind-Text="@this.ViewModel.SearchText"
+                       BindValueMode="BindValueMode.OnDelayedInput"
+                       ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                       NullText="Search in definitions..."
+                       CssClass="req-search" />
+
+            <DxTagBox Data="@this.ViewModel.AvailableOwners"
+                      Values="@this.ViewModel.SelectedOwners"
+                      ValuesChanged="@((IEnumerable<DomainOfExpertise> values) => this.ViewModel.SelectedOwners = values.ToList())"
+                      TextFieldName="@nameof(DomainOfExpertise.ShortName)"
+                      NullText="Filter by owner..."
+                      CssClass="req-filter" />
+
+            <DxTagBox Data="@this.ViewModel.AvailableCategories"
+                      Values="@this.ViewModel.SelectedCategories"
+                      ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values.ToList())"
+                      TextFieldName="@nameof(Category.ShortName)"
+                      NullText="Filter by category..."
+                      CssClass="req-filter" />
+
+            <div class="req-toolbar-group">
+                <span class="req-toolbar-label">Layout</span>
+                <div class="btn-group" role="group" aria-label="Requirement layout">
+                    @foreach (var mode in DisplayModes)
+                    {
+                        <DxButton RenderStyle="@(this.ViewModel.DisplayMode == mode ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
+                                  Text="@GetDisplayModeLabel(mode)"
+                                  title="@GetDisplayModeTitle(mode)"
+                                  Click="@(() => this.ViewModel.DisplayMode = mode)" />
+                    }
+                </div>
+            </div>
+
+            <div class="req-toolbar-group req-toolbar-right">
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
+            </div>
+        </div>
+
+        <div class="req-editor-layout @(this.ViewModel.IsTocCollapsed ? "toc-collapsed" : string.Empty)">
+            <div class="req-toc">
+                <RequirementsTree ViewModel="@this.ViewModel" />
+            </div>
+            <div class="req-document">
+                <RequirementsDocument ViewModel="@this.ViewModel" />
+            </div>
+        </div>
+    </div>
+</LoadingComponent>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -1,0 +1,101 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsEditorBody.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Support class for the <see cref="RequirementsEditorBody" /> component.
+    /// </summary>
+    public partial class RequirementsEditorBody
+    {
+        /// <summary>
+        /// The available <see cref="RequirementRowDisplayMode" />s offered as a layout toggle.
+        /// </summary>
+        private static readonly RequirementRowDisplayMode[] DisplayModes =
+        [
+            RequirementRowDisplayMode.ShortNameAndDefinition,
+            RequirementRowDisplayMode.NameAndDefinition,
+            RequirementRowDisplayMode.ShortNameNameAndDefinition
+        ];
+
+        /// <summary>
+        /// Handles the post-assignment flow of the <see cref="COMET.Web.Common.Components.Applications.ApplicationBase{TViewModel}.ViewModel" /> property.
+        /// A single subscription re-renders the whole body (tree + document) whenever the selection, search or filters change.
+        /// </summary>
+        protected override void OnViewModelAssigned()
+        {
+            base.OnViewModelAssigned();
+
+            this.Disposables.Add(this.WhenAnyValue(
+                    x => x.ViewModel.SelectedSpecification,
+                    x => x.ViewModel.SearchText,
+                    x => x.ViewModel.IsTocCollapsed,
+                    x => x.ViewModel.DisplayMode,
+                    x => x.ViewModel.SelectedOwners,
+                    x => x.ViewModel.SelectedCategories)
+                .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+        }
+
+        /// <summary>
+        /// Initializes values of the component and of the ViewModel based on parameters provided from the URL.
+        /// The Requirements Editor does not yet take any URL parameters.
+        /// </summary>
+        /// <param name="parameters">A <see cref="Dictionary{TKey,TValue}" /> for parameters</param>
+        protected override void InitializeValues(Dictionary<string, string> parameters)
+        {
+        }
+
+        /// <summary>
+        /// Gets the short toolbar label for the given <paramref name="mode" />.
+        /// </summary>
+        /// <param name="mode">The <see cref="RequirementRowDisplayMode" /></param>
+        /// <returns>The label</returns>
+        private static string GetDisplayModeLabel(RequirementRowDisplayMode mode)
+        {
+            return mode switch
+            {
+                RequirementRowDisplayMode.ShortNameAndDefinition => "ID",
+                RequirementRowDisplayMode.NameAndDefinition => "Name",
+                _ => "ID + Name"
+            };
+        }
+
+        /// <summary>
+        /// Gets the tooltip describing the given <paramref name="mode" />.
+        /// </summary>
+        /// <param name="mode">The <see cref="RequirementRowDisplayMode" /></param>
+        /// <returns>The tooltip text</returns>
+        private static string GetDisplayModeTitle(RequirementRowDisplayMode mode)
+        {
+            return mode switch
+            {
+                RequirementRowDisplayMode.ShortNameAndDefinition => "Short name – definition on one line",
+                RequirementRowDisplayMode.NameAndDefinition => "Name – definition on one line",
+                _ => "Short name and name, definition on the next line"
+            };
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -57,6 +57,9 @@ namespace COMETwebapp.Components.RequirementsEditor
                     x => x.ViewModel.SelectedOwners,
                     x => x.ViewModel.SelectedCategories)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.ShowHideDeprecatedThingsService.ShowDeprecatedThings)
+                .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
         }
 
         /// <summary>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -361,3 +361,46 @@
     border-color: rgba(0, 0, 0, 0.15);
     color: #1f2937;
 }
+
+/* Indent toggle: when off, flatten the group indentation so headers and requirements sit flush-left. */
+.req-document.no-indent ::deep .req-group {
+    margin-left: 0;
+    padding-left: 0;
+    border-left: none;
+}
+
+/* Deprecated things (rendered only when the global "Show Deprecated Things" toggle is on). */
+.req-document ::deep .req-row-deprecated {
+    opacity: 0.6;
+}
+
+.req-document ::deep .req-row-deprecated .req-id,
+.req-document ::deep .req-row-deprecated .req-name,
+.req-document ::deep .req-row-deprecated .req-spec-id,
+.req-document ::deep .req-row-deprecated .req-spec-name {
+    text-decoration: line-through;
+}
+
+.req-document ::deep .req-deprecated-badge,
+.req-toc ::deep .req-tree-deprecated .req-tree-label {
+    white-space: nowrap;
+}
+
+.req-document ::deep .req-deprecated-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    padding: 1px 8px;
+    margin: 1px 2px;
+    font-size: 0.72rem;
+    line-height: 1.2;
+    border-radius: 30px;
+    background: #fde2e1;
+    color: #b42318;
+    border: 1px solid #f5c2c0;
+}
+
+.req-toc ::deep .req-tree-deprecated .req-tree-label {
+    text-decoration: line-through;
+    color: #98a2b3;
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -1,0 +1,363 @@
+/* Fills the tab height so the tree and document panels scroll independently. Works because the shared
+   TabsPanelComponent chain (.panel-view height:100% flex → #tabs-page-content flex:1) is definite. */
+.req-editor {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.req-toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid #eaecef;
+}
+
+.req-toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+}
+
+.req-toolbar-right {
+    margin-left: auto;
+}
+
+.req-toolbar-label {
+    font-size: 0.8rem;
+    color: #667085;
+}
+
+.req-search {
+    flex: 1 1 220px;
+    min-width: 140px;
+    max-width: 360px;
+}
+
+.req-filter {
+    flex: 0 1 190px;
+    min-width: 130px;
+}
+
+.req-editor-layout {
+    display: flex;
+    gap: 16px;
+    flex: 1 1 auto;
+    min-height: 0;
+    align-items: stretch;
+}
+
+.req-toc {
+    flex: 0 0 300px;
+    min-height: 0;
+    overflow: auto;
+    border-right: 1px solid #eaecef;
+    padding-right: 8px;
+    transition: flex-basis 0.2s ease;
+}
+
+.req-editor-layout.toc-collapsed .req-toc {
+    flex-basis: 0;
+    width: 0;
+    padding: 0;
+    overflow: hidden;
+    border: none;
+}
+
+.req-document {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    scroll-behavior: smooth;
+    padding-right: 8px;
+}
+
+/* --- table-of-contents tree (rendered by RequirementsTree) --- */
+
+.req-toc ::deep ul.req-tree {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.req-toc ::deep ul.req-tree-branch {
+    list-style: none;
+    margin: 0 0 0 9px;
+    padding-left: 0;
+}
+
+.req-toc ::deep ul.req-tree-branch > li {
+    position: relative;
+    padding-left: 14px;
+}
+
+/* vertical guide line: full height for a middle child, but the last child stops at the connector
+   so the line does not run past the final node to the bottom of the branch */
+.req-toc ::deep ul.req-tree-branch > li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: #d6dae0;
+}
+
+.req-toc ::deep ul.req-tree-branch > li:last-child::before {
+    bottom: auto;
+    height: 13px;
+}
+
+/* horizontal connector from the vertical guide line to each node */
+.req-toc ::deep ul.req-tree-branch > li::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 13px;
+    width: 11px;
+    height: 1px;
+    background: #d6dae0;
+}
+
+.req-toc ::deep .req-tree-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 4px;
+    border-radius: 6px;
+    white-space: nowrap;
+}
+
+.req-toc ::deep .req-tree-group {
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.req-toc ::deep .req-tree-row .req-pills {
+    margin-left: auto;
+    padding-left: 4px;
+}
+
+.req-toc ::deep .req-tree-row:hover {
+    background: #f2f5fa;
+}
+
+.req-toc ::deep .req-tree-spec {
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.req-toc ::deep .req-tree-spec.selected {
+    background: #e7f1ff;
+}
+
+.req-toc ::deep .req-tree-chevron {
+    border: none;
+    background: none;
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.req-toc ::deep .req-tree-chevron img {
+    width: 12px;
+    height: 12px;
+}
+
+.req-toc ::deep .req-tree-chevron-placeholder {
+    width: 16px;
+    flex-shrink: 0;
+}
+
+.req-toc ::deep .req-tree-group {
+    color: #344054;
+    text-decoration: none;
+}
+
+.req-toc ::deep .req-tree-group:hover {
+    text-decoration: underline;
+}
+
+.req-toc ::deep .req-tree-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* --- document (rendered by RequirementsDocument) --- */
+
+.req-document ::deep .req-spec-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    border-bottom: 2px solid #2b3440;
+    padding-bottom: 8px;
+    margin-bottom: 14px;
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 1;
+}
+
+.req-document ::deep .req-spec-id {
+    font-size: 1.7rem;
+    font-weight: 700;
+}
+
+.req-document ::deep .req-spec-name {
+    font-size: 1.4rem;
+    color: #475467;
+    flex: 1 1 auto;
+}
+
+.req-document ::deep .req-group {
+    margin-left: 14px;
+    padding-left: 14px;
+    border-left: 2px solid #eef0f3;
+}
+
+.req-document ::deep .req-group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-weight: 700;
+    background: #f4f6f9;
+    border: 1px solid #e9edf2;
+    border-radius: 6px;
+    margin: 16px 0 8px;
+    padding: 6px 10px;
+}
+
+.req-document ::deep .req-group-level-1 {
+    font-size: 1.1rem;
+}
+
+.req-document ::deep .req-group-level-2 {
+    font-size: 1.02rem;
+}
+
+.req-document ::deep .req-group-level-3,
+.req-document ::deep .req-group-level-4 {
+    font-size: 0.96rem;
+}
+
+.req-document ::deep .req-collapse-btn {
+    border: none;
+    background: none;
+    padding: 0;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.req-document ::deep .req-collapse-btn img {
+    width: 13px;
+    height: 13px;
+}
+
+.req-document ::deep .req-group-id {
+    font-weight: 700;
+}
+
+.req-document ::deep .req-group-name {
+    color: #475467;
+    font-weight: 500;
+}
+
+.req-document ::deep .req-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 9px 8px;
+    border-bottom: 1px solid #f1f3f5;
+}
+
+.req-document ::deep .req-row:hover {
+    background: #fafbfc;
+}
+
+.req-document ::deep .req-row-main {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.req-document ::deep .req-row-header .req-id {
+    margin-right: 8px;
+}
+
+.req-document ::deep .req-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: #1f2937;
+    font-weight: 600;
+}
+
+.req-document ::deep .req-row-header .req-name {
+    font-weight: 500;
+    color: #6b7280;
+}
+
+.req-document ::deep .req-def {
+    margin: 2px 0 0;
+    line-height: 1.5;
+    color: #1f2937;
+    white-space: pre-wrap;
+}
+
+.req-document ::deep .req-row-pills {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    text-align: end;
+}
+
+.req-document ::deep .req-pills {
+    display: inline-flex;
+    gap: 3px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.req-document ::deep .req-spec-title .req-pills,
+.req-document ::deep .req-group-header .req-pills {
+    margin-left: auto;
+    padding-left: 8px;
+}
+
+.req-document ::deep .req-empty {
+    color: #98a2b3;
+    font-style: italic;
+    padding: 24px;
+}
+
+/* pill sizing: the shared .starion-pill is a fixed 19px with no horizontal padding, so text is
+   clipped. Give our pills real padding, centring and no-wrap so short names fit cleanly. */
+.req-toc ::deep .starion-pill,
+.req-document ::deep .starion-pill {
+    display: inline-flex;
+    align-items: center;
+    height: auto;
+    min-height: 18px;
+    padding: 1px 8px;
+    margin: 1px 0 1px 2px;
+    line-height: 1.2;
+    font-size: 0.72rem;
+    white-space: nowrap;
+    border-color: rgba(0, 0, 0, 0.15);
+    color: #1f2937;
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -28,7 +28,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             var isSelected = specification == this.ViewModel.SelectedSpecification;
 
             <li class="req-tree-item">
-                <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty)"
+                <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty) @(specification.IsDeprecated ? "req-tree-deprecated" : string.Empty)"
                      @onclick="@(() => this.ViewModel.SelectedSpecification = specification)">
                     <span class="req-tree-label">@specification.ShortName</span>
                 </div>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -1,0 +1,86 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using COMETwebapp.Utilities
+
+@if (this.Groups == null)
+{
+    <ul class="req-tree">
+        @foreach (var specification in this.ViewModel.AvailableSpecifications)
+        {
+            var isSelected = specification == this.ViewModel.SelectedSpecification;
+
+            <li class="req-tree-item">
+                <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty)"
+                     @onclick="@(() => this.ViewModel.SelectedSpecification = specification)">
+                    <span class="req-tree-label">@specification.ShortName</span>
+                </div>
+                @if (isSelected)
+                {
+                    <RequirementsTree ViewModel="@this.ViewModel" Groups="@this.ViewModel.GetGroups(specification)" />
+                }
+            </li>
+        }
+    </ul>
+}
+else
+{
+    <ul class="req-tree-branch">
+        @foreach (var group in this.Groups)
+        {
+            var hasChildren = this.ViewModel.GetGroups(group).Any();
+            var collapsed = this.ViewModel.IsTreeNodeCollapsed(group.Iid);
+
+            <li class="req-tree-item">
+                <div class="req-tree-row">
+                    @if (hasChildren)
+                    {
+                        <button type="button" class="req-tree-chevron" title="@(collapsed ? "Expand" : "Collapse")"
+                                @onclick="@(() => this.ViewModel.ToggleTreeNode(group.Iid))" @onclick:stopPropagation="true">
+                            <img src="@(collapsed ? "images/Collapsed.svg" : "images/Expanded.svg")" alt="" />
+                        </button>
+                    }
+                    else
+                    {
+                        <span class="req-tree-chevron-placeholder"></span>
+                    }
+                    <a class="req-tree-group" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@group.ShortName</a>
+                    <span class="req-pills">
+                        @if (this.ViewModel.ShowOwner && group.Owner != null)
+                        {
+                            <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{group.Owner.ShortName}") !important;" title="Owner: @group.Owner.Name">@group.Owner.ShortName</span>
+                        }
+                        @if (this.ViewModel.ShowCategory)
+                        {
+                            @foreach (var category in group.Category)
+                            {
+                                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                            }
+                        }
+                    </span>
+                </div>
+                @if (hasChildren && !collapsed)
+                {
+                    <RequirementsTree ViewModel="@this.ViewModel" Groups="@this.ViewModel.GetGroups(group)" />
+                }
+            </li>
+        }
+    </ul>
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor.cs
@@ -1,0 +1,50 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsTree.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Recursive table-of-contents tree for the Requirements Editor: it lists the specifications and, under the
+    /// selected one, its <see cref="RequirementsGroup" /> hierarchy used to navigate the document.
+    /// </summary>
+    public partial class RequirementsTree
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the child <see cref="RequirementsGroup" />s to render at this level. When <c>null</c>, this
+        /// instance renders the specification roots.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<RequirementsGroup> Groups { get; set; }
+    }
+}

--- a/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
+++ b/COMETwebapp/Extensions/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace COMETwebapp.Extensions
     using COMETwebapp.ViewModels.Components.ReferenceData.MeasurementScales;
     using COMETwebapp.ViewModels.Components.ReferenceData.MeasurementUnits;
     using COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
     using COMETwebapp.ViewModels.Components.SiteDirectory;
     using COMETwebapp.ViewModels.Components.SiteDirectory.DomainsOfExpertise;
     using COMETwebapp.ViewModels.Components.SiteDirectory.EngineeringModels;
@@ -98,6 +99,7 @@ namespace COMETwebapp.Extensions
             serviceCollection.AddTransient<ISubscriptionDashboardBodyViewModel, SubscriptionDashboardBodyViewModel>();
             serviceCollection.AddTransient<ISubscribedTableViewModel, SubscribedTableViewModel>();
             serviceCollection.AddTransient<IParameterEditorBodyViewModel, ParameterEditorBodyViewModel>();
+            serviceCollection.AddTransient<IRequirementsEditorBodyViewModel, RequirementsEditorBodyViewModel>();
             serviceCollection.AddTransient<IViewerBodyViewModel, ViewerBodyViewModel>();
             serviceCollection.AddTransient<IElementDefinitionDetailsViewModel, ElementDefinitionDetailsViewModel>();
             serviceCollection.AddTransient<IParameterTypeTableViewModel, ParameterTypeTableViewModel>();

--- a/COMETwebapp/Model/Applications.cs
+++ b/COMETwebapp/Model/Applications.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.Model
     using COMETwebapp.Components.ModelEditor;
     using COMETwebapp.Components.ParameterEditor;
     using COMETwebapp.Components.ReferenceData;
+    using COMETwebapp.Components.RequirementsEditor;
     using COMETwebapp.Components.SiteDirectory;
     using COMETwebapp.Components.SubscriptionDashboard;
     using COMETwebapp.Components.SystemRepresentation;
@@ -81,14 +82,14 @@ namespace COMETwebapp.Model
                     ComponentType = typeof(SubscriptionDashboardBody)
                 },
 
-                new Application
+                new TabbedApplication
                 {
                     Name = "Requirement Management",
                     Color = "#fda966",
-                    Icon = "link-intact",
-                    Description = $"Edit requirements in the model.{Environment.NewLine}Under Development",
-                    IsDisabled = true,
-                    Url = WebAppConstantValues.RequirementManagementPage
+                    IconType = typeof(FeatherFileText),
+                    Description = "View and edit requirements as documents.",
+                    Url = WebAppConstantValues.RequirementManagementPage,
+                    ComponentType = typeof(RequirementsEditorBody)
                 },
 
                 new TabbedApplication

--- a/COMETwebapp/Pages/RequirementManagement/RequirementManagement.razor
+++ b/COMETwebapp/Pages/RequirementManagement/RequirementManagement.razor
@@ -17,12 +17,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
     You should have received a copy of the GNU Affero General Public License
     along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
+@using COMETwebapp.Components.RequirementsEditor
 @using COMETwebapp.Utilities
 @inherits COMET.Web.Common.Pages.SingleIterationPageTemplate
 @attribute [Route(WebAppConstantValues.RequirementManagementPage)]
 
-<SingleIterationApplicationTemplate ShowActiveModel="true">
+<SingleIterationApplicationTemplate IterationId="@this.RequestedIteration" ShowActiveModel="true">
     <Body>
-        Application in development.
+        <RequirementsEditorBody/>
     </Body>
 </SingleIterationApplicationTemplate>

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
@@ -27,6 +27,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
     using COMET.Web.Common.ViewModels.Components.Applications;
 
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+
     /// <summary>
     /// Interface for the <see cref="RequirementsEditorBodyViewModel" />, driving the Requirements Editor application.
     /// </summary>
@@ -61,6 +63,16 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// Gets or sets a value indicating whether the category pills are shown on specifications, groups and requirements.
         /// </summary>
         bool ShowCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether groups are indented in the document.
+        /// </summary>
+        bool IndentGroups { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IShowHideDeprecatedThingsService" /> that drives whether deprecated things are shown.
+        /// </summary>
+        IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
 
         /// <summary>
         /// Gets or sets the way each requirement is rendered as a row.

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IRequirementsEditorBodyViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    /// <summary>
+    /// Interface for the <see cref="RequirementsEditorBodyViewModel" />, driving the Requirements Editor application.
+    /// </summary>
+    public interface IRequirementsEditorBodyViewModel : ISingleIterationApplicationBaseViewModel
+    {
+        /// <summary>
+        /// Gets the non-deprecated <see cref="RequirementsSpecification" />s of the current iteration.
+        /// </summary>
+        IEnumerable<RequirementsSpecification> AvailableSpecifications { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsSpecification" /> currently shown as a document.
+        /// </summary>
+        RequirementsSpecification SelectedSpecification { get; set; }
+
+        /// <summary>
+        /// Gets or sets the keyword used to filter requirements on their definition text.
+        /// </summary>
+        string SearchText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the left table-of-contents tree is collapsed.
+        /// </summary>
+        bool IsTocCollapsed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owner pill is shown on specifications, groups and requirements.
+        /// </summary>
+        bool ShowOwner { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown on specifications, groups and requirements.
+        /// </summary>
+        bool ShowCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the way each requirement is rendered as a row.
+        /// </summary>
+        RequirementRowDisplayMode DisplayMode { get; set; }
+
+        /// <summary>
+        /// Gets the distinct <see cref="DomainOfExpertise" /> owners available to filter on.
+        /// </summary>
+        IReadOnlyList<DomainOfExpertise> AvailableOwners { get; }
+
+        /// <summary>
+        /// Gets the distinct <see cref="Category" /> values available to filter on.
+        /// </summary>
+        IReadOnlyList<Category> AvailableCategories { get; }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="DomainOfExpertise" /> owners; an empty selection means no owner filtering.
+        /// </summary>
+        IEnumerable<DomainOfExpertise> SelectedOwners { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="Category" /> values; an empty selection means no category filtering.
+        /// </summary>
+        IEnumerable<Category> SelectedCategories { get; set; }
+
+        /// <summary>
+        /// Gets the visible, non-deprecated requirements located directly under the given <paramref name="container" />
+        /// (the selected specification or one of its groups), after applying search and filters.
+        /// </summary>
+        /// <param name="container">The <see cref="RequirementsContainer" /> (specification or group)</param>
+        /// <returns>The requirements to render under that container</returns>
+        IEnumerable<Requirement> GetRequirements(RequirementsContainer container);
+
+        /// <summary>
+        /// Gets the visible child <see cref="RequirementsGroup" />s of the given <paramref name="container" />.
+        /// </summary>
+        /// <param name="container">The <see cref="RequirementsContainer" /> (specification or group)</param>
+        /// <returns>The child groups to render</returns>
+        IEnumerable<RequirementsGroup> GetGroups(RequirementsContainer container);
+
+        /// <summary>
+        /// Determines whether the given <paramref name="group" /> should be displayed given the active search and filters.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /></param>
+        /// <returns>true if the group (or one of its descendants) has visible requirements, or no filter is active</returns>
+        bool ShouldDisplayGroup(RequirementsGroup group);
+
+        /// <summary>
+        /// Gets whether the tree node with the given <paramref name="iid" /> is collapsed in the table-of-contents tree.
+        /// </summary>
+        /// <param name="iid">The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the specification or group node</param>
+        /// <returns>true if collapsed</returns>
+        bool IsTreeNodeCollapsed(Guid iid);
+
+        /// <summary>
+        /// Toggles the collapsed state of the table-of-contents tree node with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the specification or group node</param>
+        void ToggleTreeNode(Guid iid);
+
+        /// <summary>
+        /// Gets whether the group with the given <paramref name="iid" /> is collapsed in the document panel.
+        /// </summary>
+        /// <param name="iid">The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the group</param>
+        /// <returns>true if collapsed</returns>
+        bool IsDocumentGroupCollapsed(Guid iid);
+
+        /// <summary>
+        /// Toggles the collapsed state of the document group with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the group</param>
+        void ToggleDocumentGroup(Guid iid);
+    }
+}

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementRowDisplayMode.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementRowDisplayMode.cs
@@ -1,0 +1,46 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRowDisplayMode.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.RequirementsEditor
+{
+    /// <summary>
+    /// Defines how a requirement is rendered as a row in the document panel of the Requirements Editor.
+    /// In every mode the definition text keeps the visual focus.
+    /// </summary>
+    public enum RequirementRowDisplayMode
+    {
+        /// <summary>
+        /// The short name and the definition are shown on a single line (<c>ShortName - Definition</c>).
+        /// </summary>
+        ShortNameAndDefinition,
+
+        /// <summary>
+        /// The name and the definition are shown on a single line (<c>Name - Definition</c>).
+        /// </summary>
+        NameAndDefinition,
+
+        /// <summary>
+        /// The short name and name are shown on a header line, with the definition on the next line.
+        /// </summary>
+        ShortNameNameAndDefinition
+    }
+}

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -30,6 +30,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.ViewModels.Components.Applications;
 
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+
     using ReactiveUI;
 
     /// <summary>
@@ -65,6 +67,11 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         private bool showCategory = true;
 
         /// <summary>
+        /// Backing field for <see cref="IndentGroups" />
+        /// </summary>
+        private bool indentGroups = true;
+
+        /// <summary>
         /// The <see cref="Guid" />s of the table-of-contents tree nodes that are currently collapsed.
         /// </summary>
         private readonly HashSet<Guid> collapsedTreeNodes = [];
@@ -94,14 +101,27 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// </summary>
         /// <param name="sessionService">The <see cref="ISessionService" /></param>
         /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
-        public RequirementsEditorBodyViewModel(ISessionService sessionService, ICDPMessageBus messageBus) : base(sessionService, messageBus)
+        /// <param name="showHideDeprecatedThingsService">The <see cref="IShowHideDeprecatedThingsService" /></param>
+        public RequirementsEditorBodyViewModel(ISessionService sessionService, ICDPMessageBus messageBus, IShowHideDeprecatedThingsService showHideDeprecatedThingsService) : base(sessionService, messageBus)
         {
+            this.ShowHideDeprecatedThingsService = showHideDeprecatedThingsService;
         }
 
         /// <summary>
-        /// Gets the non-deprecated <see cref="RequirementsSpecification" />s of the current iteration.
+        /// Gets the <see cref="IShowHideDeprecatedThingsService" /> that drives whether deprecated things are shown.
         /// </summary>
-        public IEnumerable<RequirementsSpecification> AvailableSpecifications { get; private set; } = [];
+        public IShowHideDeprecatedThingsService ShowHideDeprecatedThingsService { get; }
+
+        /// <summary>
+        /// Gets the <see cref="RequirementsSpecification" />s of the current iteration; deprecated ones are included
+        /// only when the global "Show Deprecated Things" toggle is on.
+        /// </summary>
+        public IEnumerable<RequirementsSpecification> AvailableSpecifications =>
+            this.CurrentThing == null
+                ? []
+                : this.CurrentThing.RequirementsSpecification
+                    .Where(x => this.ShowHideDeprecatedThingsService.ShowDeprecatedThings || !x.IsDeprecated)
+                    .OrderBy(x => x.ShortName);
 
         /// <summary>
         /// Gets or sets the <see cref="RequirementsSpecification" /> currently shown as a document.
@@ -146,6 +166,16 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         {
             get => this.showCategory;
             set => this.RaiseAndSetIfChanged(ref this.showCategory, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether groups are indented in the document. When off, groups and
+        /// requirements are rendered flush-left regardless of nesting depth.
+        /// </summary>
+        public bool IndentGroups
+        {
+            get => this.indentGroups;
+            set => this.RaiseAndSetIfChanged(ref this.indentGroups, value);
         }
 
         /// <summary>
@@ -205,7 +235,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             var group = container as RequirementsGroup;
 
             return this.SelectedSpecification.Requirement
-                .Where(x => !x.IsDeprecated && ReferenceEquals(x.Group, group) && this.PassesFilter(x))
+                .Where(x => (this.ShowHideDeprecatedThingsService.ShowDeprecatedThings || !x.IsDeprecated) && ReferenceEquals(x.Group, group) && this.PassesFilter(x))
                 .OrderBy(x => x.ShortName);
         }
 
@@ -305,12 +335,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
             this.IsLoading = true;
 
-            this.AvailableSpecifications = this.CurrentThing.RequirementsSpecification
+            var allRequirements = this.CurrentThing.RequirementsSpecification
                 .Where(x => !x.IsDeprecated)
-                .OrderBy(x => x.ShortName)
-                .ToList();
-
-            var allRequirements = this.AvailableSpecifications
                 .SelectMany(x => x.Requirement)
                 .Where(x => !x.IsDeprecated)
                 .ToList();

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -1,0 +1,357 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsEditorBodyViewModel.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View model that handles the logic for the Requirements Editor application: it exposes the
+    /// <see cref="RequirementsSpecification" />s of the iteration as documents, and the search/filter state used to
+    /// render them.
+    /// </summary>
+    public class RequirementsEditorBodyViewModel : SingleIterationApplicationBaseViewModel, IRequirementsEditorBodyViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedSpecification" />
+        /// </summary>
+        private RequirementsSpecification selectedSpecification;
+
+        /// <summary>
+        /// Backing field for <see cref="SearchText" />
+        /// </summary>
+        private string searchText;
+
+        /// <summary>
+        /// Backing field for <see cref="IsTocCollapsed" />
+        /// </summary>
+        private bool isTocCollapsed;
+
+        /// <summary>
+        /// Backing field for <see cref="ShowOwner" />
+        /// </summary>
+        private bool showOwner = true;
+
+        /// <summary>
+        /// Backing field for <see cref="ShowCategory" />
+        /// </summary>
+        private bool showCategory = true;
+
+        /// <summary>
+        /// The <see cref="Guid" />s of the table-of-contents tree nodes that are currently collapsed.
+        /// </summary>
+        private readonly HashSet<Guid> collapsedTreeNodes = [];
+
+        /// <summary>
+        /// The <see cref="Guid" />s of the document groups that are currently collapsed.
+        /// </summary>
+        private readonly HashSet<Guid> collapsedDocumentGroups = [];
+
+        /// <summary>
+        /// Backing field for <see cref="DisplayMode" />
+        /// </summary>
+        private RequirementRowDisplayMode displayMode = RequirementRowDisplayMode.ShortNameNameAndDefinition;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedOwners" />
+        /// </summary>
+        private IEnumerable<DomainOfExpertise> selectedOwners = [];
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedCategories" />
+        /// </summary>
+        private IEnumerable<Category> selectedCategories = [];
+
+        /// <summary>
+        /// Creates a new instance of <see cref="RequirementsEditorBodyViewModel" />
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" /></param>
+        /// <param name="messageBus">The <see cref="ICDPMessageBus" /></param>
+        public RequirementsEditorBodyViewModel(ISessionService sessionService, ICDPMessageBus messageBus) : base(sessionService, messageBus)
+        {
+        }
+
+        /// <summary>
+        /// Gets the non-deprecated <see cref="RequirementsSpecification" />s of the current iteration.
+        /// </summary>
+        public IEnumerable<RequirementsSpecification> AvailableSpecifications { get; private set; } = [];
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsSpecification" /> currently shown as a document.
+        /// </summary>
+        public RequirementsSpecification SelectedSpecification
+        {
+            get => this.selectedSpecification;
+            set => this.RaiseAndSetIfChanged(ref this.selectedSpecification, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the keyword used to filter requirements on their definition text.
+        /// </summary>
+        public string SearchText
+        {
+            get => this.searchText;
+            set => this.RaiseAndSetIfChanged(ref this.searchText, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the left table-of-contents tree is collapsed.
+        /// </summary>
+        public bool IsTocCollapsed
+        {
+            get => this.isTocCollapsed;
+            set => this.RaiseAndSetIfChanged(ref this.isTocCollapsed, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owner pill is shown on specifications, groups and requirements.
+        /// </summary>
+        public bool ShowOwner
+        {
+            get => this.showOwner;
+            set => this.RaiseAndSetIfChanged(ref this.showOwner, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown on specifications, groups and requirements.
+        /// </summary>
+        public bool ShowCategory
+        {
+            get => this.showCategory;
+            set => this.RaiseAndSetIfChanged(ref this.showCategory, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the way each requirement is rendered as a row.
+        /// </summary>
+        public RequirementRowDisplayMode DisplayMode
+        {
+            get => this.displayMode;
+            set => this.RaiseAndSetIfChanged(ref this.displayMode, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="DomainOfExpertise" /> owners; an empty selection means no owner filtering.
+        /// </summary>
+        public IEnumerable<DomainOfExpertise> SelectedOwners
+        {
+            get => this.selectedOwners;
+            set => this.RaiseAndSetIfChanged(ref this.selectedOwners, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="Category" /> values; an empty selection means no category filtering.
+        /// </summary>
+        public IEnumerable<Category> SelectedCategories
+        {
+            get => this.selectedCategories;
+            set => this.RaiseAndSetIfChanged(ref this.selectedCategories, value);
+        }
+
+        /// <summary>
+        /// Gets the distinct <see cref="DomainOfExpertise" /> owners available to filter on.
+        /// </summary>
+        public IReadOnlyList<DomainOfExpertise> AvailableOwners { get; private set; } = [];
+
+        /// <summary>
+        /// Gets the distinct <see cref="Category" /> values available to filter on.
+        /// </summary>
+        public IReadOnlyList<Category> AvailableCategories { get; private set; } = [];
+
+        /// <summary>
+        /// Gets a value indicating whether any search or filter is currently narrowing the document.
+        /// </summary>
+        private bool IsFilterActive => !string.IsNullOrWhiteSpace(this.SearchText) || this.SelectedOwners.Any() || this.SelectedCategories.Any();
+
+        /// <summary>
+        /// Gets the visible, non-deprecated requirements located directly under the given <paramref name="container" />.
+        /// </summary>
+        /// <param name="container">The <see cref="RequirementsContainer" /> (specification or group)</param>
+        /// <returns>The requirements to render under that container</returns>
+        public IEnumerable<Requirement> GetRequirements(RequirementsContainer container)
+        {
+            if (this.SelectedSpecification == null)
+            {
+                return [];
+            }
+
+            var group = container as RequirementsGroup;
+
+            return this.SelectedSpecification.Requirement
+                .Where(x => !x.IsDeprecated && ReferenceEquals(x.Group, group) && this.PassesFilter(x))
+                .OrderBy(x => x.ShortName);
+        }
+
+        /// <summary>
+        /// Gets the visible child <see cref="RequirementsGroup" />s of the given <paramref name="container" />.
+        /// </summary>
+        /// <param name="container">The <see cref="RequirementsContainer" /> (specification or group)</param>
+        /// <returns>The child groups to render</returns>
+        public IEnumerable<RequirementsGroup> GetGroups(RequirementsContainer container)
+        {
+            return container.Group
+                .Where(this.ShouldDisplayGroup)
+                .OrderBy(x => x.ShortName);
+        }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="group" /> should be displayed given the active search and filters.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /></param>
+        /// <returns>true if no filter is active, or the group (or a descendant) has visible requirements</returns>
+        public bool ShouldDisplayGroup(RequirementsGroup group)
+        {
+            if (!this.IsFilterActive)
+            {
+                return true;
+            }
+
+            return this.GetRequirements(group).Any() || group.Group.Any(this.ShouldDisplayGroup);
+        }
+
+        /// <summary>
+        /// Gets whether the tree node with the given <paramref name="iid" /> is collapsed in the table-of-contents tree.
+        /// </summary>
+        /// <param name="iid">The identifier of the specification or group node</param>
+        /// <returns>true if collapsed</returns>
+        public bool IsTreeNodeCollapsed(Guid iid)
+        {
+            return this.collapsedTreeNodes.Contains(iid);
+        }
+
+        /// <summary>
+        /// Toggles the collapsed state of the table-of-contents tree node with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The identifier of the specification or group node</param>
+        public void ToggleTreeNode(Guid iid)
+        {
+            if (!this.collapsedTreeNodes.Add(iid))
+            {
+                this.collapsedTreeNodes.Remove(iid);
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the group with the given <paramref name="iid" /> is collapsed in the document panel.
+        /// </summary>
+        /// <param name="iid">The identifier of the group</param>
+        /// <returns>true if collapsed</returns>
+        public bool IsDocumentGroupCollapsed(Guid iid)
+        {
+            return this.collapsedDocumentGroups.Contains(iid);
+        }
+
+        /// <summary>
+        /// Toggles the collapsed state of the document group with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The identifier of the group</param>
+        public void ToggleDocumentGroup(Guid iid)
+        {
+            if (!this.collapsedDocumentGroups.Add(iid))
+            {
+                this.collapsedDocumentGroups.Remove(iid);
+            }
+        }
+
+        /// <summary>
+        /// Handles the refresh of the current session by reloading the specifications while preserving the selection.
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnSessionRefreshed()
+        {
+            var previouslySelected = this.SelectedSpecification;
+            await this.OnThingChanged();
+
+            if (previouslySelected != null && this.AvailableSpecifications.Contains(previouslySelected))
+            {
+                this.SelectedSpecification = previouslySelected;
+            }
+        }
+
+        /// <summary>
+        /// Update this view model properties when the <see cref="Iteration" /> has changed.
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnThingChanged()
+        {
+            await base.OnThingChanged();
+
+            this.IsLoading = true;
+
+            this.AvailableSpecifications = this.CurrentThing.RequirementsSpecification
+                .Where(x => !x.IsDeprecated)
+                .OrderBy(x => x.ShortName)
+                .ToList();
+
+            var allRequirements = this.AvailableSpecifications
+                .SelectMany(x => x.Requirement)
+                .Where(x => !x.IsDeprecated)
+                .ToList();
+
+            this.AvailableOwners = allRequirements
+                .Select(x => x.Owner)
+                .Where(x => x != null)
+                .DistinctBy(x => x.Iid)
+                .OrderBy(x => x.ShortName)
+                .ToList();
+
+            this.AvailableCategories = allRequirements
+                .SelectMany(x => x.Category)
+                .DistinctBy(x => x.Iid)
+                .OrderBy(x => x.ShortName)
+                .ToList();
+
+            this.SelectedSpecification = this.AvailableSpecifications.FirstOrDefault();
+
+            this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="requirement" /> passes the active search and filters.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>true if it should be shown</returns>
+        private bool PassesFilter(Requirement requirement)
+        {
+            if (!string.IsNullOrWhiteSpace(this.SearchText)
+                && !requirement.Definition.Any(x => x.Content != null && x.Content.Contains(this.SearchText, StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            if (this.SelectedOwners.Any() && !this.SelectedOwners.Contains(requirement.Owner))
+            {
+                return false;
+            }
+
+            return !this.SelectedCategories.Any() || requirement.Category.Intersect(this.SelectedCategories).Any();
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #785 
Added a view for requirements management on the left it has a Table of contents with Specifications and groups with which we can quickly go to the groups in the document on the right panel.

Layout

Left: a custom, recursive table-of-contents tree: specifications with their nested RequirementsGroup hierarchy, with grey tree guide-lines and expand/collapse chevrons. Clicking a spec loads its document; clicking a group scrolls the document to that group.
Right: the selected spec rendered like a document:  spec title, group headers (as section bars), and requirement rows.
Collapse the TOC («) to give the document full width.
Fills the tab height; the tree and document panels scroll independently.
Reading & display controls (toolbar)

Search requirements by keyword in their definition text.
Filter by owner and/or category (multi-select).
Layout switch for how each requirement renders: ID, Name, or ID + Name (definition always the focus).
Indent toggle: flatten the group indentation so headers/requirements sit flush-left.
Owner / Category toggles: show/hide the coloured pills.
Metadata presentation

Owner and category shown as stable, coloured pills (reuses .starion-pill + TagColorGenerator), on specs, groups and requirements, right-aligned. Only directly-assigned categories are shown (not super-categories).
Deprecated requirements

Hooked into the existing app-wide "Show Deprecated Things" sidebar toggle. Off by default (hidden); when on, deprecated specifications/requirements appear greyed + strikethrough with a red "Deprecated" badge, and the document updates live.

Not Implemented:
- Parameteric Constraints and Simple parameter Values
- Create, update and delete of requirements groups and specs.

<img width="940" height="527" alt="image" src="https://github.com/user-attachments/assets/c540deb3-1e86-452e-957c-eb225c8a358e" />

<img width="940" height="465" alt="image" src="https://github.com/user-attachments/assets/ff824a1d-70cb-48f7-8c5c-c446358372e5" />

