### PR TITLE
fix #792 Updated to reactiveUI 23.2.28 and removed workaround

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -41,10 +41,6 @@ jobs:
         run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
       - name: Restore dependencies
-        env:
-          # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
-          # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
-          DOTNET_NUGET_SIGNATURE_VERIFICATION: false
         run: dotnet restore COMETwebapp.sln
 
       - name: Sonarqube Begin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,10 +50,6 @@ jobs:
       run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
     - name: Install dependencies
-      env:
-        # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
-        # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
-        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
       run: dotnet restore COMETwebapp.sln
 
     - name: Build

--- a/.github/workflows/nuget-reference-check.yml
+++ b/.github/workflows/nuget-reference-check.yml
@@ -33,10 +33,6 @@ jobs:
       run: dotnet nuget add source https://nuget.devexpress.com/api -n DXFeed -u DevExpress -p $DEVEXPRESS_NUGET_KEY --store-password-in-clear-text
 
     - name: Restore dependencies
-      env:
-        # Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
-        # Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
-        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
       run: dotnet restore COMETwebapp.sln
 
     - name: Build

--- a/COMET.Web.Common.Tests/Components/Applications/SingleIterationApplicationTemplateTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Applications/SingleIterationApplicationTemplateTestFixture.cs
@@ -175,11 +175,8 @@ namespace COMET.Web.Common.Tests.Components.Applications
 
             var navigationManager = this.context.Services.GetService<NavigationManager>();
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(navigationManager.Uri, Is.EqualTo("http://localhost/"));
-                this.viewModel.Verify(x => x.OnThingSelect(this.openIterations.Items[0]), Times.Exactly(2));
-            });
+            renderer.WaitForAssertion(() => Assert.That(navigationManager.Uri, Is.EqualTo("http://localhost/")));
+            this.viewModel.Verify(x => x.OnThingSelect(this.openIterations.Items[0]), Times.Exactly(2));
 
             this.viewModel.Setup(x => x.SelectedThing).Returns(this.openIterations.Items[0]);
             renderer.Instance.SetCorrectUrl();
@@ -220,9 +217,10 @@ namespace COMET.Web.Common.Tests.Components.Applications
             this.viewModel.Setup(x => x.SelectedThing).Returns((Iteration)null);
             renderer.Instance.SetCorrectUrl();
 
+            renderer.WaitForAssertion(() => Assert.That(navigationManager.Uri, Is.EqualTo("http://localhost/")));
+
             Assert.Multiple(() =>
             {
-                Assert.That(navigationManager.Uri, Is.EqualTo("http://localhost/"));
                 Assert.That(() => renderer.FindComponent<OpenModel>(), Throws.Nothing);
                 Assert.That(() => this.messageBus.SendMessage(new DomainChangedEvent(null, null)), Throws.Nothing);
             });

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageReference Include="ReactiveUI" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/COMETwebapp/COMETwebapp.csproj
+++ b/COMETwebapp/COMETwebapp.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
         <PackageReference Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
 
-        <PackageReference Include="ReactiveUI.Blazor" Version="23.1.8" />
+        <PackageReference Include="ReactiveUI.Blazor" Version="23.2.28" />
         <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.6.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/COMETwebapp/Dockerfile
+++ b/COMETwebapp/Dockerfile
@@ -5,10 +5,6 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG DEVEXPRESS_NUGET_KEY
 ARG PACKAGE_TOKEN
 
-# Workaround for NU3012: the ReactiveUI/Splat NuGet signing certificate has been revoked.
-# Disable enforced package signature verification until the packages are updated. See issue for the long-term fix.
-ENV DOTNET_NUGET_SIGNATURE_VERIFICATION=false
-
 COPY COMET.Web.Common COMET.Web.Common
 COPY COMETwebapp COMETwebapp
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Updated to reactiveUI 23.2.28 and removed workaround (Removed DOTNET_NUGET_SIGNATURE_VERIFICATION: false)