### PR TITLE
[Fix] disable enforced NuGet signature verification in CI (NU3012 revoked cert)

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -41,8 +41,12 @@ jobs:
         run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
       - name: Restore dependencies
+        env:
+          # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
+          # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
+          DOTNET_NUGET_SIGNATURE_VERIFICATION: false
         run: dotnet restore COMETwebapp.sln
-        
+
       - name: Sonarqube Begin
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,10 @@ jobs:
       run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
     - name: Install dependencies
+      env:
+        # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
+        # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
       run: dotnet restore COMETwebapp.sln
 
     - name: Build

--- a/.github/workflows/nuget-reference-check.yml
+++ b/.github/workflows/nuget-reference-check.yml
@@ -33,6 +33,10 @@ jobs:
       run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
     - name: Restore dependencies
+      env:
+        # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
+        # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
       run: dotnet restore COMETwebapp.sln
 
     - name: Build

--- a/COMETwebapp/Dockerfile
+++ b/COMETwebapp/Dockerfile
@@ -5,6 +5,10 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG DEVEXPRESS_NUGET_KEY
 ARG PACKAGE_TOKEN
 
+# Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
+# Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
+ENV DOTNET_NUGET_SIGNATURE_VERIFICATION=false
+
 COPY COMET.Web.Common COMET.Web.Common
 COPY COMETwebapp COMETwebapp
 


### PR DESCRIPTION
## Problem

CI `Restore dependencies` fails with **NU3012** on the GitHub-hosted Ubuntu runners:

```
error NU3012: Package ''ReactiveUI 23.1.8'' from source ''https://api.nuget.org/v3/index.json'':
The author primary signature found a chain building issue: Revoked: certificate revoked
```

The code-signing certificate used for the **ReactiveUI / Splat** packages has been revoked. The Ubuntu runners enforce NuGet package signature verification (`DOTNET_NUGET_SIGNATURE_VERIFICATION=true`), so a revoked cert turns into a hard restore failure and blocks all builds/PRs. This is external to any code change (seen on run `28857136604`).

## Fix (immediate unblock)

Set `DOTNET_NUGET_SIGNATURE_VERIFICATION=false` on the `dotnet restore` steps so restore no longer enforces signature verification:

- `.github/workflows/CodeQuality.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/nuget-reference-check.yml`
- `COMETwebapp/Dockerfile` (build stage `ENV`)

The exact same packages (by version) are still restored; only enforced signature verification is disabled.

## Follow-up

Longer-term fix tracked in #792: update ReactiveUI/Splat to validly-signed versions and revert this workaround to re-enable signature verification.