### PR TITLE
Bug 784 make sidebar scrollable and not overlapping items

### DIFF
--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -346,6 +346,20 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
         }
 
         [Test]
+        public void VerifySideBarFooterIsInFlow()
+        {
+            var renderer = this.context.Render<SideBar>();
+            var footer = renderer.FindComponent<SideBarFooter>();
+            var footerElement = footer.Find("div");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(footerElement.ClassList, Does.Contain("side-bar-footer"));
+                Assert.That(footerElement.GetAttribute("style"), Is.Null.Or.Empty);
+            });
+        }
+
+        [Test]
         public void VerifySideBarEntryRegistration()
         {
             var renderer = this.context.Render<SideBar>();

--- a/COMETwebapp/Shared/SideBar.razor.css
+++ b/COMETwebapp/Shared/SideBar.razor.css
@@ -1,5 +1,12 @@
 .main-side-bar {
     height: 100vh;
     background-color: var(--colors-primary-25);
-    padding: 10px 20px 30px 20px;
+    padding: 10px 20px 10px 20px;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+.main-side-bar ::deep > * {
+    flex-shrink: 0;
 }

--- a/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor
+++ b/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor
@@ -20,7 +20,7 @@
 @namespace COMETwebapp.Shared.SideBarEntry
 @inherits COMET.Web.Common.Shared.TopMenuEntry.MenuEntryBase
 
-<div style="display: ruby; position: fixed; bottom: 0; z-index: 2; margin-left: 5px;">
+<div class="side-bar-footer">
 	<a class="homelink" href="/">
 		<img src=@("_content/CDP4.WEB.Common/images/COMET-Symbol.png") class="p-1" style="width: 75px;" title="COMET Community Edition" alt="COMET Community Edition" />
 		<span class="font-weight-bold not-displayed-on-collapse" style="font-size: 0.8rem;">COMET Community Edition</span>

--- a/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor.css
+++ b/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor.css
@@ -1,0 +1,7 @@
+.side-bar-footer {
+    display: flex;
+    align-items: center;
+    margin-top: auto;
+    margin-left: 5px;
+    padding-top: 10px;
+}

--- a/COMETwebapp/Shared/SideBarEntry/SideBarItem.razor.css
+++ b/COMETwebapp/Shared/SideBarEntry/SideBarItem.razor.css
@@ -13,7 +13,7 @@
     transition: width 0.5s;
     white-space: nowrap;
     overflow: hidden;
-    height: 52px;
+    height: 44px;
     font-weight: 500;
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #784 main menu doesn't scroll; on a small screen the logo overlaps the last menu items, which become unreachable.

Root cause (two CSS mistakes, one symptom):

COMETwebapp/Shared/SideBar.razor.css:1: .main-side-bar was height: 100vh with no overflow, so once the 15 entries exceeded the viewport, the tail was simply clipped with no way to scroll to it.
COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor:23: the logo was position: fixed; bottom: 0; z-index: 2, i.e. out of the flow and painted on top of whatever entry happened to be at the bottom of the screen.

The change (CSS only):

SideBar.razor.css: the nav is now a scrolling flex column (display:flex; flex-direction:column; overflow-y:auto), plus .main-side-bar ::deep > * { flex-shrink: 0 } so the fixed-height entries overflow into the scroll instead of being squeezed to fit.
SideBarFooter.razor / new SideBarFooter.razor.css: inline position: fixed replaced by a .side-bar-footer class using margin-top: auto: the logo sits at the bottom when there's spare room and scrolls with the entries when there isn't.
