### PR TITLE
Feat 789 implemented showing traceability, constraints and values

### DIFF
--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
@@ -1,0 +1,197 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementDetailsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementDetailsTestFixture
+    {
+        private BunitContext context;
+        private CDPMessageBus messageBus;
+        private RequirementsEditorBodyViewModel viewModel;
+        private Requirement requirement;
+        private Requirement linkedRequirement;
+        private Requirement deprecatedRequirement;
+        private AndExpression andExpression;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.messageBus = new CDPMessageBus();
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var lengthType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "l", Name = "length" };
+            var kilogram = new RatioScale { Iid = Guid.NewGuid(), ShortName = "kg", Name = "kilogram" };
+
+            var boundRelational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Scale = kilogram, Value = new ValueArray<string>(["100"]) };
+            var notInner = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = lengthType, RelationalOperator = RelationalOperatorKind.GE, Value = new ValueArray<string>(["2"]) };
+            var orLeftExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.EQ, Value = new ValueArray<string>(["1"]) };
+            var orRightExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.NE, Value = new ValueArray<string>(["0"]) };
+            var xorLeftExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LT, Value = new ValueArray<string>(["9"]) };
+            var xorRightExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.GT, Value = new ValueArray<string>(["3"]) };
+
+            var notExpression = new NotExpression { Iid = Guid.NewGuid(), Term = notInner };
+            var orExpression = new OrExpression { Iid = Guid.NewGuid(), Term = { orLeftExpression, orRightExpression } };
+            var xorExpression = new ExclusiveOrExpression { Iid = Guid.NewGuid(), Term = { xorLeftExpression, xorRightExpression } };
+            this.andExpression = new AndExpression { Iid = Guid.NewGuid(), Term = { notExpression, orExpression, xorExpression, boundRelational } };
+
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = this.andExpression };
+            constraint.Expression.AddRange([this.andExpression, notExpression, orExpression, xorExpression, boundRelational, notInner, orLeftExpression, orRightExpression, xorLeftExpression, xorRightExpression]);
+
+            this.requirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R1", Name = "First requirement", Owner = domain };
+            this.requirement.ParametricConstraint.Add(constraint);
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" };
+            var parameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = massType };
+            parameter.ValueSet.Add(new ParameterValueSet { Iid = Guid.NewGuid(), Published = new ValueArray<string>(["42"]) });
+            elementDefinition.Parameter.Add(parameter);
+
+            this.linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R2", Name = "Second requirement" };
+            this.deprecatedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R0", Name = "Old requirement", IsDeprecated = true };
+
+            var specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "SPEC", Name = "Specification" };
+            specification.Requirement.AddRange([this.requirement, this.linkedRequirement, this.deprecatedRequirement]);
+
+            var iteration = new Iteration { Iid = Guid.NewGuid() };
+            iteration.RequirementsSpecification.Add(specification);
+            iteration.Element.Add(elementDefinition);
+            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = parameter, Target = boundRelational });
+            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.requirement, Target = elementDefinition });
+            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.linkedRequirement, Target = this.requirement });
+            iteration.Relationship.Add(new MultiRelationship { Iid = Guid.NewGuid(), RelatedThing = { this.requirement, this.deprecatedRequirement } });
+
+            var sessionService = new Mock<ISessionService>();
+            var session = new Mock<ISession>();
+            session.Setup(x => x.OpenReferenceDataLibraries).Returns([]);
+            sessionService.Setup(x => x.Session).Returns(session.Object);
+
+            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus, new ShowHideDeprecatedThingsService())
+            {
+                CurrentThing = iteration,
+                ShowParametricConstraints = true,
+                ShowTraceability = true
+            };
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+            this.viewModel.Dispose();
+            this.messageBus.ClearSubscriptions();
+            this.messageBus.Dispose();
+        }
+
+        private IRenderedComponent<RequirementDetails> Render()
+        {
+            return this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel)
+                .Add(p => p.Requirement, this.requirement));
+        }
+
+        [Test]
+        public void VerifyConstraintTreeRenders()
+        {
+            var component = this.Render();
+            var markup = component.Markup;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(markup, Does.Contain("Constraints"));
+                Assert.That(markup, Does.Contain("AND"));
+                Assert.That(markup, Does.Contain("OR"));
+                Assert.That(markup, Does.Contain("XOR"));
+                Assert.That(markup, Does.Contain("NOT"));
+                Assert.That(markup, Does.Contain("≤"), "the relational operator symbol must render");
+                Assert.That(markup, Does.Contain("SAT.m"), "the bound parameter model code must render");
+                Assert.That(markup, Does.Contain("= 42"), "the bound parameter published value must render");
+                Assert.That(component.FindAll(".req-expr-toggle"), Is.Not.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyTraceabilityRenders()
+        {
+            var component = this.Render();
+            var markup = component.Markup;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(markup, Does.Contain("Traceability"));
+                Assert.That(markup, Does.Contain("→"), "an outgoing relationship arrow must render");
+                Assert.That(markup, Does.Contain("←"), "an incoming relationship arrow must render");
+                Assert.That(markup, Does.Contain("↔"), "a multi relationship arrow must render");
+                Assert.That(markup, Does.Contain("Satellite"), "the related element definition label must render");
+                Assert.That(markup, Does.Contain("SPEC · R2"), "a related requirement renders as a specification-qualified link");
+                Assert.That(component.FindAll(".req-link-req.req-row-deprecated"), Is.Not.Empty, "a deprecated linked requirement is styled");
+            });
+        }
+
+        [Test]
+        public void VerifyCollapsingAnExpressionHidesItsChildren()
+        {
+            var component = this.Render();
+
+            Assert.That(this.viewModel.IsExpressionCollapsed(this.andExpression.Iid), Is.False);
+
+            // the top AND node's toggle is the first one
+            component.FindAll(".req-expr-toggle")[0].Click();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsExpressionCollapsed(this.andExpression.Iid), Is.True);
+                Assert.That(component.Markup, Does.Contain("Collapsed.svg"), "the collapsed node shows the collapsed chevron");
+            });
+        }
+
+        [Test]
+        public void VerifyClickingARequirementLinkNavigates()
+        {
+            var component = this.Render();
+
+            component.Find(".req-link-req").Click();
+
+            Assert.That(this.viewModel.ScrollTarget, Is.Not.Null, "clicking a requirement link navigates to it");
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementValueCellTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementValueCellTestFixture.cs
@@ -1,0 +1,220 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementValueCellTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components.Web;
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementValueCellTestFixture
+    {
+        private BunitContext context;
+        private CDPMessageBus messageBus;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private EnumerationParameterType enumerationParameterType;
+        private Requirement requirement;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.messageBus = new CDPMessageBus();
+            this.context.Services.AddSingleton<ICDPMessageBus>(this.messageBus);
+
+            this.enumerationParameterType = new EnumerationParameterType { Iid = Guid.NewGuid(), ShortName = "col", Name = "colour" };
+            this.enumerationParameterType.ValueDefinition.Add(new EnumerationValueDefinition { Iid = Guid.NewGuid(), ShortName = "red", Name = "red" });
+            this.enumerationParameterType.ValueDefinition.Add(new EnumerationValueDefinition { Iid = Guid.NewGuid(), ShortName = "green", Name = "green" });
+
+            this.requirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R1" };
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+            this.messageBus.ClearSubscriptions();
+            this.messageBus.Dispose();
+        }
+
+        [Test]
+        public void VerifyEmptyCellShowsAddAffordance()
+        {
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns((SimpleParameterValue)null);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.Markup, Does.Contain("req-value-cell-empty"));
+                Assert.That(cell.Markup, Does.Contain("req-value-add"));
+                Assert.That(cell.Markup, Does.Not.Contain("req-value-editor"));
+            });
+        }
+
+        [Test]
+        public void VerifyClickingValueEntersEditMode()
+        {
+            var value = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.enumerationParameterType, Value = new ValueArray<string>(["red"]) };
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns(value);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            Assert.That(cell.Markup, Does.Contain("req-value-display"));
+
+            cell.Find(".req-value-display").Click();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.Markup, Does.Contain("req-value-editor"));
+                Assert.That(cell.Markup, Does.Contain("req-value-save"));
+                Assert.That(cell.FindComponents<COMET.Web.Common.Components.ParameterTypeEditors.ParameterTypeEditorSelector>(), Is.Not.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyAddAffordanceCreatesValue()
+        {
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns((SimpleParameterValue)null);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            cell.Find(".req-value-add").Click();
+
+            this.viewModel.Verify(x => x.CreateSimpleParameterValue(this.requirement, this.enumerationParameterType), Times.Once);
+        }
+
+        [Test]
+        public void VerifySaveCommitsAndLeavesEditMode()
+        {
+            var value = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.enumerationParameterType, Value = new ValueArray<string>(["red"]) };
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns(value);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            cell.Find(".req-value-display").Click();
+            cell.Find(".req-value-save").Click();
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.UpdateSimpleParameterValue(value, It.IsAny<IEnumerable<string>>()), Times.Once);
+                Assert.That(cell.Markup, Does.Not.Contain("req-value-editor"), "edit mode is left after saving");
+            });
+        }
+
+        [Test]
+        public void VerifyCancelLeavesEditModeWithoutWriting()
+        {
+            var value = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.enumerationParameterType, Value = new ValueArray<string>(["red"]) };
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns(value);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            cell.Find(".req-value-display").Click();
+            cell.Find(".req-value-cancel").Click();
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.UpdateSimpleParameterValue(It.IsAny<SimpleParameterValue>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+                Assert.That(cell.Markup, Does.Not.Contain("req-value-editor"));
+            });
+        }
+
+        [Test]
+        public void VerifyEnterWithoutAStagedChangeDoesNotCommit()
+        {
+            var value = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.enumerationParameterType, Value = new ValueArray<string>(["red"]) };
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns(value);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            cell.Find(".req-value-display").Click();
+            cell.Find(".req-value-editor").KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.UpdateSimpleParameterValue(It.IsAny<SimpleParameterValue>(), It.IsAny<IEnumerable<string>>()), Times.Never, "an Enter that only picks a dropdown item must not be swallowed as a no-op commit");
+                Assert.That(cell.Markup, Does.Contain("req-value-editor"), "the editor stays open");
+            });
+        }
+
+        [Test]
+        public void VerifyEscapeCancelsEdit()
+        {
+            var value = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.enumerationParameterType, Value = new ValueArray<string>(["red"]) };
+            this.viewModel.Setup(x => x.GetSimpleParameterValue(this.requirement, this.enumerationParameterType)).Returns(value);
+
+            var cell = this.context.Render<RequirementValueCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.ParameterType, this.enumerationParameterType));
+
+            cell.Find(".req-value-display").Click();
+            cell.Find(".req-value-editor").KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.UpdateSimpleParameterValue(It.IsAny<SimpleParameterValue>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+                Assert.That(cell.Markup, Does.Not.Contain("req-value-editor"));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
@@ -55,6 +55,8 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
         private IRenderedComponent<RequirementsEditorBody> renderedComponent;
         private CDPMessageBus messageBus;
         private RequirementsEditorBodyViewModel viewModel;
+        private Mock<IDomDataService> domDataService;
+        private Requirement requirement;
 
         [SetUp]
         public void SetUp()
@@ -69,7 +71,7 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
 
             var group = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "OPERATE", Name = "Operate", Owner = domain };
 
-            var requirement = new Requirement
+            this.requirement = new Requirement
             {
                 Iid = Guid.NewGuid(), ShortName = "R24", Name = "Provide user with sensor information", Owner = domain,
                 Definition = { new Definition { LanguageCode = "en", Content = "The USV SHALL provide sensor information." } },
@@ -79,18 +81,18 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
 
             var massParameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
             var kilogramScale = new RatioScale { Iid = Guid.NewGuid(), ShortName = "kg", Name = "kilogram" };
-            requirement.ParameterValue.Add(new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = massParameterType, Scale = kilogramScale, Value = new ValueArray<string>(["100"]) });
+            this.requirement.ParameterValue.Add(new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = massParameterType, Scale = kilogramScale, Value = new ValueArray<string>(["100"]) });
 
             var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massParameterType, RelationalOperator = RelationalOperatorKind.LE, Scale = kilogramScale, Value = new ValueArray<string>(["100"]) };
-            requirement.ParametricConstraint.Add(new ParametricConstraint { Iid = Guid.NewGuid(), Expression = { relationalExpression }, TopExpression = relationalExpression });
+            this.requirement.ParametricConstraint.Add(new ParametricConstraint { Iid = Guid.NewGuid(), Expression = { relationalExpression }, TopExpression = relationalExpression });
 
             var specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", Owner = domain };
             specification.Group.Add(group);
-            specification.Requirement.Add(requirement);
+            specification.Requirement.Add(this.requirement);
 
             var iteration = new Iteration { Iid = Guid.NewGuid() };
             iteration.RequirementsSpecification.Add(specification);
-            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = requirement, Target = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" } });
+            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.requirement, Target = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" } });
 
             var sessionService = new Mock<ISessionService>();
             var session = new Mock<ISession>();
@@ -109,8 +111,10 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
                 CurrentThing = iteration
             };
 
+            this.domDataService = new Mock<IDomDataService>();
+
             this.context.Services.AddSingleton(configuration.Object);
-            this.context.Services.AddSingleton(new Mock<IDomDataService>().Object);
+            this.context.Services.AddSingleton(this.domDataService.Object);
             this.context.Services.AddSingleton<ICDPMessageBus>(this.messageBus);
             this.context.Services.AddSingleton<IRequirementsEditorBodyViewModel>(this.viewModel);
 
@@ -144,6 +148,32 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
                 Assert.That(markup, Does.Contain("starion-pill"));
                 Assert.That(markup, Does.Contain("KUR"));
             });
+        }
+
+        [Test]
+        public void VerifyScrollTargetIsScrolledIntoViewAndCleared()
+        {
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.viewModel.IsLoading, Is.False));
+
+            this.renderedComponent.InvokeAsync(() => this.viewModel.ScrollTarget = this.requirement);
+
+            this.renderedComponent.WaitForAssertion(() =>
+            {
+                this.domDataService.Verify(x => x.ScrollElementIntoView(RequirementsDocument.RequirementAnchorId(this.requirement)), Times.Once);
+                Assert.That(this.viewModel.ScrollTarget, Is.Null, "the target is cleared once scrolled");
+            });
+        }
+
+        [Test]
+        public void VerifyTreeNameToggle()
+        {
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.viewModel.IsLoading, Is.False));
+
+            Assert.That(this.renderedComponent.Markup, Does.Contain("KUR"), "the tree labels by short name by default");
+
+            this.renderedComponent.InvokeAsync(() => this.viewModel.TreeUsesShortName = false);
+
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.renderedComponent.Markup, Does.Contain("Key-User Requirements"), "the tree labels by name when toggled"));
         }
 
         [Test]

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsEditorBodyTestFixture.cs
@@ -27,6 +27,7 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Permission;
@@ -37,6 +38,7 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
     using COMET.Web.Common.Test.Helpers;
 
     using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.Services.Interoperability;
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
 
@@ -75,18 +77,27 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
                 Group = group
             };
 
+            var massParameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var kilogramScale = new RatioScale { Iid = Guid.NewGuid(), ShortName = "kg", Name = "kilogram" };
+            requirement.ParameterValue.Add(new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = massParameterType, Scale = kilogramScale, Value = new ValueArray<string>(["100"]) });
+
+            var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massParameterType, RelationalOperator = RelationalOperatorKind.LE, Scale = kilogramScale, Value = new ValueArray<string>(["100"]) };
+            requirement.ParametricConstraint.Add(new ParametricConstraint { Iid = Guid.NewGuid(), Expression = { relationalExpression }, TopExpression = relationalExpression });
+
             var specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements", Owner = domain };
             specification.Group.Add(group);
             specification.Requirement.Add(requirement);
 
             var iteration = new Iteration { Iid = Guid.NewGuid() };
             iteration.RequirementsSpecification.Add(specification);
+            iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = requirement, Target = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" } });
 
             var sessionService = new Mock<ISessionService>();
             var session = new Mock<ISession>();
             var permissionService = new Mock<IPermissionService>();
             permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             session.Setup(x => x.PermissionService).Returns(permissionService.Object);
+            session.Setup(x => x.OpenReferenceDataLibraries).Returns([]);
             sessionService.Setup(x => x.Session).Returns(session.Object);
             sessionService.Setup(x => x.GetDomainOfExpertise(iteration)).Returns(domain);
 
@@ -99,6 +110,8 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
             };
 
             this.context.Services.AddSingleton(configuration.Object);
+            this.context.Services.AddSingleton(new Mock<IDomDataService>().Object);
+            this.context.Services.AddSingleton<ICDPMessageBus>(this.messageBus);
             this.context.Services.AddSingleton<IRequirementsEditorBodyViewModel>(this.viewModel);
 
             this.renderedComponent = this.context.Render<RequirementsEditorBody>();
@@ -143,6 +156,34 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
             this.renderedComponent.InvokeAsync(() => this.viewModel.DisplayMode = RequirementRowDisplayMode.ShortNameAndDefinition);
 
             this.renderedComponent.WaitForAssertion(() => Assert.That(this.renderedComponent.Markup, Does.Not.Contain("req-row-header")));
+        }
+
+        [Test]
+        public void VerifyDetailTogglesRevealSections()
+        {
+            this.renderedComponent.WaitForAssertion(() => Assert.That(this.viewModel.IsLoading, Is.False));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderedComponent.Markup, Does.Not.Contain("req-row-values"));
+                Assert.That(this.renderedComponent.Markup, Does.Not.Contain("req-section"));
+            });
+
+            this.viewModel.ShowSimpleParameterValues = true;
+            this.viewModel.ShowParametricConstraints = true;
+            this.viewModel.ShowTraceability = true;
+
+            var document = this.context.Render<RequirementsDocument>(parameters => parameters.Add(p => p.ViewModel, this.viewModel));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(document.Markup, Does.Contain("req-row-values"), "the value columns must be on the requirement row");
+                Assert.That(document.Markup, Does.Contain("req-value-display"), "the existing value must be shown and clickable");
+                Assert.That(document.Markup, Does.Contain("Constraints"));
+                Assert.That(document.Markup, Does.Contain("req-expr-leaf"));
+                Assert.That(document.Markup, Does.Contain("Traceability"));
+                Assert.That(document.Markup, Does.Contain("Satellite"), "the related element definition must be listed");
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/Services/Interoperability/DomDataServiceTestFixture.cs
+++ b/COMETwebapp.Tests/Services/Interoperability/DomDataServiceTestFixture.cs
@@ -50,6 +50,7 @@ namespace COMETwebapp.Tests.Services.Interoperability
 
             this.context.JSInterop.SetupVoid("setDotNetHelper");
             this.context.JSInterop.SetupVoid("SubscribeToResizeEvent");
+            this.context.JSInterop.SetupVoid("ScrollElementIntoView");
             this.context.JSInterop.Setup<float[]>("GetElementSizeAndPosition").SetResult(new float[] { 1, 2, 3, 4 });
             
             this.service = new DomDataService(jsRuntime.Object);
@@ -65,6 +66,7 @@ namespace COMETwebapp.Tests.Services.Interoperability
                 Assert.That(() => this.service.LoadDotNetHelper(dotnet), Throws.Nothing);
                 Assert.That(async () => await this.service.GetElementSizeAndPosition(0, "node", true), Throws.Nothing);
                 Assert.That(() => this.service.SubscribeToResizeEvent("resize"), Throws.Nothing);
+                Assert.That(() => this.service.ScrollElementIntoView("req-x"), Throws.Nothing);
             });
         }
     }

--- a/COMETwebapp.Tests/Utilities/ParameterValueFormatterTestFixture.cs
+++ b/COMETwebapp.Tests/Utilities/ParameterValueFormatterTestFixture.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.Tests.Utilities
 {
+    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
@@ -72,6 +73,20 @@ namespace COMETwebapp.Tests.Utilities
                 // Any other parameter type falls back to the flat formatting.
                 Assert.That(ParameterValueFormatter.Format(new ValueArray<string>(["1", "2", "3"]), new SimpleQuantityKind()),
                     Is.EqualTo("{1, 2, 3}"));
+            });
+        }
+
+        [Test]
+        public void VerifyRelationalOperatorSymbol()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.EQ), Is.EqualTo("="));
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.NE), Is.EqualTo("≠"));
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.LT), Is.EqualTo("<"));
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.GT), Is.EqualTo(">"));
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.LE), Is.EqualTo("≤"));
+                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.GE), Is.EqualTo("≥"));
             });
         }
     }

--- a/COMETwebapp.Tests/Utilities/ParameterValueFormatterTestFixture.cs
+++ b/COMETwebapp.Tests/Utilities/ParameterValueFormatterTestFixture.cs
@@ -22,7 +22,6 @@
 
 namespace COMETwebapp.Tests.Utilities
 {
-    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
@@ -73,20 +72,6 @@ namespace COMETwebapp.Tests.Utilities
                 // Any other parameter type falls back to the flat formatting.
                 Assert.That(ParameterValueFormatter.Format(new ValueArray<string>(["1", "2", "3"]), new SimpleQuantityKind()),
                     Is.EqualTo("{1, 2, 3}"));
-            });
-        }
-
-        [Test]
-        public void VerifyRelationalOperatorSymbol()
-        {
-            Assert.Multiple(() =>
-            {
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.EQ), Is.EqualTo("="));
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.NE), Is.EqualTo("≠"));
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.LT), Is.EqualTo("<"));
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.GT), Is.EqualTo(">"));
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.LE), Is.EqualTo("≤"));
-                Assert.That(ParameterValueFormatter.RelationalOperatorSymbol(RelationalOperatorKind.GE), Is.EqualTo("≥"));
             });
         }
     }

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
@@ -25,16 +25,20 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
 
     using CDP4Web.Enumerations;
 
+    using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using FluentResults;
 
     using Moq;
 
@@ -59,6 +63,10 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
         private RequirementsSpecification deprecatedSpecification;
         private Requirement deprecatedRequirement;
         private ShowHideDeprecatedThingsService showHideService;
+        private Mock<ISessionService> sessionService;
+        private SimpleQuantityKind massParameterType;
+        private SimpleQuantityKind lengthParameterType;
+        private SimpleParameterValue massValue;
 
         [SetUp]
         public void SetUp()
@@ -106,17 +114,25 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
 
             this.deprecatedSpecification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "OLD", Name = "Deprecated", Owner = this.systemDomain, IsDeprecated = true };
 
+            this.massParameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            this.lengthParameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "l", Name = "length" };
+            this.massValue = new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.massParameterType, Value = new ValueArray<string>(["100"]) };
+            this.topRequirement.ParameterValue.Add(this.massValue);
+            this.c4iRequirement.ParameterValue.Add(new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.lengthParameterType, Value = new ValueArray<string>(["2"]) });
+            this.c4iRequirement.ParameterValue.Add(new SimpleParameterValue { Iid = Guid.NewGuid(), ParameterType = this.massParameterType, Value = new ValueArray<string>(["5"]) });
+
             this.iteration = new Iteration { Iid = Guid.NewGuid() };
             this.iteration.RequirementsSpecification.AddRange([this.specification, this.deprecatedSpecification]);
 
-            var sessionService = new Mock<ISessionService>();
+            this.sessionService = new Mock<ISessionService>();
             this.session = new Mock<ISession>();
-            sessionService.Setup(x => x.Session).Returns(this.session.Object);
-            sessionService.Setup(x => x.GetDomainOfExpertise(this.iteration)).Returns(this.systemDomain);
+            this.sessionService.Setup(x => x.Session).Returns(this.session.Object);
+            this.sessionService.Setup(x => x.GetDomainOfExpertise(this.iteration)).Returns(this.systemDomain);
+            this.sessionService.Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>())).ReturnsAsync(Result.Ok());
             this.messageBus = new CDPMessageBus();
             this.showHideService = new ShowHideDeprecatedThingsService();
 
-            this.viewModel = new RequirementsEditorBodyViewModel(sessionService.Object, this.messageBus, this.showHideService)
+            this.viewModel = new RequirementsEditorBodyViewModel(this.sessionService.Object, this.messageBus, this.showHideService)
             {
                 CurrentThing = this.iteration
             };
@@ -275,6 +291,24 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
         }
 
         [Test]
+        public async Task VerifySessionRefreshWithNullIterationDoesNotThrow()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.viewModel.CurrentThing = null;
+
+            Assert.DoesNotThrow(() => this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.session.Object));
+
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.SelectedSpecification, Is.Null);
+                Assert.That(this.viewModel.AvailableSpecifications, Is.Empty);
+            });
+        }
+
+        [Test]
         public async Task VerifyIndentGroupsToggle()
         {
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
@@ -301,6 +335,289 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
             {
                 Assert.That(this.viewModel.AvailableSpecifications, Does.Contain(this.deprecatedSpecification));
                 Assert.That(this.viewModel.GetRequirements(this.specification), Does.Contain(this.deprecatedRequirement));
+            });
+        }
+
+        [Test]
+        public async Task VerifyDetailToggleDefaults()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ShowSimpleParameterValues, Is.False);
+                Assert.That(this.viewModel.ShowParametricConstraints, Is.False);
+                Assert.That(this.viewModel.ShowTraceability, Is.False);
+            });
+
+            this.viewModel.ShowSimpleParameterValues = true;
+            this.viewModel.ShowParametricConstraints = true;
+            this.viewModel.ShowTraceability = true;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ShowSimpleParameterValues, Is.True);
+                Assert.That(this.viewModel.ShowParametricConstraints, Is.True);
+                Assert.That(this.viewModel.ShowTraceability, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task VerifyGetSpecificationParameterTypes()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            // distinct over all requirements of the selected specification, ordered by short name
+            Assert.That(this.viewModel.GetSpecificationParameterTypes(), Is.EqualTo(new ParameterType[] { this.lengthParameterType, this.massParameterType }));
+
+            this.viewModel.SelectedSpecification = null;
+            Assert.That(this.viewModel.GetSpecificationParameterTypes(), Is.Empty);
+        }
+
+        [Test]
+        public async Task VerifyGetSimpleParameterValue()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetSimpleParameterValue(this.topRequirement, this.massParameterType), Is.EqualTo(this.massValue));
+                Assert.That(this.viewModel.GetSimpleParameterValue(this.topRequirement, this.lengthParameterType), Is.Null);
+                Assert.That(this.viewModel.GetSimpleParameterValue(this.operateRequirement, this.massParameterType), Is.Null);
+            });
+        }
+
+        [Test]
+        public async Task VerifyUpdateSimpleParameterValue()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            await this.viewModel.UpdateSimpleParameterValue(this.massValue, ["100"]);
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Never);
+
+            await this.viewModel.UpdateSimpleParameterValue(this.massValue, ["250"]);
+
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(
+                It.IsAny<Thing>(),
+                It.Is<IReadOnlyCollection<Thing>>(things => things.OfType<SimpleParameterValue>().Single().Value.Single() == "250"),
+                It.IsAny<NotificationDescription>()), Times.Once);
+
+            Assert.That(this.massValue.Value.Single(), Is.EqualTo("100"), "the original must not be mutated, only its clone");
+        }
+
+        [Test]
+        public async Task VerifyCreateSimpleParameterValue()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            await this.viewModel.CreateSimpleParameterValue(this.operateRequirement, this.massParameterType);
+
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(
+                It.IsAny<Thing>(),
+                It.Is<IReadOnlyCollection<Thing>>(things =>
+                    things.OfType<SimpleParameterValue>().Single().ParameterType == this.massParameterType
+                    && things.OfType<SimpleParameterValue>().Single().Value.Single() == "-"
+                    && things.OfType<Requirement>().Single().ParameterValue.Count == 1),
+                It.IsAny<NotificationDescription>()), Times.Once);
+
+            Assert.That(this.operateRequirement.ParameterValue, Is.Empty, "the original requirement must not be mutated, only its clone");
+        }
+
+        [Test]
+        public async Task VerifyGetVisibleParameterTypes()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.GetVisibleParameterTypes(), Is.EqualTo(new ParameterType[] { this.lengthParameterType, this.massParameterType }), "no picker selection shows all");
+
+            this.viewModel.SelectedParameterTypeColumns = [this.massParameterType];
+            Assert.That(this.viewModel.GetVisibleParameterTypes(), Is.EqualTo(new ParameterType[] { this.massParameterType }));
+        }
+
+        [Test]
+        public async Task VerifyExpressionCollapseState()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var iid = Guid.NewGuid();
+            Assert.That(this.viewModel.IsExpressionCollapsed(iid), Is.False);
+
+            this.viewModel.ToggleExpression(iid);
+            Assert.That(this.viewModel.IsExpressionCollapsed(iid), Is.True);
+
+            this.viewModel.ToggleExpression(iid);
+            Assert.That(this.viewModel.IsExpressionCollapsed(iid), Is.False);
+        }
+
+        [Test]
+        public async Task VerifyGetTopExpressionsAndTerms()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var firstRelational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var secondRelational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.lengthParameterType, RelationalOperator = RelationalOperatorKind.GT, Value = new ValueArray<string>(["2"]) };
+            var andExpression = new AndExpression { Iid = Guid.NewGuid(), Term = { firstRelational, secondRelational } };
+            var notExpression = new NotExpression { Iid = Guid.NewGuid(), Term = firstRelational };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), Expression = { andExpression, firstRelational, secondRelational } };
+
+            Assert.Multiple(() =>
+            {
+                // no TopExpression set: fall back to the expressions that are not a term of another expression
+                Assert.That(this.viewModel.GetTopExpressions(constraint), Is.EqualTo(new BooleanExpression[] { andExpression }));
+                Assert.That(this.viewModel.GetTerms(andExpression), Is.EqualTo(new BooleanExpression[] { firstRelational, secondRelational }));
+                Assert.That(this.viewModel.GetTerms(notExpression), Is.EqualTo(new BooleanExpression[] { firstRelational }));
+                Assert.That(this.viewModel.GetTerms(firstRelational), Is.Empty);
+            });
+
+            constraint.TopExpression = firstRelational;
+            Assert.That(this.viewModel.GetTopExpressions(constraint), Is.EqualTo(new BooleanExpression[] { firstRelational }));
+        }
+
+        [Test]
+        public async Task VerifyGetBoundParameterModelCode()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT" };
+            var parameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            parameter.ValueSet.Add(new ParameterValueSet { Iid = Guid.NewGuid(), Published = new ValueArray<string>(["42"]) });
+            elementDefinition.Parameter.Add(parameter);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetBoundParameter(relationalExpression), Is.Null);
+                Assert.That(this.viewModel.GetBoundParameterModelCode(relationalExpression), Is.Null);
+                Assert.That(this.viewModel.GetBoundParameterPublishedValue(relationalExpression), Is.Null);
+            });
+
+            this.iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = parameter, Target = relationalExpression });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetBoundParameter(relationalExpression), Is.EqualTo(parameter));
+                Assert.That(this.viewModel.GetBoundParameterModelCode(relationalExpression), Is.EqualTo(parameter.ModelCode()));
+                Assert.That(this.viewModel.GetBoundParameterPublishedValue(relationalExpression), Is.EqualTo("42"));
+            });
+
+            // a second value set (e.g. option/state-dependent) makes the published value ambiguous, so none is shown
+            parameter.ValueSet.Add(new ParameterValueSet { Iid = Guid.NewGuid(), Published = new ValueArray<string>(["7"]) });
+            Assert.That(this.viewModel.GetBoundParameterPublishedValue(relationalExpression), Is.Null);
+        }
+
+        [Test]
+        public async Task VerifyGetExpressionSummary()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var notExpression = new NotExpression { Iid = Guid.NewGuid(), Term = relational };
+            var andExpression = new AndExpression { Iid = Guid.NewGuid(), Term = { notExpression, relational } };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.GetExpressionSummary(relational), Is.EqualTo("m ≤ 100"));
+                Assert.That(this.viewModel.GetExpressionSummary(notExpression), Does.Contain("NOT"), "the NOT operator must not be dropped from the summary");
+                Assert.That(this.viewModel.GetExpressionSummary(andExpression), Does.Contain("NOT").And.Contain("AND"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyTreeUsesShortNameToggle()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.TreeUsesShortName, Is.True);
+            this.viewModel.TreeUsesShortName = false;
+            Assert.That(this.viewModel.TreeUsesShortName, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyGetTraceability()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var verifiesCategory = new Category { Iid = Guid.NewGuid(), ShortName = "verifies", Name = "verifies" };
+            var strictlyVerifiesCategory = new Category { Iid = Guid.NewGuid(), ShortName = "strictVerifies", Name = "strictly verifies", SuperCategory = { verifiesCategory } };
+            var rule = new BinaryRelationshipRule { Iid = Guid.NewGuid(), Name = "Requirement verification", RelationshipCategory = verifiesCategory };
+            var rdl = new SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
+            rdl.Rule.Add(rule);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns([rdl]);
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT" };
+
+            // the relationship carries a SUB-category of the rule's category; the rule must still apply
+            var outgoing = new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.topRequirement, Target = elementDefinition, Category = { strictlyVerifiesCategory } };
+            var incoming = new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.c4iRequirement, Target = this.topRequirement };
+            var multi = new MultiRelationship { Iid = Guid.NewGuid(), RelatedThing = { this.topRequirement, this.operateRequirement, elementDefinition } };
+            var unrelated = new BinaryRelationship { Iid = Guid.NewGuid(), Source = this.c4iRequirement, Target = elementDefinition };
+            this.iteration.Relationship.AddRange([outgoing, incoming, multi, unrelated]);
+
+            var rows = this.viewModel.GetTraceability(this.topRequirement);
+
+            Assert.That(rows, Has.Count.EqualTo(3));
+
+            var outgoingRow = rows.Single(x => x.Relationship == outgoing);
+            var incomingRow = rows.Single(x => x.Relationship == incoming);
+            var multiRow = rows.Single(x => x.Relationship == multi);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(outgoingRow.Direction, Is.EqualTo(RelationshipDirection.Outgoing));
+                Assert.That(outgoingRow.RelatedThings, Is.EqualTo(new Thing[] { elementDefinition }));
+                Assert.That(outgoingRow.RuleNames, Is.EqualTo(new[] { "Requirement verification" }));
+                Assert.That(incomingRow.Direction, Is.EqualTo(RelationshipDirection.Incoming));
+                Assert.That(incomingRow.RelatedThings, Is.EqualTo(new Thing[] { this.c4iRequirement }));
+                Assert.That(incomingRow.RuleNames, Is.Empty);
+                Assert.That(multiRow.Direction, Is.EqualTo(RelationshipDirection.Bidirectional));
+                Assert.That(multiRow.RelatedThings, Is.EqualTo(new Thing[] { this.operateRequirement, elementDefinition }));
+            });
+        }
+
+        [Test]
+        public async Task VerifyNavigateToRequirement()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.viewModel.ToggleDocumentGroup(this.operateGroup.Iid);
+            this.viewModel.ToggleDocumentGroup(this.c4iGroup.Iid);
+            this.viewModel.SelectedSpecification = this.deprecatedSpecification;
+            this.viewModel.SearchText = "nomatch";
+            this.viewModel.SelectedOwners = [this.thermalDomain];
+            this.viewModel.SelectedCategories = [this.keyUserCategory];
+
+            this.viewModel.NavigateToRequirement(this.c4iRequirement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+                Assert.That(this.viewModel.ScrollTarget, Is.EqualTo(this.c4iRequirement));
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.c4iGroup.Iid), Is.False);
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.False);
+
+                // filters are cleared so the target renders (its anchor exists to scroll to)
+                Assert.That(this.viewModel.SearchText, Is.Null);
+                Assert.That(this.viewModel.SelectedOwners, Is.Empty);
+                Assert.That(this.viewModel.SelectedCategories, Is.Empty);
+                Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Does.Contain(this.c4iRequirement));
+                Assert.That(this.showHideService.ShowDeprecatedThings, Is.False, "a non-deprecated target does not flip the global toggle");
+            });
+        }
+
+        [Test]
+        public async Task VerifyNavigateToDeprecatedRequirementShowsDeprecated()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.showHideService.ShowDeprecatedThings, Is.False);
+
+            this.viewModel.NavigateToRequirement(this.deprecatedRequirement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.showHideService.ShowDeprecatedThings, Is.True, "navigating to a deprecated target reveals deprecated things so its anchor renders");
+                Assert.That(this.viewModel.SelectedSpecification, Is.EqualTo(this.specification));
+                Assert.That(this.viewModel.ScrollTarget, Is.EqualTo(this.deprecatedRequirement));
             });
         }
     }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
@@ -34,7 +34,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                 <span class="req-expr-leaf">
                     <span class="req-expr-pt" title="@relational.ParameterType?.Name">@relational.ParameterType?.ShortName</span>
-                    <span class="req-expr-op">@ParameterValueFormatter.RelationalOperatorSymbol(relational.RelationalOperator)</span>
+                    <span class="req-expr-op">@relational.RelationalOperator.ToScientificNotationString()</span>
                     <span class="req-expr-value">@string.Join(", ", relational.Value)</span>
                     @if (relational.Scale != null)
                     {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
@@ -1,0 +1,137 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using CDP4Common.EngineeringModelData
+@using COMETwebapp.Utilities
+@using COMETwebapp.ViewModels.Components.RequirementsEditor
+
+@{
+    RenderFragment<BooleanExpression> expressionNode = null;
+
+    expressionNode = expression =>
+        @<div class="req-expr">
+            @if (expression is RelationalExpression relational)
+            {
+                var boundModelCode = this.ViewModel.GetBoundParameterModelCode(relational);
+                var publishedValue = this.ViewModel.GetBoundParameterPublishedValue(relational);
+
+                <span class="req-expr-leaf">
+                    <span class="req-expr-pt" title="@relational.ParameterType?.Name">@relational.ParameterType?.ShortName</span>
+                    <span class="req-expr-op">@ParameterValueFormatter.RelationalOperatorSymbol(relational.RelationalOperator)</span>
+                    <span class="req-expr-value">@string.Join(", ", relational.Value)</span>
+                    @if (relational.Scale != null)
+                    {
+                        <span class="req-expr-scale" title="@relational.Scale.Name">@relational.Scale.ShortName</span>
+                    }
+                    @if (boundModelCode != null)
+                    {
+                        <span class="req-expr-binding" title="Bound parameter">@boundModelCode</span>
+                        @if (publishedValue != null)
+                        {
+                            <span class="req-expr-published" title="Published value of the bound parameter">= @publishedValue</span>
+                        }
+                    }
+                </span>
+            }
+            else
+            {
+                var collapsed = this.ViewModel.IsExpressionCollapsed(expression.Iid);
+                var summary = this.ViewModel.GetExpressionSummary(expression);
+
+                <div class="req-expr-node">
+                    <button type="button" class="req-expr-toggle" title="@(collapsed ? "Expand" : "Collapse")"
+                            @onclick="@(() => this.ViewModel.ToggleExpression(expression.Iid))">
+                        <img src="@(collapsed ? "images/Collapsed.svg" : "images/Expanded.svg")" alt="" />
+                    </button>
+                    <span class="req-expr-operator">@GetExpressionLabel(expression)</span>
+                    <span class="req-expr-summary" title="@summary">@summary</span>
+                </div>
+
+                @if (!collapsed)
+                {
+                    <div class="req-expr-children">
+                        @foreach (var term in this.ViewModel.GetTerms(expression))
+                        {
+                            @expressionNode(term)
+                        }
+                    </div>
+                }
+            }
+        </div>;
+}
+
+<div class="req-details">
+    @if (this.ViewModel.ShowParametricConstraints && this.Requirement.ParametricConstraint.Count > 0)
+    {
+        <div class="req-section">
+            <span class="req-section-title">Constraints</span>
+            @foreach (ParametricConstraint constraint in this.Requirement.ParametricConstraint)
+            {
+                <div class="req-constraint">
+                    @foreach (var topExpression in this.ViewModel.GetTopExpressions(constraint))
+                    {
+                        @expressionNode(topExpression)
+                    }
+                </div>
+            }
+        </div>
+    }
+
+    @if (this.ViewModel.ShowTraceability)
+    {
+        var traceabilityRows = this.ViewModel.GetTraceability(this.Requirement);
+
+        @if (traceabilityRows.Count > 0)
+        {
+            <div class="req-section">
+                <span class="req-section-title">Traceability</span>
+                @foreach (var row in traceabilityRows)
+                {
+                    <div class="req-link-row">
+                        <span class="req-link-direction" title="@GetDirectionTitle(row.Direction)">@GetDirectionSymbol(row.Direction)</span>
+                        <span class="req-link-targets">
+                            @foreach (var relatedThing in row.RelatedThings)
+                            {
+                                @if (relatedThing is Requirement linkedRequirement)
+                                {
+                                    <button type="button" class="req-link-req @(linkedRequirement.IsDeprecated ? "req-row-deprecated" : string.Empty)"
+                                            title="@linkedRequirement.Name"
+                                            @onclick="@(() => this.ViewModel.NavigateToRequirement(linkedRequirement))">
+                                        @GetRequirementLabel(linkedRequirement)
+                                    </button>
+                                }
+                                else
+                                {
+                                    <span class="req-link-thing">@GetThingLabel(relatedThing)</span>
+                                }
+                            }
+                        </span>
+                        <span class="req-pills">
+                            @foreach (var ruleName in row.RuleNames)
+                            {
+                                <span class="req-link-rule" title="Relationship rule">@ruleName</span>
+                            }
+                        </span>
+                    </div>
+                }
+            </div>
+        }
+    }
+</div>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
@@ -1,0 +1,127 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementDetails.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders the block detail sections of a <see cref="Requirement" /> in the document: its
+    /// <see cref="ParametricConstraint" /> expression trees and the relationships it participates in, side by side,
+    /// driven by the "Constraints" and "Traceability" toolbar toggles. The <see cref="SimpleParameterValue" /> columns
+    /// are rendered separately on the requirement row by <see cref="RequirementValueCell" />.
+    /// </summary>
+    public partial class RequirementDetails
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> whose details are rendered.
+        /// </summary>
+        [Parameter]
+        public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets the operator label of the given non-leaf <paramref name="expression" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="BooleanExpression" /></param>
+        /// <returns>The label</returns>
+        private static string GetExpressionLabel(BooleanExpression expression)
+        {
+            return expression switch
+            {
+                AndExpression => "AND",
+                OrExpression => "OR",
+                ExclusiveOrExpression => "XOR",
+                NotExpression => "NOT",
+                _ => expression.ClassKind.ToString()
+            };
+        }
+
+        /// <summary>
+        /// Gets the arrow symbol for the given <paramref name="direction" />.
+        /// </summary>
+        /// <param name="direction">The <see cref="RelationshipDirection" /></param>
+        /// <returns>The symbol</returns>
+        private static string GetDirectionSymbol(RelationshipDirection direction)
+        {
+            return direction switch
+            {
+                RelationshipDirection.Outgoing => "→",
+                RelationshipDirection.Incoming => "←",
+                _ => "↔"
+            };
+        }
+
+        /// <summary>
+        /// Gets the tooltip for the given <paramref name="direction" />.
+        /// </summary>
+        /// <param name="direction">The <see cref="RelationshipDirection" /></param>
+        /// <returns>The tooltip text</returns>
+        private static string GetDirectionTitle(RelationshipDirection direction)
+        {
+            return direction switch
+            {
+                RelationshipDirection.Outgoing => "Outgoing relationship",
+                RelationshipDirection.Incoming => "Incoming relationship",
+                _ => "Multi relationship"
+            };
+        }
+
+        /// <summary>
+        /// Gets the link label of a related <see cref="Requirement" />: its specification's short name and its own.
+        /// </summary>
+        /// <param name="requirement">The related <see cref="Requirement" /></param>
+        /// <returns>The label</returns>
+        private static string GetRequirementLabel(Requirement requirement)
+        {
+            var specification = requirement.GetContainerOfType<RequirementsSpecification>();
+            return specification == null ? requirement.ShortName : $"{specification.ShortName} · {requirement.ShortName}";
+        }
+
+        /// <summary>
+        /// Gets the display label of a related <see cref="Thing" /> that is not a <see cref="Requirement" />;
+        /// element definitions and usages include their model code.
+        /// </summary>
+        /// <param name="thing">The related <see cref="Thing" /></param>
+        /// <returns>The label</returns>
+        private static string GetThingLabel(Thing thing)
+        {
+            return thing switch
+            {
+                ElementDefinition elementDefinition => $"{elementDefinition.Name} ({elementDefinition.ModelCode()})",
+                ElementUsage elementUsage => $"{elementUsage.Name} ({elementUsage.ModelCode()})",
+                DefinedThing definedThing => $"{definedThing.ShortName} – {definedThing.Name}",
+                _ => thing.UserFriendlyName
+            };
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
@@ -1,0 +1,55 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using COMET.Web.Common.Components.ParameterTypeEditors
+@using COMET.Web.Common.Enumerations
+@using COMETwebapp.Utilities
+
+@{
+    var currentValue = this.Value;
+}
+
+<div class="req-value-cell @(currentValue == null && !this.IsEditing ? "req-value-cell-empty" : string.Empty)">
+    <span class="req-value-label" title="@this.ParameterType.Name">@this.ParameterType.ShortName</span>
+
+    @if (this.IsEditing)
+    {
+        <div class="req-value-editor @(this.stagedValue != null ? "req-value-editor-dirty" : string.Empty)" @onkeydown="this.OnEditorKeyDownAsync">
+            <div class="req-value-editor-actions">
+                <button type="button" class="req-value-save" title="Save (Enter)" @onclick="this.CommitAsync">&#10003;</button>
+                <button type="button" class="req-value-cancel" title="Cancel (Esc)" @onclick="this.Cancel">&#10007;</button>
+            </div>
+            <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" />
+        </div>
+    }
+    else if (currentValue == null)
+    {
+        <button type="button" class="req-value-add" title="This requirement has no @this.ParameterType.Name value yet &#8212; click to add it"
+                @onclick="this.AddAsync">
+            + add
+        </button>
+    }
+    else
+    {
+        <button type="button" class="req-value-display" title="Click to edit" @onclick="@(() => this.BeginEdit(currentValue))">
+            @ParameterValueFormatter.Format(currentValue.Value, this.ParameterType, currentValue.Scale)
+        </button>
+    }
+</div>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor.cs
@@ -1,0 +1,196 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementValueCell.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.ViewModels.Components.ParameterEditors;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
+
+    /// <summary>
+    /// One DOORS-style value cell on a requirement row: it shows the requirement's <see cref="SimpleParameterValue" />
+    /// for a single <see cref="ParameterType" /> (or an "add" affordance when the requirement has no such value yet),
+    /// and turns into the shared per-type editor on click so enumerations, dates and quantities are edited with the
+    /// same widgets as the Edit Parameter dialog. The commit is explicit (Enter / the tick) and the original value is
+    /// never mutated, so a rejected write simply leaves the displayed value unchanged.
+    /// </summary>
+    public partial class RequirementValueCell
+    {
+        /// <summary>
+        /// The <see cref="SimpleParameterValue" /> being edited, captured when edit mode began.
+        /// </summary>
+        private SimpleParameterValue editingValue;
+
+        /// <summary>
+        /// The selector view model driving the shared per-type editor while <see cref="IsEditing" /> is true.
+        /// </summary>
+        private ParameterTypeEditorSelectorViewModel editorSelectorViewModel;
+
+        /// <summary>
+        /// The value staged by the editor since editing began, or null when nothing has been edited yet.
+        /// </summary>
+        private ValueArray<string> stagedValue;
+
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> this cell belongs to.
+        /// </summary>
+        [Parameter]
+        public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterType" /> this cell shows the value for.
+        /// </summary>
+        [Parameter]
+        public ParameterType ParameterType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ICDPMessageBus" /> the shared editors publish on.
+        /// </summary>
+        [Inject]
+        public ICDPMessageBus MessageBus { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the cell is currently in edit mode.
+        /// </summary>
+        public bool IsEditing => this.editorSelectorViewModel != null;
+
+        /// <summary>
+        /// Gets the <see cref="SimpleParameterValue" /> this cell currently shows, resolved fresh from the view model
+        /// so a just-added or just-saved value is reflected without a parent re-render.
+        /// </summary>
+        private SimpleParameterValue Value => this.ViewModel.GetSimpleParameterValue(this.Requirement, this.ParameterType);
+
+        /// <summary>
+        /// Enters edit mode by building a proxy <see cref="ParameterValueSet" /> around the given value and wiring the
+        /// shared per-type editor to it, pinned to the Manual switch.
+        /// </summary>
+        /// <param name="value">The <see cref="SimpleParameterValue" /> to edit</param>
+        private void BeginEdit(SimpleParameterValue value)
+        {
+            this.editingValue = value;
+            this.stagedValue = null;
+
+            var proxy = new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(value.Value),
+                Computed = new ValueArray<string>(value.Value),
+                Reference = new ValueArray<string>(value.Value),
+                Formula = new ValueArray<string>(Enumerable.Repeat("-", value.Value.Count)),
+                Published = new ValueArray<string>(value.Value),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            };
+
+            this.editorSelectorViewModel = new ParameterTypeEditorSelectorViewModel(this.ParameterType, proxy, false, this.MessageBus)
+            {
+                Scale = value.Scale,
+                ParameterValueChanged = new EventCallbackFactory().Create<(IValueSet, int)>(this, this.OnEditorValueChanged)
+            };
+
+            this.editorSelectorViewModel.UpdateSwitchKind(ParameterSwitchKind.MANUAL);
+        }
+
+        /// <summary>
+        /// Stages the value emitted by the editor (the editor clones the proxy, so the Manual array is the new value).
+        /// </summary>
+        /// <param name="editorValue">The emitted value set clone and value-array index</param>
+        private void OnEditorValueChanged((IValueSet ValueSet, int Index) editorValue)
+        {
+            if (editorValue.ValueSet is ParameterValueSetBase emitted)
+            {
+                this.stagedValue = emitted.Manual;
+            }
+        }
+
+        /// <summary>
+        /// Commits the staged value to the server through the view model, then leaves edit mode.
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task CommitAsync()
+        {
+            if (this.editingValue == null)
+            {
+                return;
+            }
+
+            var valueToWrite = this.editingValue;
+            var newValue = this.stagedValue ?? valueToWrite.Value;
+            this.Cancel();
+            await this.ViewModel.UpdateSimpleParameterValue(valueToWrite, newValue);
+        }
+
+        /// <summary>
+        /// Leaves edit mode without writing anything.
+        /// </summary>
+        private void Cancel()
+        {
+            this.editorSelectorViewModel = null;
+            this.editingValue = null;
+            this.stagedValue = null;
+        }
+
+        /// <summary>
+        /// Creates the missing <see cref="SimpleParameterValue" /> on the requirement so it becomes editable.
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task AddAsync()
+        {
+            await this.ViewModel.CreateSimpleParameterValue(this.Requirement, this.ParameterType);
+        }
+
+        /// <summary>
+        /// Commits on Enter and cancels on Escape while editing.
+        /// </summary>
+        /// <param name="eventArgs">The <see cref="KeyboardEventArgs" /></param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task OnEditorKeyDownAsync(KeyboardEventArgs eventArgs)
+        {
+            switch (eventArgs.Key)
+            {
+                // only commit once the editor has actually staged a change, so an Enter that merely picks a value
+                // from an open dropdown is not swallowed as a no-op that closes the editor
+                case "Enter" when this.stagedValue != null:
+                    await this.CommitAsync();
+                    break;
+
+                case "Escape":
+                    this.Cancel();
+                    break;
+            }
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -32,39 +32,58 @@ Copyright (c) 2023-2026 Starion Group S.A.
             }
             @if (this.ViewModel.ShowCategory)
             {
-                @foreach (var category in context.Categories)
-                {
-                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
-                }
+                <span class="req-pill-categories">
+                    @foreach (var category in context.Categories)
+                    {
+                        <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                    }
+                </span>
             }
         </span>;
 
+    IReadOnlyList<ParameterType> visibleParameterTypes = this.ViewModel.ShowSimpleParameterValues ? this.ViewModel.GetVisibleParameterTypes() : [];
+
     RenderFragment<Requirement> requirementRow = requirement =>
-        @<div class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
-            <div class="req-row-main">
-                @switch (this.ViewModel.DisplayMode)
-                {
-                    case RequirementRowDisplayMode.ShortNameAndDefinition:
-                        <p class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @GetDefinition(requirement)</p>
-                        break;
+        @<div @key="requirement.Iid" id="@RequirementAnchorId(requirement)" class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
+            <div class="req-row-top">
+                <div class="req-row-main">
+                    @switch (this.ViewModel.DisplayMode)
+                    {
+                        case RequirementRowDisplayMode.ShortNameAndDefinition:
+                            <p class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @GetDefinition(requirement)</p>
+                            break;
 
-                    case RequirementRowDisplayMode.NameAndDefinition:
-                        <p class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @GetDefinition(requirement)</p>
-                        break;
+                        case RequirementRowDisplayMode.NameAndDefinition:
+                            <p class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @GetDefinition(requirement)</p>
+                            break;
 
-                    default:
-                        <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
-                        <p class="req-def">@GetDefinition(requirement)</p>
-                        break;
-                }
-            </div>
-            <div class="req-row-pills">
-                @if (requirement.IsDeprecated)
+                        default:
+                            <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
+                            <p class="req-def">@GetDefinition(requirement)</p>
+                            break;
+                    }
+                </div>
+                @if (this.ViewModel.ShowSimpleParameterValues)
                 {
-                    <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+                    <div class="req-row-values">
+                        @foreach (var parameterType in visibleParameterTypes)
+                        {
+                            <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" ParameterType="@parameterType" />
+                        }
+                    </div>
                 }
-                @pills((requirement.Owner, requirement.Category))
+                <div class="req-row-pills @(this.ViewModel.ShowSimpleParameterValues ? "req-pills-stacked" : string.Empty)">
+                    @if (requirement.IsDeprecated)
+                    {
+                        <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+                    }
+                    @pills((requirement.Owner, requirement.Category))
+                </div>
             </div>
+            @if (this.ViewModel.ShowParametricConstraints || this.ViewModel.ShowTraceability)
+            {
+                <RequirementDetails ViewModel="@this.ViewModel" Requirement="@requirement" />
+            }
         </div>;
 }
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
@@ -64,6 +64,16 @@ namespace COMETwebapp.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Gets the HTML anchor id used to scroll to the given <paramref name="requirement" /> from a traceability link.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>The anchor id</returns>
+        public static string RequirementAnchorId(Requirement requirement)
+        {
+            return $"req-{requirement.Iid}";
+        }
+
+        /// <summary>
         /// Gets the definition text of the given <paramref name="requirement" />.
         /// </summary>
         /// <param name="requirement">The <see cref="Requirement" /></param>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -54,6 +54,17 @@ Copyright (c) 2023-2026 Starion Group S.A.
                       NullText="Filter by category..."
                       CssClass="req-filter" />
 
+            @if (this.ViewModel.ShowSimpleParameterValues && this.ViewModel.GetSpecificationParameterTypes().Count > 0)
+            {
+                <DxTagBox Data="@this.ViewModel.GetSpecificationParameterTypes()"
+                          Values="@this.ViewModel.SelectedParameterTypeColumns"
+                          ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypeColumns = values.ToList())"
+                          TextFieldName="@nameof(ParameterType.ShortName)"
+                          NullText="All value columns..."
+                          title="Choose which simple parameter value columns to show"
+                          CssClass="req-filter" />
+            }
+
             <div class="req-toolbar-group">
                 <span class="req-toolbar-label">Layout</span>
                 <div class="btn-group" role="group" aria-label="Requirement layout">
@@ -71,6 +82,9 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent</DxCheckBox>
                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowSimpleParameterValues" CheckType="CheckType.Switch" title="Show the simple parameter values of each requirement as editable columns">Values</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowParametricConstraints" CheckType="CheckType.Switch" title="Show the parametric constraints of each requirement">Constraints</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowTraceability" CheckType="CheckType.Switch" title="Show the relationships to and from each requirement">Traceability</DxCheckBox>
             </div>
         </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -22,7 +22,11 @@
 
 namespace COMETwebapp.Components.RequirementsEditor
 {
+    using COMETwebapp.Services.Interoperability;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.JSInterop;
 
     using ReactiveUI;
 
@@ -42,6 +46,12 @@ namespace COMETwebapp.Components.RequirementsEditor
         ];
 
         /// <summary>
+        /// Gets or sets the <see cref="IDomDataService" /> used to scroll a navigated-to requirement into view.
+        /// </summary>
+        [Inject]
+        public IDomDataService DomDataService { get; set; }
+
+        /// <summary>
         /// Handles the post-assignment flow of the <see cref="COMET.Web.Common.Components.Applications.ApplicationBase{TViewModel}.ViewModel" /> property.
         /// A single subscription re-renders the whole body (tree + document) whenever the selection, search or filters change.
         /// </summary>
@@ -55,11 +65,41 @@ namespace COMETwebapp.Components.RequirementsEditor
                     x => x.ViewModel.IsTocCollapsed,
                     x => x.ViewModel.DisplayMode,
                     x => x.ViewModel.SelectedOwners,
-                    x => x.ViewModel.SelectedCategories)
+                    x => x.ViewModel.SelectedCategories,
+                    x => x.ViewModel.ScrollTarget)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.ShowHideDeprecatedThingsService.ShowDeprecatedThings)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+        }
+
+        /// <summary>
+        /// Scrolls the document to the <see cref="IRequirementsEditorBodyViewModel.ScrollTarget" /> once it has been
+        /// rendered, after a traceability link navigated to it.
+        /// </summary>
+        /// <param name="firstRender">true on the first render of the component</param>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            var target = this.ViewModel?.ScrollTarget;
+
+            if (target != null)
+            {
+                this.ViewModel.ScrollTarget = null;
+
+                try
+                {
+                    await this.DomDataService.ScrollElementIntoView(RequirementsDocument.RequirementAnchorId(target));
+                }
+                catch (Exception exception) when (exception is JSException or JSDisconnectedException)
+                {
+                    // The scroll is purely cosmetic; a stale cached DomData.js (missing ScrollElementIntoView) or a
+                    // circuit that disconnected mid-render must never kill the page. Navigation already switched the
+                    // specification and expanded the target's groups.
+                }
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -46,12 +46,15 @@
     min-width: 78px;
 }
 
+/* the table of contents keeps a fixed, readable width and the document a readable minimum; when they don't
+   both fit on a narrow panel the layout scrolls horizontally rather than squeezing the TOC to uselessness */
 .req-editor-layout {
     display: flex;
     gap: 16px;
     flex: 1 1 auto;
     min-height: 0;
     align-items: stretch;
+    overflow-x: auto;
 }
 
 .req-toc {
@@ -71,12 +74,19 @@
     border: none;
 }
 
+/* only ever scroll vertically: horizontal overflow would leave a dangling scrollbar, make the sticky
+   specification header stop short of the right edge, and (with both side menus open on a tiny screen) trap
+   the document so it can't be scrolled at all. Everything inside wraps, so nothing needs horizontal scroll. */
+/* a readable minimum width; when the TOC + this minimum exceed the panel the layout gets a horizontal
+   scrollbar (above) rather than squeezing the document to one word per line. Content still wraps within this
+   width, so the document itself never needs its own horizontal scrollbar. */
 .req-document {
     flex: 1 1 auto;
+    min-width: 400px;
     min-height: 0;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     scroll-behavior: smooth;
-    padding-right: 8px;
 }
 
 /* --- table-of-contents tree (rendered by RequirementsTree) --- */
@@ -314,17 +324,19 @@
     background: #fafbfc;
 }
 
-/* the header strip: definition (grows) | owner/category pills | value columns pinned to the right so they
-   line up vertically across every requirement regardless of the pill widths to their left */
+/* the header strip: definition (grows) | value columns | owner/category pills. On a wide row everything sits
+   on one line and the value columns line up across requirements; on a narrow panel the strip wraps so the
+   value columns and pills drop below the definition instead of squeezing it to one word per line. */
 .req-document ::deep .req-row-top {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: 12px;
 }
 
 .req-document ::deep .req-row-main {
-    flex: 1 1 auto;
-    min-width: 0;
+    flex: 1 1 240px;
+    min-width: 200px;
 }
 
 .req-document ::deep .req-row-header .req-id {
@@ -439,8 +451,9 @@
 /* DOORS-like value columns: fixed-width cells on the right of every requirement row, one per visible
    parameter type in a fixed order, so the cells line up vertically across requirements. */
 .req-document ::deep .req-row-values {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     gap: 6px;
     padding-left: 8px;
@@ -450,6 +463,7 @@
     display: flex;
     flex-direction: column;
     width: 130px;
+    max-width: 100%;
     padding: 3px 8px;
     background: #f8fafc;
     border: 1px solid #e9edf2;
@@ -634,6 +648,7 @@
     border: 1px solid #ddd4f4;
     border-radius: 4px;
     padding: 0 5px;
+    overflow-wrap: anywhere;
 }
 
 .req-document ::deep .req-expr-children {
@@ -642,8 +657,11 @@
     border-left: 1px solid #d8e3f4;
 }
 
+/* wrap so the bound-parameter model code and its published value drop to the next line inside the constraint
+   card on a narrow panel instead of spilling past its right edge */
 .req-document ::deep .req-expr-leaf {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: baseline;
     gap: 5px;
     padding: 1px 0;
@@ -676,9 +694,10 @@
     padding: 0 5px;
 }
 
-/* traceability rows */
+/* traceability rows: wrap so the linked things and the rule pills stay inside the card on a narrow panel */
 .req-document ::deep .req-link-row {
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
     gap: 8px;
     padding: 2px 0;
@@ -709,6 +728,8 @@
     color: #0d6efd;
     cursor: pointer;
     text-decoration: none;
+    text-align: left;
+    overflow-wrap: anywhere;
 }
 
 .req-document ::deep .req-link-req:hover {
@@ -717,6 +738,7 @@
 
 .req-document ::deep .req-link-thing {
     color: #344054;
+    overflow-wrap: anywhere;
 }
 
 .req-document ::deep .req-link-row .req-pills {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -12,10 +12,11 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     padding-bottom: 10px;
     margin-bottom: 8px;
     border-bottom: 1px solid #eaecef;
+    overflow-x: auto;
 }
 
 .req-toolbar-group {
@@ -35,14 +36,14 @@
 }
 
 .req-search {
-    flex: 1 1 220px;
-    min-width: 140px;
-    max-width: 360px;
+    flex: 1 1 130px;
+    min-width: 90px;
+    max-width: 260px;
 }
 
 .req-filter {
-    flex: 0 1 190px;
-    min-width: 130px;
+    flex: 1 1 100px;
+    min-width: 78px;
 }
 
 .req-editor-layout {
@@ -79,6 +80,24 @@
 }
 
 /* --- table-of-contents tree (rendered by RequirementsTree) --- */
+
+.req-toc ::deep .req-tree-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    padding: 0 2px 6px;
+    margin-bottom: 4px;
+    border-bottom: 1px solid #eaecef;
+}
+
+.req-toc ::deep .req-tree-header-title {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #667085;
+}
 
 .req-toc ::deep ul.req-tree {
     list-style: none;
@@ -283,14 +302,24 @@
 
 .req-document ::deep .req-row {
     display: flex;
-    justify-content: space-between;
-    gap: 12px;
+    flex-direction: column;
+    gap: 6px;
     padding: 9px 8px;
     border-bottom: 1px solid #f1f3f5;
+    /* keep a navigated-to requirement clear of the sticky specification header instead of landing behind it */
+    scroll-margin-top: 60px;
 }
 
 .req-document ::deep .req-row:hover {
     background: #fafbfc;
+}
+
+/* the header strip: definition (grows) | owner/category pills | value columns pinned to the right so they
+   line up vertically across every requirement regardless of the pill widths to their left */
+.req-document ::deep .req-row-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
 }
 
 .req-document ::deep .req-row-main {
@@ -326,7 +355,28 @@
     text-align: end;
 }
 
+/* with values open the pills sit at the far right in a fixed-width column so the value columns to their left
+   stay vertically aligned across rows: the owner pill on top, the category pills as one wrapping row below */
+.req-document ::deep .req-row-pills.req-pills-stacked {
+    flex: 0 0 130px;
+    white-space: normal;
+}
+
+.req-document ::deep .req-row-pills.req-pills-stacked .req-pills {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+}
+
 .req-document ::deep .req-pills {
+    display: inline-flex;
+    gap: 3px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+/* the category pills always share one (wrapping) row, whether the block is inline or stacked under the owner */
+.req-document ::deep .req-pill-categories {
     display: inline-flex;
     gap: 3px;
     flex-wrap: wrap;
@@ -367,6 +417,326 @@
     margin-left: 0;
     padding-left: 0;
     border-left: none;
+}
+
+/* --- requirement detail sections (rendered by RequirementDetails) --- */
+
+/* constraints + traceability sit side by side to use the horizontal space; they wrap on a narrow row */
+.req-document ::deep .req-details {
+    margin-top: 6px;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.req-document ::deep .req-details > .req-section {
+    flex: 1 1 260px;
+    min-width: 0;
+}
+
+/* DOORS-like value columns: fixed-width cells on the right of every requirement row, one per visible
+   parameter type in a fixed order, so the cells line up vertically across requirements. */
+.req-document ::deep .req-row-values {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding-left: 8px;
+}
+
+.req-document ::deep .req-value-cell {
+    display: flex;
+    flex-direction: column;
+    width: 130px;
+    padding: 3px 8px;
+    background: #f8fafc;
+    border: 1px solid #e9edf2;
+    border-radius: 6px;
+}
+
+.req-document ::deep .req-value-cell-empty {
+    background: repeating-linear-gradient(135deg, #fbfcfd, #fbfcfd 6px, #f3f5f8 6px, #f3f5f8 12px);
+    border-style: dashed;
+}
+
+/* an editing cell grows to fit the (wider) date/combo editor instead of cramping it into the column width */
+.req-document ::deep .req-value-cell:has(.req-value-editor) {
+    width: auto;
+    min-width: 160px;
+}
+
+.req-document ::deep .req-value-label {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #667085;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.req-document ::deep .req-value-display {
+    border: 1px solid transparent;
+    background: none;
+    padding: 1px 3px;
+    text-align: left;
+    font-size: 0.88rem;
+    color: #1f2937;
+    cursor: pointer;
+    border-radius: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.req-document ::deep .req-value-display:hover {
+    border-color: #d6dae0;
+    background: #fff;
+}
+
+/* empty cell: an obviously-different "+ add" affordance so a missing value never looks like a set one */
+.req-document ::deep .req-value-add {
+    border: none;
+    background: none;
+    padding: 1px 3px;
+    text-align: left;
+    font-size: 0.8rem;
+    font-style: italic;
+    color: #98a2b3;
+    cursor: pointer;
+}
+
+.req-document ::deep .req-value-add:hover {
+    color: #0d6efd;
+    text-decoration: underline;
+}
+
+/* actions sit on a row ABOVE the editor so the value/date stays fully readable before confirming */
+.req-document ::deep .req-value-editor {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 3px;
+    border-radius: 4px;
+    padding: 1px;
+}
+
+/* clearly show an unsaved edit */
+.req-document ::deep .req-value-editor-dirty {
+    outline: 2px solid #ffd666;
+    background: #fffbe6;
+}
+
+.req-document ::deep .req-value-editor-actions {
+    display: flex;
+    gap: 2px;
+    justify-content: flex-end;
+    flex: 0 0 auto;
+}
+
+.req-document ::deep .req-value-save,
+.req-document ::deep .req-value-cancel {
+    border: none;
+    background: none;
+    padding: 0 3px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+.req-document ::deep .req-value-save {
+    color: #12805c;
+}
+
+.req-document ::deep .req-value-cancel {
+    color: #b42318;
+}
+
+/* shared shell for the Constraints and Traceability sections */
+.req-document ::deep .req-section {
+    padding: 5px 10px 7px;
+    background: #fbfcfe;
+    border: 1px solid #eef0f3;
+    border-left: 3px solid #d8e3f4;
+    border-radius: 6px;
+}
+
+.req-document ::deep .req-section-title {
+    display: block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #667085;
+    margin-bottom: 3px;
+}
+
+/* constraint expression tree */
+.req-document ::deep .req-constraint + .req-constraint {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px dashed #e5e9ee;
+}
+
+/* a non-leaf node: collapse toggle + operator chip + one-line summary of the whole subtree */
+.req-document ::deep .req-expr-node {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 1px 0;
+}
+
+.req-document ::deep .req-expr-toggle {
+    border: none;
+    background: none;
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.req-document ::deep .req-expr-toggle img {
+    width: 11px;
+    height: 11px;
+}
+
+.req-document ::deep .req-expr-operator {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #3b5b8c;
+    background: #e7f0fd;
+    border-radius: 4px;
+    padding: 0 6px;
+}
+
+.req-document ::deep .req-expr-summary {
+    font-size: 0.82rem;
+    color: #667085;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* neutral violet: the published value is informational, not a pass/fail — green/red/amber all carry a
+   validation meaning in the IME, so they are deliberately avoided here */
+.req-document ::deep .req-expr-published {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    color: #5b4bb0;
+    background: #f1eefb;
+    border: 1px solid #ddd4f4;
+    border-radius: 4px;
+    padding: 0 5px;
+}
+
+.req-document ::deep .req-expr-children {
+    margin-left: 9px;
+    padding-left: 12px;
+    border-left: 1px solid #d8e3f4;
+}
+
+.req-document ::deep .req-expr-leaf {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    padding: 1px 0;
+    font-size: 0.88rem;
+}
+
+.req-document ::deep .req-expr-pt {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.req-document ::deep .req-expr-op {
+    color: #3b5b8c;
+    font-weight: 600;
+}
+
+.req-document ::deep .req-expr-scale {
+    color: #667085;
+    font-size: 0.8rem;
+}
+
+.req-document ::deep .req-expr-binding {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    color: #475467;
+    background: #eef2f6;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    padding: 0 5px;
+}
+
+/* traceability rows */
+.req-document ::deep .req-link-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 2px 0;
+    font-size: 0.88rem;
+}
+
+.req-document ::deep .req-link-direction {
+    flex: 0 0 auto;
+    color: #3b5b8c;
+    font-weight: 700;
+}
+
+.req-document ::deep .req-link-targets {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+}
+
+.req-document ::deep .req-link-req {
+    border: none;
+    background: none;
+    padding: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #0d6efd;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.req-document ::deep .req-link-req:hover {
+    text-decoration: underline;
+}
+
+.req-document ::deep .req-link-thing {
+    color: #344054;
+}
+
+.req-document ::deep .req-link-row .req-pills {
+    margin-left: auto;
+    padding-left: 6px;
+}
+
+.req-document ::deep .req-link-rule {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    padding: 1px 8px;
+    margin: 1px 0 1px 2px;
+    font-size: 0.72rem;
+    line-height: 1.2;
+    border-radius: 30px;
+    background: #eef2f6;
+    color: #475467;
+    border: 1px solid #dbe2ea;
+    white-space: nowrap;
 }
 
 /* Deprecated things (rendered only when the global "Show Deprecated Things" toggle is on). */

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -18,10 +18,40 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
+@using CDP4Common.SiteDirectoryData
 @using COMETwebapp.Utilities
+
+@{
+    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
+        @<span class="req-pills">
+            @if (this.ViewModel.ShowOwner && context.Owner != null)
+            {
+                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{context.Owner.ShortName}") !important;" title="Owner: @context.Owner.Name">@context.Owner.ShortName</span>
+            }
+            @if (this.ViewModel.ShowCategory)
+            {
+                @foreach (var category in context.Categories)
+                {
+                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                }
+            }
+        </span>;
+}
 
 @if (this.Groups == null)
 {
+    <div class="req-tree-header">
+        <span class="req-tree-header-title">Contents</span>
+        <div class="btn-group" role="group" aria-label="Table of contents label">
+            <DxButton RenderStyle="@(this.ViewModel.TreeUsesShortName ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
+                      Text="ID" title="Label by short name"
+                      Click="@(() => this.ViewModel.TreeUsesShortName = true)" />
+            <DxButton RenderStyle="@(this.ViewModel.TreeUsesShortName ? ButtonRenderStyle.Light : ButtonRenderStyle.Primary)"
+                      Text="Name" title="Label by name"
+                      Click="@(() => this.ViewModel.TreeUsesShortName = false)" />
+        </div>
+    </div>
+
     <ul class="req-tree">
         @foreach (var specification in this.ViewModel.AvailableSpecifications)
         {
@@ -30,7 +60,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <li class="req-tree-item">
                 <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty) @(specification.IsDeprecated ? "req-tree-deprecated" : string.Empty)"
                      @onclick="@(() => this.ViewModel.SelectedSpecification = specification)">
-                    <span class="req-tree-label">@specification.ShortName</span>
+                    <span class="req-tree-label">@(this.ViewModel.TreeUsesShortName ? specification.ShortName : specification.Name)</span>
+                    @pills((specification.Owner, specification.Category))
                 </div>
                 @if (isSelected)
                 {
@@ -61,20 +92,8 @@ else
                     {
                         <span class="req-tree-chevron-placeholder"></span>
                     }
-                    <a class="req-tree-group" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@group.ShortName</a>
-                    <span class="req-pills">
-                        @if (this.ViewModel.ShowOwner && group.Owner != null)
-                        {
-                            <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{group.Owner.ShortName}") !important;" title="Owner: @group.Owner.Name">@group.Owner.ShortName</span>
-                        }
-                        @if (this.ViewModel.ShowCategory)
-                        {
-                            @foreach (var category in group.Category)
-                            {
-                                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
-                            }
-                        }
-                    </span>
+                    <a class="req-tree-group" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</a>
+                    @pills((group.Owner, group.Category))
                 </div>
                 @if (hasChildren && !collapsed)
                 {

--- a/COMETwebapp/Services/Interoperability/DomDataService.cs
+++ b/COMETwebapp/Services/Interoperability/DomDataService.cs
@@ -70,5 +70,15 @@ namespace COMETwebapp.Services.Interoperability
         {
             await this.JsRuntime.InvokeVoidAsync("SubscribeToResizeEvent", callbackMethodName);
         }
+
+        /// <summary>
+        /// Smooth-scrolls the element with the given id into view, if it exists
+        /// </summary>
+        /// <param name="elementId">the id of the element to scroll to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task ScrollElementIntoView(string elementId)
+        {
+            await this.JsRuntime.InvokeVoidAsync("ScrollElementIntoView", elementId);
+        }
     }
 }

--- a/COMETwebapp/Services/Interoperability/IDomDataService.cs
+++ b/COMETwebapp/Services/Interoperability/IDomDataService.cs
@@ -53,5 +53,12 @@ namespace COMETwebapp.Services.Interoperability
         /// <param name="dotNetHelper">the dotnet helper</param>
         /// <returns>A <see cref="Task" /></returns>
         Task LoadDotNetHelper<TItem>(DotNetObjectReference<BookEditorColumn<TItem>> dotNetHelper);
+
+        /// <summary>
+        /// Smooth-scrolls the element with the given id into view, if it exists
+        /// </summary>
+        /// <param name="elementId">the id of the element to scroll to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        Task ScrollElementIntoView(string elementId);
     }
 }

--- a/COMETwebapp/Utilities/ParameterValueFormatter.cs
+++ b/COMETwebapp/Utilities/ParameterValueFormatter.cs
@@ -22,7 +22,6 @@
 
 namespace COMETwebapp.Utilities
 {
-    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
@@ -32,25 +31,6 @@ namespace COMETwebapp.Utilities
     /// </summary>
     public static class ParameterValueFormatter
     {
-        /// <summary>
-        /// Gets the mathematical symbol for the given relational <paramref name="operatorKind" />.
-        /// </summary>
-        /// <param name="operatorKind">The <see cref="RelationalOperatorKind" />.</param>
-        /// <returns>The symbol.</returns>
-        public static string RelationalOperatorSymbol(RelationalOperatorKind operatorKind)
-        {
-            return operatorKind switch
-            {
-                RelationalOperatorKind.EQ => "=",
-                RelationalOperatorKind.NE => "≠",
-                RelationalOperatorKind.LT => "<",
-                RelationalOperatorKind.GT => ">",
-                RelationalOperatorKind.LE => "≤",
-                RelationalOperatorKind.GE => "≥",
-                _ => operatorKind.ToString()
-            };
-        }
-
         /// <summary>
         /// Formats a value array as a single display string: comma-separates the entries, wraps them in braces when
         /// there is more than one, and appends a <c>[shortName]</c> scale suffix when <paramref name="scale" /> is set.

--- a/COMETwebapp/Utilities/ParameterValueFormatter.cs
+++ b/COMETwebapp/Utilities/ParameterValueFormatter.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.Utilities
 {
+    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
@@ -31,6 +32,25 @@ namespace COMETwebapp.Utilities
     /// </summary>
     public static class ParameterValueFormatter
     {
+        /// <summary>
+        /// Gets the mathematical symbol for the given relational <paramref name="operatorKind" />.
+        /// </summary>
+        /// <param name="operatorKind">The <see cref="RelationalOperatorKind" />.</param>
+        /// <returns>The symbol.</returns>
+        public static string RelationalOperatorSymbol(RelationalOperatorKind operatorKind)
+        {
+            return operatorKind switch
+            {
+                RelationalOperatorKind.EQ => "=",
+                RelationalOperatorKind.NE => "≠",
+                RelationalOperatorKind.LT => "<",
+                RelationalOperatorKind.GT => ">",
+                RelationalOperatorKind.LE => "≤",
+                RelationalOperatorKind.GE => "≥",
+                _ => operatorKind.ToString()
+            };
+        }
+
         /// <summary>
         /// Formats a value array as a single display string: comma-separates the entries, wraps them in braces when
         /// there is more than one, and appends a <c>[shortName]</c> scale suffix when <paramref name="scale" /> is set.

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
@@ -29,6 +29,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
 
+    using FluentResults;
+
     /// <summary>
     /// Interface for the <see cref="RequirementsEditorBodyViewModel" />, driving the Requirements Editor application.
     /// </summary>
@@ -78,6 +80,12 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// Gets or sets the way each requirement is rendered as a row.
         /// </summary>
         RequirementRowDisplayMode DisplayMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the table-of-contents tree labels specifications and groups by their
+        /// short name (true) or their name (false).
+        /// </summary>
+        bool TreeUsesShortName { get; set; }
 
         /// <summary>
         /// Gets the distinct <see cref="DomainOfExpertise" /> owners available to filter on.
@@ -133,6 +141,151 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// </summary>
         /// <param name="iid">The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the specification or group node</param>
         void ToggleTreeNode(Guid iid);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="SimpleParameterValue" /> columns are shown under each requirement.
+        /// </summary>
+        bool ShowSimpleParameterValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="ParametricConstraint" /> trees are shown under each requirement.
+        /// </summary>
+        bool ShowParametricConstraints { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the relationships to and from each requirement are shown under it.
+        /// </summary>
+        bool ShowTraceability { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> the document should scroll to on the next render, set by
+        /// <see cref="NavigateToRequirement" /> and cleared by the component once the scroll has happened.
+        /// </summary>
+        Requirement ScrollTarget { get; set; }
+
+        /// <summary>
+        /// Gets the distinct <see cref="ParameterType" />s used by the <see cref="SimpleParameterValue" />s of the
+        /// non-deprecated requirements of the selected specification, ordered by short name. The columns are stable
+        /// across search and owner/category filtering.
+        /// </summary>
+        /// <returns>The parameter types, or an empty list when no specification is selected</returns>
+        IReadOnlyList<ParameterType> GetSpecificationParameterTypes();
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterType" /> value columns the user chose to show; an empty selection shows
+        /// every parameter type used in the specification.
+        /// </summary>
+        IEnumerable<ParameterType> SelectedParameterTypeColumns { get; set; }
+
+        /// <summary>
+        /// Gets the parameter-type value columns to render: <see cref="GetSpecificationParameterTypes" /> narrowed to
+        /// <see cref="SelectedParameterTypeColumns" />, or all of them when the user has not picked any.
+        /// </summary>
+        /// <returns>The columns to show, in short-name order</returns>
+        IReadOnlyList<ParameterType> GetVisibleParameterTypes();
+
+        /// <summary>
+        /// Gets the <see cref="SimpleParameterValue" /> of the given <paramref name="requirement" /> for the given
+        /// <paramref name="parameterType" />.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <param name="parameterType">The <see cref="ParameterType" /></param>
+        /// <returns>The value, or null when the requirement has no value for that parameter type</returns>
+        SimpleParameterValue GetSimpleParameterValue(Requirement requirement, ParameterType parameterType);
+
+        /// <summary>
+        /// Updates the given <see cref="SimpleParameterValue" /> on the server with the given <paramref name="newValue" />;
+        /// the original is never mutated, a clone is sent, and the outcome (including a concurrency conflict) is surfaced
+        /// as a toast.
+        /// </summary>
+        /// <param name="value">The <see cref="SimpleParameterValue" /> to update</param>
+        /// <param name="newValue">The new value (one entry per component)</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the write</returns>
+        Task<Result> UpdateSimpleParameterValue(SimpleParameterValue value, IEnumerable<string> newValue);
+
+        /// <summary>
+        /// Creates a new, empty <see cref="SimpleParameterValue" /> of the given <paramref name="parameterType" /> on the
+        /// given <paramref name="requirement" /> so the parameter becomes available to edit.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /> the value is added to</param>
+        /// <param name="parameterType">The <see cref="ParameterType" /> of the new value</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the write</returns>
+        Task<Result> CreateSimpleParameterValue(Requirement requirement, ParameterType parameterType);
+
+        /// <summary>
+        /// Gets the root <see cref="BooleanExpression" />s of the given <paramref name="constraint" />: its
+        /// <see cref="ParametricConstraint.TopExpression" /> when set, otherwise the expressions that are not a term
+        /// of any other expression.
+        /// </summary>
+        /// <param name="constraint">The <see cref="ParametricConstraint" /></param>
+        /// <returns>The root expressions to render the constraint tree from</returns>
+        IEnumerable<BooleanExpression> GetTopExpressions(ParametricConstraint constraint);
+
+        /// <summary>
+        /// Gets the child terms of the given <paramref name="expression" />; relational expressions are leaves.
+        /// </summary>
+        /// <param name="expression">The <see cref="BooleanExpression" /></param>
+        /// <returns>The child expressions</returns>
+        IReadOnlyList<BooleanExpression> GetTerms(BooleanExpression expression);
+
+        /// <summary>
+        /// Gets the <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
+        /// <see cref="BinaryRelationship" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The bound parameter, or null when none is bound</returns>
+        ParameterOrOverrideBase GetBoundParameter(RelationalExpression expression);
+
+        /// <summary>
+        /// Gets the model code of the <see cref="ParameterOrOverrideBase" /> bound to the given
+        /// <paramref name="expression" /> through a <see cref="BinaryRelationship" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The model code, or null when no parameter is bound</returns>
+        string GetBoundParameterModelCode(RelationalExpression expression);
+
+        /// <summary>
+        /// Gets the published value of the <see cref="ParameterOrOverrideBase" /> bound to the given
+        /// <paramref name="expression" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The formatted published value, or null when no parameter is bound</returns>
+        string GetBoundParameterPublishedValue(RelationalExpression expression);
+
+        /// <summary>
+        /// Gets a one-line human-readable summary of the given <paramref name="expression" /> tree.
+        /// </summary>
+        /// <param name="expression">The <see cref="BooleanExpression" /></param>
+        /// <returns>The summary string</returns>
+        string GetExpressionSummary(BooleanExpression expression);
+
+        /// <summary>
+        /// Gets whether the constraint expression tree node with the given <paramref name="iid" /> is collapsed.
+        /// </summary>
+        /// <param name="iid">The identifier of the <see cref="BooleanExpression" /></param>
+        /// <returns>true if collapsed</returns>
+        bool IsExpressionCollapsed(Guid iid);
+
+        /// <summary>
+        /// Toggles the collapsed state of the constraint expression tree node with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The identifier of the <see cref="BooleanExpression" /></param>
+        void ToggleExpression(Guid iid);
+
+        /// <summary>
+        /// Gets a display row for every <see cref="BinaryRelationship" /> and <see cref="MultiRelationship" /> of the
+        /// iteration the given <paramref name="requirement" /> participates in.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>The traceability rows</returns>
+        IReadOnlyList<RequirementRelationshipRow> GetTraceability(Requirement requirement);
+
+        /// <summary>
+        /// Navigates the document to the given <paramref name="requirement" />: selects its specification, expands
+        /// its ancestor groups and flags it as the <see cref="ScrollTarget" />.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /> to navigate to</param>
+        void NavigateToRequirement(Requirement requirement);
 
         /// <summary>
         /// Gets whether the group with the given <paramref name="iid" /> is collapsed in the document panel.

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RelationshipDirection.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RelationshipDirection.cs
@@ -1,0 +1,45 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RelationshipDirection.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.RequirementsEditor
+{
+    /// <summary>
+    /// The direction of a relationship relative to the requirement it is displayed under.
+    /// </summary>
+    public enum RelationshipDirection
+    {
+        /// <summary>
+        /// The requirement is the source of a binary relationship.
+        /// </summary>
+        Outgoing,
+
+        /// <summary>
+        /// The requirement is the target of a binary relationship.
+        /// </summary>
+        Incoming,
+
+        /// <summary>
+        /// The requirement participates in a multi relationship, which has no direction.
+        /// </summary>
+        Bidirectional
+    }
+}

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementRelationshipRow.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementRelationshipRow.cs
@@ -1,0 +1,55 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRelationshipRow.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.RequirementsEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// A display row describing one <see cref="Relationship" /> a requirement participates in: its direction, the
+    /// things at the other end, and the names of the <see cref="CDP4Common.SiteDirectoryData.Rule" />s that match the
+    /// relationship's categories.
+    /// </summary>
+    public class RequirementRelationshipRow
+    {
+        /// <summary>
+        /// Gets the <see cref="Relationship" /> this row describes.
+        /// </summary>
+        public Relationship Relationship { get; init; }
+
+        /// <summary>
+        /// Gets the direction of the relationship relative to the requirement.
+        /// </summary>
+        public RelationshipDirection Direction { get; init; }
+
+        /// <summary>
+        /// Gets the things at the other end of the relationship.
+        /// </summary>
+        public IReadOnlyList<Thing> RelatedThings { get; init; }
+
+        /// <summary>
+        /// Gets the names of the relationship rules that apply to the relationship's categories.
+        /// </summary>
+        public IReadOnlyList<string> RuleNames { get; init; }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -22,15 +22,22 @@
 
 namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
 
+    using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
+    using COMETwebapp.Utilities;
+
+    using FluentResults;
 
     using ReactiveUI;
 
@@ -82,9 +89,24 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         private readonly HashSet<Guid> collapsedDocumentGroups = [];
 
         /// <summary>
+        /// The <see cref="Guid" />s of the constraint expression tree nodes that are currently collapsed.
+        /// </summary>
+        private readonly HashSet<Guid> collapsedExpressions = [];
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedParameterTypeColumns" />
+        /// </summary>
+        private IEnumerable<ParameterType> selectedParameterTypeColumns = [];
+
+        /// <summary>
         /// Backing field for <see cref="DisplayMode" />
         /// </summary>
         private RequirementRowDisplayMode displayMode = RequirementRowDisplayMode.ShortNameNameAndDefinition;
+
+        /// <summary>
+        /// Backing field for <see cref="TreeUsesShortName" />
+        /// </summary>
+        private bool treeUsesShortName = true;
 
         /// <summary>
         /// Backing field for <see cref="SelectedOwners" />
@@ -95,6 +117,32 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// Backing field for <see cref="SelectedCategories" />
         /// </summary>
         private IEnumerable<Category> selectedCategories = [];
+
+        /// <summary>
+        /// Backing field for <see cref="ShowSimpleParameterValues" />
+        /// </summary>
+        private bool showSimpleParameterValues;
+
+        /// <summary>
+        /// Backing field for <see cref="ShowParametricConstraints" />
+        /// </summary>
+        private bool showParametricConstraints;
+
+        /// <summary>
+        /// Backing field for <see cref="ShowTraceability" />
+        /// </summary>
+        private bool showTraceability;
+
+        /// <summary>
+        /// Backing field for <see cref="ScrollTarget" />
+        /// </summary>
+        private Requirement scrollTarget;
+
+        /// <summary>
+        /// Memoised result of <see cref="GetSpecificationParameterTypes" /> - it is queried once per requirement row,
+        /// so caching it keeps document rendering linear in the number of requirements.
+        /// </summary>
+        private (RequirementsSpecification Specification, bool ShowDeprecated, IReadOnlyList<ParameterType> ParameterTypes) parameterTypesCache;
 
         /// <summary>
         /// Creates a new instance of <see cref="RequirementsEditorBodyViewModel" />
@@ -188,6 +236,16 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the table-of-contents tree labels specifications and groups by their
+        /// short name (true) or their name (false).
+        /// </summary>
+        public bool TreeUsesShortName
+        {
+            get => this.treeUsesShortName;
+            set => this.RaiseAndSetIfChanged(ref this.treeUsesShortName, value);
+        }
+
+        /// <summary>
         /// Gets or sets the selected <see cref="DomainOfExpertise" /> owners; an empty selection means no owner filtering.
         /// </summary>
         public IEnumerable<DomainOfExpertise> SelectedOwners
@@ -203,6 +261,53 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         {
             get => this.selectedCategories;
             set => this.RaiseAndSetIfChanged(ref this.selectedCategories, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="SimpleParameterValue" /> columns are shown under each requirement.
+        /// </summary>
+        public bool ShowSimpleParameterValues
+        {
+            get => this.showSimpleParameterValues;
+            set => this.RaiseAndSetIfChanged(ref this.showSimpleParameterValues, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="ParametricConstraint" /> trees are shown under each requirement.
+        /// </summary>
+        public bool ShowParametricConstraints
+        {
+            get => this.showParametricConstraints;
+            set => this.RaiseAndSetIfChanged(ref this.showParametricConstraints, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the relationships to and from each requirement are shown under it.
+        /// </summary>
+        public bool ShowTraceability
+        {
+            get => this.showTraceability;
+            set => this.RaiseAndSetIfChanged(ref this.showTraceability, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> the document should scroll to on the next render, set by
+        /// <see cref="NavigateToRequirement" /> and cleared by the component once the scroll has happened.
+        /// </summary>
+        public Requirement ScrollTarget
+        {
+            get => this.scrollTarget;
+            set => this.RaiseAndSetIfChanged(ref this.scrollTarget, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterType" /> value columns the user chose to show; an empty selection shows
+        /// every parameter type used in the specification.
+        /// </summary>
+        public IEnumerable<ParameterType> SelectedParameterTypeColumns
+        {
+            get => this.selectedParameterTypeColumns;
+            set => this.RaiseAndSetIfChanged(ref this.selectedParameterTypeColumns, value);
         }
 
         /// <summary>
@@ -311,6 +416,324 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Gets the distinct <see cref="ParameterType" />s used by the <see cref="SimpleParameterValue" />s of the
+        /// non-deprecated requirements of the selected specification, ordered by short name. The columns are stable
+        /// across search and owner/category filtering so requirement rows line up; they form the value columns shown
+        /// under each requirement.
+        /// </summary>
+        /// <returns>The parameter types, or an empty list when no specification is selected</returns>
+        public IReadOnlyList<ParameterType> GetSpecificationParameterTypes()
+        {
+            if (this.SelectedSpecification == null)
+            {
+                return [];
+            }
+
+            var showDeprecated = this.ShowHideDeprecatedThingsService.ShowDeprecatedThings;
+
+            if (ReferenceEquals(this.parameterTypesCache.Specification, this.SelectedSpecification) && this.parameterTypesCache.ShowDeprecated == showDeprecated)
+            {
+                return this.parameterTypesCache.ParameterTypes;
+            }
+
+            var parameterTypes = this.SelectedSpecification.Requirement
+                .Where(x => showDeprecated || !x.IsDeprecated)
+                .SelectMany(x => x.ParameterValue)
+                .Select(x => x.ParameterType)
+                .Where(x => x != null)
+                .DistinctBy(x => x.Iid)
+                .OrderBy(x => x.ShortName)
+                .ToList();
+
+            this.parameterTypesCache = (this.SelectedSpecification, showDeprecated, parameterTypes);
+            return parameterTypes;
+        }
+
+        /// <summary>
+        /// Gets the parameter-type value columns to render: <see cref="GetSpecificationParameterTypes" /> narrowed to
+        /// <see cref="SelectedParameterTypeColumns" />, or all of them when the user has not picked any.
+        /// </summary>
+        /// <returns>The columns to show, in short-name order</returns>
+        public IReadOnlyList<ParameterType> GetVisibleParameterTypes()
+        {
+            var all = this.GetSpecificationParameterTypes();
+            var selectedIids = this.SelectedParameterTypeColumns.Select(x => x.Iid).ToHashSet();
+
+            return selectedIids.Count == 0 ? all : all.Where(x => selectedIids.Contains(x.Iid)).ToList();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SimpleParameterValue" /> of the given <paramref name="requirement" /> for the given
+        /// <paramref name="parameterType" />.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <param name="parameterType">The <see cref="ParameterType" /></param>
+        /// <returns>The value, or null when the requirement has no value for that parameter type</returns>
+        public SimpleParameterValue GetSimpleParameterValue(Requirement requirement, ParameterType parameterType)
+        {
+            return requirement.ParameterValue.FirstOrDefault(x => x.ParameterType?.Iid == parameterType.Iid);
+        }
+
+        /// <summary>
+        /// Updates the given <see cref="SimpleParameterValue" /> on the server with the given <paramref name="newValue" />;
+        /// the original is never mutated, a clone is sent. A <see cref="NotificationDescription" /> surfaces the outcome
+        /// (including a concurrency conflict rejected by the server) as a toast; on failure the original value is left
+        /// untouched so the document reverts to it on the next render.
+        /// </summary>
+        /// <param name="value">The <see cref="SimpleParameterValue" /> to update</param>
+        /// <param name="newValue">The new value (one entry per component)</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the write</returns>
+        public async Task<Result> UpdateSimpleParameterValue(SimpleParameterValue value, IEnumerable<string> newValue)
+        {
+            var newValueArray = new ValueArray<string>(newValue);
+
+            if (value.Value.SequenceEqual(newValueArray))
+            {
+                return Result.Ok();
+            }
+
+            var clone = value.Clone(false);
+            clone.Value = newValueArray;
+
+            return await this.SessionService.CreateOrUpdateThingsWithNotification(value.GetContainerOfType<Iteration>().Clone(false), [clone],
+                new NotificationDescription { OnSuccess = "Value updated", OnError = "Failed to update the value (it may have been changed by someone else)" });
+        }
+
+        /// <summary>
+        /// Creates a new, empty <see cref="SimpleParameterValue" /> of the given <paramref name="parameterType" /> on the
+        /// given <paramref name="requirement" /> so the parameter becomes available to edit; the default value is a "-"
+        /// per component. The <paramref name="requirement" /> is cloned before the write.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /> the value is added to</param>
+        /// <param name="parameterType">The <see cref="ParameterType" /> of the new value</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the write</returns>
+        public async Task<Result> CreateSimpleParameterValue(Requirement requirement, ParameterType parameterType)
+        {
+            var newValue = new SimpleParameterValue
+            {
+                Iid = Guid.NewGuid(),
+                ParameterType = parameterType,
+                Scale = (parameterType as QuantityKind)?.DefaultScale,
+                Value = new ValueArray<string>(Enumerable.Repeat("-", Math.Max(parameterType.NumberOfValues, 1)))
+            };
+
+            var requirementClone = requirement.Clone(false);
+            requirementClone.ParameterValue.Add(newValue);
+
+            return await this.SessionService.CreateOrUpdateThingsWithNotification(requirement.GetContainerOfType<Iteration>().Clone(false), [requirementClone, newValue],
+                new NotificationDescription { OnSuccess = $"Added {parameterType.ShortName}", OnError = $"Failed to add {parameterType.ShortName}" });
+        }
+
+        /// <summary>
+        /// Gets the root <see cref="BooleanExpression" />s of the given <paramref name="constraint" />: its
+        /// <see cref="ParametricConstraint.TopExpression" /> when set, otherwise the expressions that are not a term
+        /// of any other expression.
+        /// </summary>
+        /// <param name="constraint">The <see cref="ParametricConstraint" /></param>
+        /// <returns>The root expressions to render the constraint tree from</returns>
+        public IEnumerable<BooleanExpression> GetTopExpressions(ParametricConstraint constraint)
+        {
+            if (constraint.TopExpression != null)
+            {
+                return [constraint.TopExpression];
+            }
+
+            return constraint.Expression.GetTopLevelExpressions();
+        }
+
+        /// <summary>
+        /// Gets the child terms of the given <paramref name="expression" />; relational expressions are leaves.
+        /// </summary>
+        /// <param name="expression">The <see cref="BooleanExpression" /></param>
+        /// <returns>The child expressions</returns>
+        public IReadOnlyList<BooleanExpression> GetTerms(BooleanExpression expression)
+        {
+            return expression switch
+            {
+                AndExpression andExpression => andExpression.Term,
+                OrExpression orExpression => orExpression.Term,
+                ExclusiveOrExpression exclusiveOrExpression => exclusiveOrExpression.Term,
+                NotExpression { Term: not null } notExpression => [notExpression.Term],
+                _ => []
+            };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
+        /// <see cref="BinaryRelationship" />, the way requirement verification links a parameter to a relational
+        /// expression.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The bound parameter, or null when none is bound</returns>
+        public ParameterOrOverrideBase GetBoundParameter(RelationalExpression expression)
+        {
+            var binding = this.CurrentThing?.Relationship.OfType<BinaryRelationship>()
+                .FirstOrDefault(x => (x.Source == expression && x.Target is ParameterOrOverrideBase) || (x.Target == expression && x.Source is ParameterOrOverrideBase));
+
+            if (binding == null)
+            {
+                return null;
+            }
+
+            return (ParameterOrOverrideBase)(binding.Source == expression ? binding.Target : binding.Source);
+        }
+
+        /// <summary>
+        /// Gets the model code of the <see cref="ParameterOrOverrideBase" /> bound to the given
+        /// <paramref name="expression" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The model code, or null when no parameter is bound</returns>
+        public string GetBoundParameterModelCode(RelationalExpression expression)
+        {
+            return this.GetBoundParameter(expression)?.ModelCode();
+        }
+
+        /// <summary>
+        /// Gets the published value of the <see cref="ParameterOrOverrideBase" /> bound to the given
+        /// <paramref name="expression" /> — the value the bound element last published, to compare against the
+        /// constraint's threshold.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The formatted published value, or null when no parameter is bound</returns>
+        public string GetBoundParameterPublishedValue(RelationalExpression expression)
+        {
+            var parameter = this.GetBoundParameter(expression);
+            var valueSets = parameter?.ValueSets.OfType<ParameterValueSetBase>().ToList() ?? [];
+
+            // only show a single, unambiguous published value; an option/state-dependent parameter has several and we
+            // would otherwise present an arbitrary one as "the" published value
+            return valueSets.Count == 1 ? ParameterValueFormatter.Format(valueSets[0].Published, parameter.Scale) : null;
+        }
+
+        /// <summary>
+        /// Gets a one-line human-readable summary of the given <paramref name="expression" /> subtree (e.g.
+        /// <c>NOT (d_r &lt; 500) AND (a &gt; 4)</c>), built the same way the tree renders so it stays consistent with it.
+        /// </summary>
+        /// <param name="expression">The <see cref="BooleanExpression" /></param>
+        /// <returns>The summary string</returns>
+        public string GetExpressionSummary(BooleanExpression expression)
+        {
+            switch (expression)
+            {
+                case RelationalExpression relational:
+                    var scale = relational.Scale == null ? string.Empty : $" {relational.Scale.ShortName}";
+                    return $"{relational.ParameterType?.ShortName} {ParameterValueFormatter.RelationalOperatorSymbol(relational.RelationalOperator)} {string.Join(", ", relational.Value)}{scale}";
+
+                case NotExpression { Term: not null } not:
+                    return $"NOT ({this.GetExpressionSummary(not.Term)})";
+
+                default:
+                    var separator = expression switch
+                    {
+                        AndExpression => " AND ",
+                        OrExpression => " OR ",
+                        ExclusiveOrExpression => " XOR ",
+                        _ => " "
+                    };
+
+                    return string.Join(separator, this.GetTerms(expression).Select(x => $"({this.GetExpressionSummary(x)})"));
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the expression tree node with the given <paramref name="iid" /> is collapsed.
+        /// </summary>
+        /// <param name="iid">The identifier of the <see cref="BooleanExpression" /></param>
+        /// <returns>true if collapsed</returns>
+        public bool IsExpressionCollapsed(Guid iid)
+        {
+            return this.collapsedExpressions.Contains(iid);
+        }
+
+        /// <summary>
+        /// Toggles the collapsed state of the expression tree node with the given <paramref name="iid" />.
+        /// </summary>
+        /// <param name="iid">The identifier of the <see cref="BooleanExpression" /></param>
+        public void ToggleExpression(Guid iid)
+        {
+            if (!this.collapsedExpressions.Add(iid))
+            {
+                this.collapsedExpressions.Remove(iid);
+            }
+        }
+
+        /// <summary>
+        /// Gets a display row for every <see cref="BinaryRelationship" /> and <see cref="MultiRelationship" /> of the
+        /// iteration the given <paramref name="requirement" /> participates in.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>The traceability rows</returns>
+        public IReadOnlyList<RequirementRelationshipRow> GetTraceability(Requirement requirement)
+        {
+            if (this.CurrentThing == null)
+            {
+                return [];
+            }
+
+            var rows = new List<RequirementRelationshipRow>();
+
+            // ponytail: linear scan of the iteration's relationships; if this shows up in a profile on large models,
+            // requirement.QueryRelationships is the SDK's indexed reverse-lookup.
+            foreach (var relationship in this.CurrentThing.Relationship)
+            {
+                switch (relationship)
+                {
+                    case BinaryRelationship binary when binary.Source == requirement || binary.Target == requirement:
+                        rows.Add(new RequirementRelationshipRow
+                        {
+                            Relationship = binary,
+                            Direction = binary.Source == requirement ? RelationshipDirection.Outgoing : RelationshipDirection.Incoming,
+                            RelatedThings = [binary.Source == requirement ? binary.Target : binary.Source],
+                            RuleNames = this.GetMatchingRuleNames(binary)
+                        });
+
+                        break;
+
+                    case MultiRelationship multi when multi.RelatedThing.Contains(requirement):
+                        rows.Add(new RequirementRelationshipRow
+                        {
+                            Relationship = multi,
+                            Direction = RelationshipDirection.Bidirectional,
+                            RelatedThings = multi.RelatedThing.Where(x => x != requirement).ToList(),
+                            RuleNames = this.GetMatchingRuleNames(multi)
+                        });
+
+                        break;
+                }
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Navigates the document to the given <paramref name="requirement" />: clears the active search and filters
+        /// (so the target is guaranteed to render), selects its specification, expands its ancestor groups and flags
+        /// it as the <see cref="ScrollTarget" />.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /> to navigate to</param>
+        public void NavigateToRequirement(Requirement requirement)
+        {
+            this.SearchText = null;
+            this.SelectedOwners = [];
+            this.SelectedCategories = [];
+
+            // a link can point at a deprecated requirement; surface deprecated things so the target actually renders
+            if (requirement.IsDeprecated)
+            {
+                this.ShowHideDeprecatedThingsService.ShowDeprecatedThings = true;
+            }
+
+            for (var group = requirement.Group; group != null; group = group.Container as RequirementsGroup)
+            {
+                this.collapsedDocumentGroups.Remove(group.Iid);
+            }
+
+            this.SelectedSpecification = requirement.GetContainerOfType<RequirementsSpecification>();
+            this.ScrollTarget = requirement;
+        }
+
+        /// <summary>
         /// Handles the refresh of the current session by reloading the specifications while preserving the selection.
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -334,6 +757,16 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             await base.OnThingChanged();
 
             this.IsLoading = true;
+            this.parameterTypesCache = default;
+
+            if (this.CurrentThing == null)
+            {
+                this.AvailableOwners = [];
+                this.AvailableCategories = [];
+                this.SelectedSpecification = null;
+                this.IsLoading = false;
+                return;
+            }
 
             var allRequirements = this.CurrentThing.RequirementsSpecification
                 .Where(x => !x.IsDeprecated)
@@ -378,6 +811,35 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             }
 
             return !this.SelectedCategories.Any() || requirement.Category.Intersect(this.SelectedCategories).Any();
+        }
+
+        /// <summary>
+        /// Gets the names of the <see cref="BinaryRelationshipRule" />s or <see cref="MultiRelationshipRule" />s of the
+        /// open reference data libraries whose relationship category is carried by the given <paramref name="relationship" />.
+        /// </summary>
+        /// <param name="relationship">The <see cref="Relationship" /></param>
+        /// <returns>The matching rule names</returns>
+        private List<string> GetMatchingRuleNames(Relationship relationship)
+        {
+            var rules = this.SessionService.Session.OpenReferenceDataLibraries.SelectMany(x => x.Rule);
+
+            var matching = relationship is BinaryRelationship
+                ? rules.OfType<BinaryRelationshipRule>().Where(x => RelationshipCarriesCategory(relationship, x.RelationshipCategory)).Select(x => x.Name)
+                : rules.OfType<MultiRelationshipRule>().Where(x => RelationshipCarriesCategory(relationship, x.RelationshipCategory)).Select(x => x.Name);
+
+            return matching.ToList();
+        }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="relationship" /> carries the given <paramref name="ruleCategory" />
+        /// directly or through a sub-category, the way a relationship satisfies a rule under ECSS-E-TM-10-25.
+        /// </summary>
+        /// <param name="relationship">The <see cref="Relationship" /></param>
+        /// <param name="ruleCategory">The rule's <see cref="Category" /></param>
+        /// <returns>true if the relationship is categorised with the rule's category or a sub-category of it</returns>
+        private static bool RelationshipCarriesCategory(Relationship relationship, Category ruleCategory)
+        {
+            return relationship.Category.Any(x => x == ruleCategory || x.AllSuperCategories().Contains(ruleCategory));
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -618,7 +618,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             {
                 case RelationalExpression relational:
                     var scale = relational.Scale == null ? string.Empty : $" {relational.Scale.ShortName}";
-                    return $"{relational.ParameterType?.ShortName} {ParameterValueFormatter.RelationalOperatorSymbol(relational.RelationalOperator)} {string.Join(", ", relational.Value)}{scale}";
+                    return $"{relational.ParameterType?.ShortName} {relational.RelationalOperator.ToScientificNotationString()} {string.Join(", ", relational.Value)}{scale}";
 
                 case NotExpression { Term: not null } not:
                     return $"NOT ({this.GetExpressionSummary(not.Term)})";

--- a/COMETwebapp/wwwroot/Scripts/DomData.js
+++ b/COMETwebapp/wwwroot/Scripts/DomData.js
@@ -39,6 +39,20 @@ function GetElementSizeAndPosition(index, cssSelector, useScroll)
 }
 
 /**
+ * Smooth-scrolls the element with the given id into view, if it exists
+ * @param {string} elementId
+ */
+function ScrollElementIntoView(elementId)
+{
+    let element = document.getElementById(elementId);
+
+    if (element != null)
+    {
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+}
+
+/**
  * Subscribes to the resize event of the window and use a callback method to alert
  * @param {string} callbackMethodName
  */


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feature #789 
Summary
Extends the Requirements Editor document with three inline, independently-toggleable views for each requirement, so the specification still reads as a real document (export-friendly) while surfacing the engineering data attached to each requirement:

- Simple parameter values: value columns on each requirement row, inline-editable.
- Parametric constraints: the constraint expression tree, collapsible per level, with a one-line summary and the bound parameter's published value.
- Traceability: the relationships to and from each requirement, with click-to-navigate links.
- Each view is a toolbar switch (Values / Constraints / Traceability) and works in any combination.

What's new
Simple parameter values

- One column per ParameterType used across the specification's requirements, aligned vertically across every row and stable across filtering.
- A toolbar column picker to choose which value columns to show.
- Click-to-edit cells reusing the shared ParameterTypeEditorSelector from the Edit Parameter dialog, so enumerations get a dropdown, dates/date-times a calendar/clock, quantities a scaled editor, via a proxy ParameterValueSet (since SimpleParameterValue is not an IValueSet). Commit is explicit (✓ / Enter), cancel is ✗ / Esc; the ✓/✗ sit on a row above the field so the value stays readable.
- Writes go through CreateOrUpdateThingsWithNotification, so a concurrent-edit conflict raises a toast and the field reverts (only a clone is ever sent; the original is untouched).
- Requirements without a value show a distinct dashed "+ add" cell that creates the SimpleParameterValue so the parameter becomes editable.

Parametric constraints

- Renders the BooleanExpression tree (AND / OR / XOR / NOT / relational leaves); every non-leaf level is expand/collapsible.
0 Each node shows a one-line human-readable summary (e.g. (NOT (d_r < 500 m)) AND ((a > 4 m/s²) AND (v < 50 m/s))).
0 Relational leaves bound to a model parameter (via a BinaryRelationship) show the parameter's model code and its published value.

Traceability

- Lists every BinaryRelationship (in/out) and MultiRelationship the requirement participates in, with a direction indicator and the related things (element definitions/usages show their model code).
- Links to related requirements are clickable, navigating selects the target's specification, expands its groups, and smooth-scrolls it into view (below the sticky specification header).
- Matching relationship rules are shown as pills.
Table of contents

Layout / UX
- Requirement rows are a two-level layout: a top strip (definition | value columns | owner-over-category pills) and, below it, constraints and traceability side by side.
- The toolbar stays on one row even with the column picker.
- 
<img width="940" height="557" alt="image" src="https://github.com/user-attachments/assets/93b6a45d-b13d-4432-a54b-0a6d001bb4a2" />

<img width="940" height="554" alt="image" src="https://github.com/user-attachments/assets/b1ce8a72-ed6c-4069-ab0a-ebb3be72ee40" />

