### PR TITLE
Fixes all open model editor issues 742, 726,739, 727, 735,740

### DIFF
--- a/COMET.Web.Common.Tests/Components/OpenModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/OpenModelTestFixture.cs
@@ -121,6 +121,11 @@ namespace COMET.Web.Common.Tests.Components
         {
             this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
             this.sessionService.Setup(x => x.GetParticipantModels()).Returns(this.engineeringModels);
+
+            // Without this the mock returns a null Task, and awaiting it throws inside the click handler.
+            this.sessionService.Setup(x => x.ReadIteration(It.IsAny<IterationSetup>(), It.IsAny<DomainOfExpertise>()))
+                .ReturnsAsync(FluentResults.Result.Ok(new Iteration()));
+
             var renderer = this.context.Render<OpenModel>();
             var layoutItems = renderer.FindComponents<DxFormLayoutItem>();
 
@@ -201,6 +206,41 @@ namespace COMET.Web.Common.Tests.Components
                 Assert.That(result.IsFailed, Is.True);
                 Assert.That(result.Errors[0].Message, Is.EqualTo("The selected iteration is already openened"));
             });
+        }
+
+        /// <summary>
+        /// Verifies that invoking <see cref="OpenModel.OpenSessionAsync" /> surfaces a failed
+        /// <see cref="OpenModelViewModel.OpenSession" /> result to the user, instead of silently discarding it as it did
+        /// when the button was bound directly to <see cref="OpenModelViewModel.OpenSession" />.
+        /// </summary>
+        [Test]
+        public async Task VerifyOpenSessionAsyncSetsErrorMessageOnFailure()
+        {
+            this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+            this.sessionService.Setup(x => x.GetParticipantModels()).Returns(this.engineeringModels);
+            this.sessionService.Setup(x => x.GetModelDomains(It.IsAny<EngineeringModelSetup>()))
+                .Returns(new List<DomainOfExpertise> { new() { Name = "Thermodynamic" } });
+
+            var renderer = this.context.Render<OpenModel>();
+
+            this.viewModel.SelectedEngineeringModel = this.viewModel.AvailableEngineeringModelSetups.First();
+            this.viewModel.SelectedDomainOfExpertise = this.viewModel.AvailablesDomainOfExpertises.First();
+            this.viewModel.SelectedIterationSetup = this.viewModel.AvailableIterationSetups.First();
+
+            var alreadyOpenIteration = new Iteration(Guid.NewGuid(), null, null)
+            {
+                IterationSetup = this.engineeringModels.SelectMany(x => x.IterationSetup).Single(x => x.Iid == this.viewModel.SelectedIterationSetup.IterationSetupId)
+            };
+
+            var openIterations = new SourceList<Iteration>();
+            openIterations.Add(alreadyOpenIteration);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(openIterations);
+
+            Assert.That(renderer.Instance.ErrorMessage, Is.Null.Or.Empty);
+
+            await renderer.InvokeAsync(renderer.Instance.OpenSessionAsync);
+
+            Assert.That(renderer.Instance.ErrorMessage, Is.EqualTo("The selected iteration is already openened"));
         }
     }
 }

--- a/COMET.Web.Common.Tests/Components/OpenModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/OpenModelTestFixture.cs
@@ -242,5 +242,27 @@ namespace COMET.Web.Common.Tests.Components
 
             Assert.That(renderer.Instance.ErrorMessage, Is.EqualTo("The selected iteration is already openened"));
         }
+
+        [Test]
+        public async Task VerifyOpenSessionAsyncClearsTheErrorMessageOnSuccess()
+        {
+            this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+            this.sessionService.Setup(x => x.GetParticipantModels()).Returns(this.engineeringModels);
+            this.sessionService.Setup(x => x.GetModelDomains(It.IsAny<EngineeringModelSetup>()))
+                .Returns(new List<DomainOfExpertise> { new() { Name = "Thermodynamic" } });
+
+            this.sessionService.Setup(x => x.ReadIteration(It.IsAny<IterationSetup>(), It.IsAny<DomainOfExpertise>()))
+                .ReturnsAsync(FluentResults.Result.Ok(new Iteration()));
+
+            var renderer = this.context.Render<OpenModel>();
+
+            this.viewModel.SelectedEngineeringModel = this.viewModel.AvailableEngineeringModelSetups.First();
+            this.viewModel.SelectedDomainOfExpertise = this.viewModel.AvailablesDomainOfExpertises.First();
+            this.viewModel.SelectedIterationSetup = this.viewModel.AvailableIterationSetups.First();
+
+            await renderer.InvokeAsync(renderer.Instance.OpenSessionAsync);
+
+            Assert.That(renderer.Instance.ErrorMessage, Is.Empty);
+        }
     }
 }

--- a/COMET.Web.Common.Tests/ViewModels/Components/OpenModelViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/OpenModelViewModelTestFixture.cs
@@ -136,6 +136,44 @@ namespace COMET.Web.Common.Tests.ViewModels.Components
             Assert.That(this.viewModel.SelectedDomainOfExpertise, Is.EqualTo(domainOfExpertise));
         }
 
+        /// <summary>
+        /// Verifies that when the cached <see cref="BrowserSessionSettingKey.LastUsedIterationData" /> refers to an
+        /// <see cref="Iteration" /> that is already open, it is not restored into <see cref="OpenModelViewModel.SelectedIterationSetup" />,
+        /// since an already-open iteration cannot be selected/opened again.
+        /// </summary>
+        [Test]
+        public void VerifyInitializePropertiesDoesNotRestoreAlreadyOpenIteration()
+        {
+            var preselectedEngineeringModel = this.models.First();
+            var alreadyOpenIterationSetup = preselectedEngineeringModel.IterationSetup.First();
+            var alreadyOpenIterationId = Guid.NewGuid();
+            alreadyOpenIterationSetup.IterationIid = alreadyOpenIterationId;
+
+            var alreadyOpenIteration = new Iteration
+            {
+                Iid = alreadyOpenIterationId,
+                IterationSetup = alreadyOpenIterationSetup
+            };
+
+            var openIterations = new SourceList<Iteration>();
+            openIterations.Add(alreadyOpenIteration);
+            this.sessionService.Setup(x => x.OpenIterations).Returns(openIterations);
+
+            object engineeringModelSetup = preselectedEngineeringModel;
+            object iterationData = new IterationData(alreadyOpenIterationSetup);
+
+            this.cacheService.Setup(x => x.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedEngineeringModel, out engineeringModelSetup)).Returns(true);
+            this.cacheService.Setup(x => x.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedIterationData, out iterationData)).Returns(true);
+
+            this.viewModel.InitializesProperties();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.SelectedIterationSetup, Is.Null);
+                Assert.That(this.viewModel.AvailableIterationSetups.Any(x => x.IterationSetupId == alreadyOpenIterationSetup.Iid), Is.False);
+            });
+        }
+
         private static List<EngineeringModelSetup> CreateData()
         {
             var rdl1 = new ModelReferenceDataLibrary(Guid.NewGuid(), null, null)

--- a/COMET.Web.Common/Components/OpenModel.razor
+++ b/COMET.Web.Common/Components/OpenModel.razor
@@ -55,7 +55,8 @@
 		</DxFormLayoutItem>
 	}
 </DxFormLayout>
+<ValidationMessageComponent ValidationMessage="@this.ErrorMessage" />
 <div class="modal-footer">
 	<DxButton Id="openmodel__button" CssClass="btn btn-connect"
-	          Text="@this.ButtonText" Enabled="@this.ButtonEnabled" Click="@(this.ViewModel.OpenSession)" />
+	          Text="@this.ButtonText" Enabled="@this.ButtonEnabled" Click="@this.OpenSessionAsync" />
 </div>

--- a/COMET.Web.Common/Components/OpenModel.razor.cs
+++ b/COMET.Web.Common/Components/OpenModel.razor.cs
@@ -85,6 +85,23 @@ namespace COMET.Web.Common.Components
         public string ButtonText => this.ViewModel.IsOpeningSession ? "Opening" : "Open";
 
         /// <summary>
+        /// The message to display when opening the <see cref="Iteration" /> failed
+        /// </summary>
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Opens the selected <see cref="Iteration" /> and reports the reason to the user when that fails, instead of
+        /// leaving the user with a button that appears to do nothing
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task OpenSessionAsync()
+        {
+            var result = await this.ViewModel.OpenSession();
+
+            this.ErrorMessage = result.IsFailed ? string.Join(", ", result.Errors.Select(x => x.Message)) : string.Empty;
+        }
+
+        /// <summary>
         /// Method invoked when the component is ready to start, having received its
         /// initial parameters from its parent in the render tree.
         /// </summary>

--- a/COMET.Web.Common/ViewModels/Components/OpenModelViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/OpenModelViewModel.cs
@@ -149,6 +149,14 @@ namespace COMET.Web.Common.ViewModels.Components
         }
 
         /// <summary>
+        /// Gets a value indicating whether an <see cref="Iteration" /> that is already open may still be selected.
+        /// Opening a model can only ever open an iteration that is not open yet, so this is false here. Opening a tab, on the
+        /// other hand, legitimately targets an already open iteration, to show it in another view - see the override in the
+        /// OpenTabViewModel.
+        /// </summary>
+        protected virtual bool CanSelectAlreadyOpenIteration => false;
+
+        /// <summary>
         /// Initializes this view model properties
         /// </summary>
         public void InitializesProperties()
@@ -165,7 +173,13 @@ namespace COMET.Web.Common.ViewModels.Components
 
             if (this.cacheService.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedIterationData, out var iterationData))
             {
-                this.selectedIterationSetup = iterationData as IterationData;
+                // The last used iteration is typically the one that is currently open, and an open iteration cannot be opened
+                // again, so it is only restored when it is still available.
+                var lastUsedIterationData = iterationData as IterationData;
+
+                this.selectedIterationSetup = this.AvailableIterationSetups?.Any(x => x.IterationSetupId == lastUsedIterationData?.IterationSetupId) == true
+                    ? lastUsedIterationData
+                    : null;
             }
 
             if (this.cacheService.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedDomainOfExpertise, out var domainOfExpertise))
@@ -276,27 +290,21 @@ namespace COMET.Web.Common.ViewModels.Components
 
                 this.SetAvailableDomainOfEpertiseAndIterationSetups();
 
+                // Deliberately left null when every iteration of the model is already open: an open iteration must not be
+                // selectable, since opening it again does nothing.
                 this.SelectedIterationSetup = this.AvailableIterationSetups.LastOrDefault();
-
-                if (this.SelectedIterationSetup != null)
-                {
-                    return;
-                }
-
-                var currentModelIteration = this.SelectedEngineeringModel.IterationSetup.Find(x => x == this.sessionService.OpenIterations.Items.FirstOrDefault(i => i.Iid == x.IterationIid)?.IterationSetup);
-                this.SelectedIterationSetup = new IterationData(currentModelIteration);
             }
         }
 
         /// <summary>
-        /// Sets the <see cref="AvailablesDomainOfExpertises"/> and <see cref="AvailableIterationSetups"/> 
+        /// Sets the <see cref="AvailablesDomainOfExpertises"/> and <see cref="AvailableIterationSetups"/>
         /// </summary>
         private void SetAvailableDomainOfEpertiseAndIterationSetups()
         {
             this.AvailablesDomainOfExpertises = this.sessionService.GetModelDomains(this.SelectedEngineeringModel);
 
             this.AvailableIterationSetups = this.SelectedEngineeringModel.IterationSetup
-                .Where(x => this.sessionService.OpenIterations.Items.All(i => i.Iid != x.IterationIid))
+                .Where(x => this.CanSelectAlreadyOpenIteration || this.sessionService.OpenIterations.Items.All(i => i.Iid != x.IterationIid))
                 .OrderBy(x => x.IterationNumber)
                 .Select(x => new IterationData(x));
         }

--- a/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
@@ -217,6 +217,26 @@ namespace COMETwebapp.Tests.Components.ModelEditor
             Assert.That(renderedComponent.Instance.InitialIteration, Is.EqualTo(iteration2));
         }
 
+        /// <summary>
+        /// Verifies that the owner and the category pills can each be toggled off on the tree nodes, the way the product tree
+        /// of the System Representation allows it
+        /// </summary>
+        [Test]
+        public void VerifyOwnerAndCategoryPillsCanBeToggled()
+        {
+            // The pills are shown by default.
+            Assert.That(renderedComponent.FindAll(".starion-pill"), Is.Not.Empty);
+
+            renderedComponent = context.Render<ElementDefinitionTree>(parameters =>
+            {
+                parameters
+                    .Add(p => p.ShowOwner, false)
+                    .Add(p => p.ShowCategories, false);
+            });
+
+            Assert.That(renderedComponent.FindAll(".starion-pill"), Is.Empty, "Unchecking both options must hide every pill.");
+        }
+
         [Test]
         public void VerifyDragIsNotAllowed()
         {

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -1,0 +1,280 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ModelEditorTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.ModelEditor
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4DalCommon.Protocol.Operations;
+
+    using COMET.Web.Common.Model.Configuration;
+    using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.ViewModels.Components.Common;
+    using COMETwebapp.ViewModels.Components.ModelEditor;
+    using COMETwebapp.ViewModels.Components.ModelEditor.CopySettings;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ElementDefinitionTree = COMETwebapp.Components.ModelEditor.ElementDefinitionTree;
+    using ModelEditorComponent = COMETwebapp.Components.ModelEditor.ModelEditor;
+
+    /// <summary>
+    /// Test fixture for the <see cref="ModelEditorComponent" /> component, focused on the independent
+    /// collapse/expand behavior of the source tree panel and the details panel (issue GH742).
+    /// </summary>
+    [TestFixture]
+    public class ModelEditorTestFixture
+    {
+        /// <summary>
+        /// The css class that a minimized panel carries.
+        /// </summary>
+        private const string CollapsedPanelClass = "model-editor-panel-collapsed";
+
+        /// <summary>
+        /// The bunit <see cref="BunitContext" /> used to render the component under test.
+        /// </summary>
+        private BunitContext context;
+
+        /// <summary>
+        /// The mocked <see cref="IModelEditorViewModel" /> bound to the component.
+        /// </summary>
+        private Mock<IModelEditorViewModel> viewModel;
+
+        /// <summary>
+        /// The mocked <see cref="IElementDetailsPanelViewModel" /> exposed by <see cref="viewModel" />.
+        /// </summary>
+        private Mock<IElementDetailsPanelViewModel> detailsPanelViewModel;
+
+        /// <summary>
+        /// The mocked <see cref="ICopySettingsViewModel" /> exposed by <see cref="viewModel" />.
+        /// </summary>
+        private Mock<ICopySettingsViewModel> copySettingsViewModel;
+
+        /// <summary>
+        /// The mocked <see cref="COMETwebapp.ViewModels.Components.ModelEditor.IElementDefinitionTreeViewModel" />
+        /// resolved from DI by both nested <see cref="ElementDefinitionTree" /> components.
+        /// </summary>
+        private Mock<IElementDefinitionTreeViewModel> elementDefinitionTreeViewModel;
+
+        /// <summary>
+        /// The <see cref="Iteration" /> exposed as <see cref="IModelEditorViewModel.CurrentThing" />.
+        /// </summary>
+        private Iteration iteration;
+
+        /// <summary>
+        /// Initializes the bunit context and a mocked <see cref="IModelEditorViewModel" /> sufficient to render
+        /// the component without a selected element and without the copy-settings popup open.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            var configuration = new Mock<IConfigurationService>();
+            configuration.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
+            this.context.Services.AddSingleton(configuration.Object);
+
+            this.elementDefinitionTreeViewModel = new Mock<IElementDefinitionTreeViewModel>();
+            this.elementDefinitionTreeViewModel.Setup(x => x.Rows).Returns([]);
+            this.elementDefinitionTreeViewModel.Setup(x => x.Iterations).Returns([]);
+            this.context.Services.AddSingleton(this.elementDefinitionTreeViewModel.Object);
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                IterationSetup = new IterationSetup
+                {
+                    IterationNumber = 1,
+                    Container = new EngineeringModelSetup
+                    {
+                        Iid = Guid.NewGuid(),
+                        Name = "ModelName",
+                        ShortName = "ModelShortName"
+                    }
+                }
+            };
+
+            this.detailsPanelViewModel = new Mock<IElementDetailsPanelViewModel>();
+            this.detailsPanelViewModel.Setup(x => x.SelectedElementDefinition).Returns((ElementDefinition)null);
+
+            this.copySettingsViewModel = new Mock<ICopySettingsViewModel>();
+            this.copySettingsViewModel.Setup(x => x.AvailableOperationKinds).Returns(new CopyOperationKinds());
+            this.copySettingsViewModel.Setup(x => x.SelectedOperationKind).Returns(OperationKind.Copy);
+
+            this.viewModel = new Mock<IModelEditorViewModel>();
+            this.viewModel.Setup(x => x.IsLoading).Returns(false);
+            this.viewModel.Setup(x => x.CurrentThing).Returns(this.iteration);
+            this.viewModel.Setup(x => x.IsSourceModelSameAsTargetModel).Returns(true);
+            this.viewModel.Setup(x => x.IsOnCopySettingsMode).Returns(false);
+            this.viewModel.Setup(x => x.CopySettingsViewModel).Returns(this.copySettingsViewModel.Object);
+            this.viewModel.Setup(x => x.DetailsPanelViewModel).Returns(this.detailsPanelViewModel.Object);
+
+            // ApplicationBase<TViewModel>.InjectedViewModel is [Inject] and must be resolvable from DI even
+            // though the same instance is also supplied explicitly as ParameterizedViewModel below.
+            this.context.Services.AddSingleton(this.viewModel.Object);
+        }
+
+        /// <summary>
+        /// Disposes of the bunit context.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Renders the <see cref="ModelEditorComponent" /> bound to <see cref="viewModel" />.
+        /// </summary>
+        /// <returns>The rendered <see cref="ModelEditorComponent" />.</returns>
+        private IRenderedComponent<ModelEditorComponent> RenderModelEditor()
+        {
+            return this.context.Render<ModelEditorComponent>(parameters =>
+                parameters.Add(p => p.ParameterizedViewModel, this.viewModel.Object));
+        }
+
+        [Test]
+        public void VerifyComponent()
+        {
+            var renderedComponent = this.RenderModelEditor();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderedComponent, Is.Not.Null);
+                Assert.That(renderedComponent.Instance, Is.Not.Null);
+                Assert.That(renderedComponent.Instance.ViewModel, Is.EqualTo(this.viewModel.Object));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that the iteration of both trees reaches the ViewModel, which is what decides whether a copy between the two
+        /// panels crosses iterations. The trees are captured with @ref and are therefore still null when the parameters are set,
+        /// so subscribing to them any earlier than the first render leaves the ViewModel believing the panels hold different
+        /// iterations, and the Model Editor then wrongly announces the different-Iteration copy mode.
+        /// </summary>
+        [Test]
+        public void VerifyTreeIterationsReachTheViewModel()
+        {
+            this.elementDefinitionTreeViewModel.Setup(x => x.Iteration).Returns(this.iteration);
+
+            var renderedComponent = this.RenderModelEditor();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                this.viewModel.VerifySet(x => x.SourceIteration = this.iteration, Times.AtLeastOnce);
+                this.viewModel.VerifySet(x => x.TargetIteration = this.iteration, Times.AtLeastOnce);
+            });
+        }
+
+        [Test]
+        public void VerifyPanelCollapseAndExpand()
+        {
+            var renderedComponent = this.RenderModelEditor();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsSourcePanelCollapsed, Is.False);
+                Assert.That(renderedComponent.Instance.IsDetailsPanelCollapsed, Is.False);
+                Assert.That(renderedComponent.Find("#sourcePanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
+                Assert.That(renderedComponent.Find("#detailsPanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
+                Assert.That(renderedComponent.FindAll(".model-editor-collapsed-strip"), Is.Empty);
+            });
+
+            // Collapse the source panel: only the source panel is affected.
+            renderedComponent.Find("#collapseSourcePanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsSourcePanelCollapsed, Is.True);
+                Assert.That(renderedComponent.Find("#sourcePanel").ClassList, Does.Contain(CollapsedPanelClass));
+                Assert.That(() => renderedComponent.Find("#expandSourcePanel"), Throws.Nothing);
+                Assert.That(renderedComponent.Find("#detailsPanel").ClassList, Does.Not.Contain(CollapsedPanelClass),
+                    "Collapsing the source panel must not affect the details panel.");
+            });
+
+            // Re-expand the source panel.
+            renderedComponent.Find("#expandSourcePanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsSourcePanelCollapsed, Is.False);
+                Assert.That(renderedComponent.Find("#sourcePanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
+                Assert.That(() => renderedComponent.Find("#expandSourcePanel"), Throws.TypeOf<ElementNotFoundException>());
+            });
+
+            // Collapse the details panel: only the details panel is affected.
+            renderedComponent.Find("#collapseDetailsPanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsDetailsPanelCollapsed, Is.True);
+                Assert.That(renderedComponent.Find("#detailsPanel").ClassList, Does.Contain(CollapsedPanelClass));
+                Assert.That(() => renderedComponent.Find("#expandDetailsPanel"), Throws.Nothing);
+                Assert.That(renderedComponent.Instance.IsSourcePanelCollapsed, Is.False,
+                    "Collapsing the details panel must not affect the source panel.");
+                Assert.That(renderedComponent.Find("#sourcePanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
+            });
+
+            // Re-expand the details panel.
+            renderedComponent.Find("#expandDetailsPanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsDetailsPanelCollapsed, Is.False);
+                Assert.That(renderedComponent.Find("#detailsPanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
+                Assert.That(() => renderedComponent.Find("#expandDetailsPanel"), Throws.TypeOf<ElementNotFoundException>());
+            });
+        }
+
+        /// <summary>
+        /// Verifies that collapsing a panel only hides it, and never unmounts its <see cref="ElementDefinitionTree" />.
+        /// An unmounted tree would discard its transient ViewModel without disposing the message bus and
+        /// DynamicData subscriptions that it owns, leaking them on every collapse.
+        /// </summary>
+        [Test]
+        public void VerifyCollapsedPanelsStayMounted()
+        {
+            var renderedComponent = this.RenderModelEditor();
+
+            Assert.That(renderedComponent.FindComponents<ElementDefinitionTree>(), Has.Count.EqualTo(2));
+
+            renderedComponent.Find("#collapseSourcePanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsSourcePanelCollapsed, Is.True);
+                Assert.That(renderedComponent.FindComponents<ElementDefinitionTree>(), Has.Count.EqualTo(2),
+                    "A collapsed source panel must stay mounted, so that its ViewModel's subscriptions are not leaked.");
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -36,7 +36,9 @@ namespace COMETwebapp.Tests.Components.ModelEditor
     using COMETwebapp.ViewModels.Components.Common;
     using COMETwebapp.ViewModels.Components.ModelEditor;
     using COMETwebapp.ViewModels.Components.ModelEditor.CopySettings;
+    using COMETwebapp.ViewModels.Components.ModelEditor.Rows;
 
+    using Microsoft.AspNetCore.Components.Web;
     using Microsoft.Extensions.DependencyInjection;
 
     using Moq;
@@ -193,6 +195,108 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 this.viewModel.VerifySet(x => x.SourceIteration = this.iteration, Times.AtLeastOnce);
                 this.viewModel.VerifySet(x => x.TargetIteration = this.iteration, Times.AtLeastOnce);
             });
+        }
+        
+        [Test]
+        public async Task VerifyDragAndDropUsesTheModifierKeyOperationKind()
+        {
+            var owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+            var draggedElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Dragged", Owner = owner };
+            var targetElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Target", Owner = owner };
+            this.iteration.Element.Add(draggedElement);
+            this.iteration.Element.Add(targetElement);
+
+            var draggedRow = new ElementDefinitionTreeRowViewModel(draggedElement);
+            var targetRow = new ElementDefinitionTreeRowViewModel(targetElement);
+
+            this.elementDefinitionTreeViewModel.Setup(x => x.Iteration).Returns(this.iteration);
+
+            var renderedComponent = this.RenderModelEditor();
+            var trees = renderedComponent.FindComponents<ElementDefinitionTree>();
+            var sourceTree = trees[0].Instance;
+            var targetTree = trees[1].Instance;
+
+            // Nothing is being dragged yet, so no drop is allowed.
+            await renderedComponent.InvokeAsync(() => targetTree.OnCalculateDropIsAllowed.InvokeAsync(targetTree));
+            Assert.That(targetTree.AllowNodeDrop, Is.False);
+
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragStart.InvokeAsync((sourceTree, draggedRow)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnDragEnter.InvokeAsync((targetTree, null)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnCalculateDropIsAllowed.InvokeAsync(targetTree));
+
+            Assert.That(targetTree.AllowNodeDrop, Is.True, "Dragging an ElementDefinition over the target tree must allow the drop.");
+
+            // Ctrl + Shift maps to CopyKeepValues: keep the parameter values and the original owner.
+            await renderedComponent.InvokeAsync(() => targetTree.OnDrop.InvokeAsync((targetTree, null, new DragEventArgs { CtrlKey = true, ShiftKey = true })));
+
+            this.viewModel.Verify(x => x.CopyAndAddNewElementAsync(targetTree, draggedElement, OperationKind.CopyKeepValues), Times.Once);
+
+            // Without a modifier key the copy mode selected in the copy settings applies, which the ViewModel resolves itself.
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragStart.InvokeAsync((sourceTree, draggedRow)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnDrop.InvokeAsync((targetTree, null, new DragEventArgs())));
+
+            this.viewModel.Verify(x => x.CopyAndAddNewElementAsync(targetTree, draggedElement, null), Times.Once);
+
+            // Dropping onto a node adds an ElementUsage rather than copying.
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragStart.InvokeAsync((sourceTree, draggedRow)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnDrop.InvokeAsync((targetTree, targetRow, new DragEventArgs())));
+
+            this.viewModel.Verify(x => x.AddNewElementUsageAsync(draggedElement, targetElement), Times.Once);
+
+            await renderedComponent.InvokeAsync(() => targetTree.OnDragLeave.InvokeAsync((targetTree, null)));
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragEnd.InvokeAsync((sourceTree, draggedRow)));
+
+            // The drag is over, so a drop is no longer allowed.
+            await renderedComponent.InvokeAsync(() => targetTree.OnCalculateDropIsAllowed.InvokeAsync(targetTree));
+            Assert.That(targetTree.AllowNodeDrop, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that a failing copy is reported to the user instead of being swallowed
+        /// </summary>
+        [Test]
+        public async Task VerifyDropReportsAFailingCopy()
+        {
+            var owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+            var draggedElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Dragged", Owner = owner };
+            this.iteration.Element.Add(draggedElement);
+            var draggedRow = new ElementDefinitionTreeRowViewModel(draggedElement);
+
+            this.elementDefinitionTreeViewModel.Setup(x => x.Iteration).Returns(this.iteration);
+
+            this.viewModel.Setup(x => x.CopyAndAddNewElementAsync(It.IsAny<ElementDefinitionTree>(), It.IsAny<ElementBase>(), It.IsAny<OperationKind?>()))
+                .ThrowsAsync(new InvalidOperationException("copy refused"));
+
+            var renderedComponent = this.RenderModelEditor();
+            var trees = renderedComponent.FindComponents<ElementDefinitionTree>();
+            var sourceTree = trees[0].Instance;
+            var targetTree = trees[1].Instance;
+
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragStart.InvokeAsync((sourceTree, draggedRow)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnDrop.InvokeAsync((targetTree, null, new DragEventArgs())));
+
+            renderedComponent.WaitForAssertion(() => Assert.That(renderedComponent.Markup, Does.Contain("copy refused")));
+        }
+
+        /// <summary>
+        /// Verifies that selecting a node in either tree drives the details panel, and clears the selection of the other tree
+        /// </summary>
+        [Test]
+        public async Task VerifySelectingANodeDrivesTheDetailsPanel()
+        {
+            var owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Selected", Owner = owner };
+            this.iteration.Element.Add(elementDefinition);
+            var row = new ElementDefinitionTreeRowViewModel(elementDefinition);
+
+            var renderedComponent = this.RenderModelEditor();
+            var trees = renderedComponent.FindComponents<ElementDefinitionTree>();
+
+            await renderedComponent.InvokeAsync(() => trees[0].Instance.SelectionChanged.InvokeAsync(row));
+            this.detailsPanelViewModel.Verify(x => x.SelectElement(elementDefinition), Times.Once);
+
+            await renderedComponent.InvokeAsync(() => trees[1].Instance.SelectionChanged.InvokeAsync(null));
+            this.detailsPanelViewModel.Verify(x => x.SelectElement(null), Times.Once);
         }
 
         [Test]

--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -391,6 +391,13 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
             renderer.Render();
 
             renderer.WaitForAssertion(() => Assert.That(sideBar.IsCollapsed, Is.True, "Shrinking the window collapses the side bar again."));
+
+            // Re-assigning the same viewport state is a no-op, and must not drop a preference the user has meanwhile set.
+            await renderer.InvokeAsync(sideBar.ToggleCollapsed);
+            await renderer.InvokeAsync(() => sideBar.IsNarrowViewport = true);
+            renderer.Render();
+
+            renderer.WaitForAssertion(() => Assert.That(sideBar.IsCollapsed, Is.False, "Re-setting the same viewport state must keep the user's own choice."));
         }
 
         [Test]

--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -345,6 +345,54 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
             });
         }
 
+        /// <summary>
+        /// Verifies that a narrow viewport collapses the side bar by default, that the user can still expand it again while the
+        /// viewport stays narrow, and that resizing the window drops that manual override (issue GH742)
+        /// </summary>
+        [Test]
+        public async Task VerifySideBarCollapsesOnNarrowViewport()
+        {
+            var renderer = this.context.Render<SideBar>();
+            var sideBar = renderer.Instance;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sideBar.IsCollapsed, Is.False);
+                Assert.That(renderer.Find("nav").ClassList, Does.Not.Contain("collapsed"));
+            });
+
+            // A narrow viewport collapses the side bar. In the running app the DxLayoutBreakpoint two-way binding both assigns
+            // the property and triggers the re-render.
+            await renderer.InvokeAsync(() => sideBar.IsNarrowViewport = true);
+            renderer.Render();
+
+            renderer.WaitForAssertion(() =>
+            {
+                Assert.That(sideBar.IsCollapsed, Is.True);
+                Assert.That(renderer.Find("nav").ClassList, Does.Contain("collapsed"));
+            });
+
+            // The toggle remains available on a narrow viewport, so the user can expand the side bar anyway.
+            await renderer.InvokeAsync(() => renderer.Find("#side-bar-collapse-button").Click());
+
+            renderer.WaitForAssertion(() =>
+            {
+                Assert.That(sideBar.IsCollapsed, Is.False, "The user must be able to expand the side bar on a small screen.");
+                Assert.That(renderer.Find("nav").ClassList, Does.Not.Contain("collapsed"));
+            });
+
+            // Widening the window drops the manual override, so the side bar follows the viewport again.
+            await renderer.InvokeAsync(() => sideBar.IsNarrowViewport = false);
+            renderer.Render();
+
+            renderer.WaitForAssertion(() => Assert.That(sideBar.IsCollapsed, Is.False));
+
+            await renderer.InvokeAsync(() => sideBar.IsNarrowViewport = true);
+            renderer.Render();
+
+            renderer.WaitForAssertion(() => Assert.That(sideBar.IsCollapsed, Is.True, "Shrinking the window collapses the side bar again."));
+        }
+
         [Test]
         public void VerifySideBarFooterIsInFlow()
         {
@@ -394,12 +442,12 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
             Assert.Multiple(() =>
             {
                 Assert.That(fakeNavigationManager.Uri, Does.Contain(this.registeredApplications[1].Url));
-                Assert.That(renderer.Instance.Collapsed, Is.False);
+                Assert.That(renderer.Instance.IsCollapsed, Is.False);
             });
-            
+
             var sideBarCollapseButton = renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "side-bar-collapse-button");
             await renderer.InvokeAsync(sideBarCollapseButton.Instance.Click.InvokeAsync);
-            Assert.That(renderer.Instance.Collapsed, Is.True);
+            Assert.That(renderer.Instance.IsCollapsed, Is.True);
         }
     }
 }

--- a/COMETwebapp.Tests/Utilities/DragEventArgsExtensionsTestFixture.cs
+++ b/COMETwebapp.Tests/Utilities/DragEventArgsExtensionsTestFixture.cs
@@ -1,0 +1,56 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DragEventArgsExtensionsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Utilities
+{
+    using CDP4DalCommon.Protocol.Operations;
+
+    using COMETwebapp.Utilities;
+
+    using Microsoft.AspNetCore.Components.Web;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for the <see cref="DragEventArgsExtensions" />
+    /// </summary>
+    [TestFixture]
+    public class DragEventArgsExtensionsTestFixture
+    {
+        [Test]
+        public void VerifyGetCopyOperationKind()
+        {
+            var ctrlOnly = new DragEventArgs { CtrlKey = true, ShiftKey = false };
+            var shiftOnly = new DragEventArgs { CtrlKey = false, ShiftKey = true };
+            var ctrlAndShift = new DragEventArgs { CtrlKey = true, ShiftKey = true };
+            var noModifier = new DragEventArgs { CtrlKey = false, ShiftKey = false };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ctrlOnly.GetCopyOperationKind(), Is.EqualTo(OperationKind.CopyKeepValuesChangeOwner));
+                Assert.That(shiftOnly.GetCopyOperationKind(), Is.EqualTo(OperationKind.Copy));
+                Assert.That(ctrlAndShift.GetCopyOperationKind(), Is.EqualTo(OperationKind.CopyKeepValues));
+                Assert.That(noModifier.GetCopyOperationKind(), Is.Null);
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
@@ -103,7 +103,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
         [Test]
         public void VerifyAlreadyOpenIterationCanStillBeSelectedForANewTab()
         {
-            var alreadyOpenIteration = this.alreadyOpenIterations.Items.First();
+            var alreadyOpenIteration = this.alreadyOpenIterations.Items[0];
             var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
 
             // The "is this iteration already open" check matches IterationSetup.IterationIid against Iteration.Iid, so the
@@ -131,7 +131,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
         [Test]
         public void VerifyInitializesPropertiesRestoresTheAlreadyOpenIteration()
         {
-            var alreadyOpenIteration = this.alreadyOpenIterations.Items.First();
+            var alreadyOpenIteration = this.alreadyOpenIterations.Items[0];
             var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
 
             alreadyOpenIteration.IterationSetup.IterationIid = alreadyOpenIteration.Iid;

--- a/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
@@ -25,6 +25,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.Cache;
     using COMET.Web.Common.Services.ConfigurationService;
@@ -92,6 +93,63 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
         {
             this.viewModel?.Dispose();
             this.alreadyOpenIterations?.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that an <see cref="Iteration" /> that is already open can still be selected when opening a tab, so that the
+        /// same iteration can be shown in several views at once, for instance the Model Editor next to the System
+        /// Representation. Only opening a <i>model</i> refuses an already open iteration.
+        /// </summary>
+        [Test]
+        public void VerifyAlreadyOpenIterationCanStillBeSelectedForANewTab()
+        {
+            var alreadyOpenIteration = this.alreadyOpenIterations.Items.First();
+            var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
+
+            // The "is this iteration already open" check matches IterationSetup.IterationIid against Iteration.Iid, so the
+            // setup has to point back at its iteration for the iteration to count as open at all.
+            alreadyOpenIteration.IterationSetup.IterationIid = alreadyOpenIteration.Iid;
+
+            this.viewModel.SelectedEngineeringModel = engineeringModelSetup;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.AvailableIterationSetups.Select(x => x.IterationSetupId),
+                    Does.Contain(alreadyOpenIteration.IterationSetup.Iid),
+                    "An already open iteration must remain selectable when opening a new tab on it.");
+
+                Assert.That(this.viewModel.SelectedIterationSetup, Is.Not.Null,
+                    "Without a selected iteration the Open Tab button stays disabled, which would block opening a second view on the iteration.");
+            });
+        }
+
+        /// <summary>
+        /// Verifies the path that the Open Tab component actually takes: it calls <c>InitializesProperties</c>, which restores the
+        /// last used iteration from the browser session cache. That iteration is normally the one that is currently open, and it
+        /// must still be restored here, otherwise the Open Tab button stays disabled and no second view can be opened on it.
+        /// </summary>
+        [Test]
+        public void VerifyInitializesPropertiesRestoresTheAlreadyOpenIteration()
+        {
+            var alreadyOpenIteration = this.alreadyOpenIterations.Items.First();
+            var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
+
+            alreadyOpenIteration.IterationSetup.IterationIid = alreadyOpenIteration.Iid;
+
+            var cachedIterationData = new IterationData(alreadyOpenIteration.IterationSetup);
+
+            this.sessionService.Setup(x => x.GetParticipantModels()).Returns([engineeringModelSetup]);
+
+            object engineeringModelSetting = engineeringModelSetup;
+            object iterationSetting = cachedIterationData;
+
+            this.cacheService.Setup(x => x.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedEngineeringModel, out engineeringModelSetting)).Returns(true);
+            this.cacheService.Setup(x => x.TryGetBrowserSessionSetting(BrowserSessionSettingKey.LastUsedIterationData, out iterationSetting)).Returns(true);
+
+            this.viewModel.InitializesProperties();
+
+            Assert.That(this.viewModel.SelectedIterationSetup?.IterationSetupId, Is.EqualTo(cachedIterationData.IterationSetupId),
+                "The already open iteration must be restored, so that another view can be opened on it.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModelTestFixture.cs
@@ -136,14 +136,14 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
         [Test]
         public void VerifyIterationRefresh()
         {
-            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(2));
+            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(1));
 
             this.iterations.Remove(this.iteration);
-            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(1));
+            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(0));
 
             this.iterations.Add(this.iteration);
 
-            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(2));
+            Assert.That(this.viewModel.Iterations, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             {
                 Assert.That(this.viewModel.Description, Is.EqualTo(expectedIterationData.IterationName));
                 Assert.That(this.viewModel.Iteration, Is.EqualTo(this.iteration));
-                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(2));
+                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(1));
                 Assert.That(this.viewModel.SelectedIterationData, Is.EqualTo(expectedIterationData));
                 Assert.That(this.viewModel.Rows.Count, Is.EqualTo(2));
             });
@@ -196,7 +196,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             {
                 Assert.That(this.viewModel.Description, Is.EqualTo("Please select a model"));
                 Assert.That(this.viewModel.Iteration, Is.Null);
-                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(2));
+                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(1));
                 Assert.That(this.viewModel.SelectedIterationData, Is.Null);
                 Assert.That(this.viewModel.Rows.Count, Is.EqualTo(0));
             });
@@ -208,7 +208,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             {
                 Assert.That(this.viewModel.Description, Is.EqualTo(expectedIterationData.IterationName));
                 Assert.That(this.viewModel.Iteration, Is.EqualTo(this.iteration));
-                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(2));
+                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(1));
                 Assert.That(this.viewModel.SelectedIterationData, Is.EqualTo(expectedIterationData));
                 Assert.That(this.viewModel.Rows.Count, Is.EqualTo(2));
             });
@@ -224,7 +224,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             {
                 Assert.That(this.viewModel.Description, Is.EqualTo(expectedIterationData.IterationName));
                 Assert.That(this.viewModel.Iteration, Is.EqualTo(this.iteration));
-                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(2));
+                Assert.That(this.viewModel.Iterations.Count, Is.EqualTo(1));
                 Assert.That(this.viewModel.SelectedIterationData, Is.EqualTo(expectedIterationData));
                 Assert.That(this.viewModel.Rows.Count, Is.EqualTo(2));
             });

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -73,6 +73,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
         /// The currently logged-in <see cref="DomainOfExpertise" />.
         /// </summary>
         private DomainOfExpertise currentDomain;
+        private Mock<ISession> session;
 
         /// <summary>
         /// Builds the iteration graph and the view model with mocked dependencies.
@@ -84,8 +85,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             this.sessionService = new Mock<ISessionService>();
             var cacheService = new Mock<ICacheService>();
 
-            var session = new Mock<ISession>();
-            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+            this.session = new Mock<ISession>();
+            this.sessionService.Setup(x => x.Session).Returns(this.session.Object);
             this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
 
             var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
@@ -99,7 +100,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             var iterationSetup = new IterationSetup { IterationNumber = 1 };
             modelSetup.IterationSetup.Add(iterationSetup);
             this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
-            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+            this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
 
             this.topElement = new ElementDefinition
             {
@@ -161,6 +162,49 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             this.viewModel.TargetIteration = this.iteration;
 
             Assert.That(this.viewModel.IsSourceModelSameAsTargetModel, Is.True);
+        }
+        
+        [Test]
+        public void VerifyIsSourceModelSameAsTargetModel()
+        {
+            var otherIteration = new Iteration { Iid = Guid.NewGuid() };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.IsSourceModelSameAsTargetModel, Is.False, "No source iteration is selected yet.");
+
+                this.viewModel.SourceIteration = otherIteration;
+                this.viewModel.TargetIteration = this.iteration;
+                Assert.That(this.viewModel.IsSourceModelSameAsTargetModel, Is.False);
+
+                this.viewModel.SourceIteration = this.iteration;
+                Assert.That(this.viewModel.IsSourceModelSameAsTargetModel, Is.True);
+
+                this.viewModel.SourceIteration = null;
+                Assert.That(this.viewModel.IsSourceModelSameAsTargetModel, Is.False);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that the copy and the element usage entry points refuse null arguments, rather than failing later inside the
+        /// SDK copy machinery where the cause would be much harder to see
+        /// </summary>
+        [Test]
+        public void VerifyCopyAndAddNewElementAsyncGuardsItsArguments()
+        {
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Owner = this.currentDomain };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(async () => await this.viewModel.CopyAndAddNewElementAsync(null, elementDefinition),
+                    Throws.TypeOf<ArgumentNullException>());
+
+                Assert.That(async () => await this.viewModel.AddNewElementUsageAsync(null, elementDefinition),
+                    Throws.TypeOf<ArgumentNullException>());
+
+                Assert.That(async () => await this.viewModel.AddNewElementUsageAsync(elementDefinition, null),
+                    Throws.TypeOf<ArgumentNullException>());
+            });
         }
     }
 }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
@@ -38,26 +38,20 @@ else
     <h6>@this.ViewModel.Description</h6>
 }
 </div>
-<p>
-    <table>
-        <tr>
-            <td id="search-textbox" style="visibility:@(this.AllowSearch ? "block": "hidden");">
-                <DxTextBox CssClass="inline-search-icon" SizeMode="SizeMode.Medium" BindValueMode="BindValueMode.OnDelayedInput" InputDelay="500" @bind-Text="this.SearchTerm" NullText="Search..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto">
-                </DxTextBox>
-            </td>
-        </tr>
-    </table>
-</p>
+<div id="search-textbox" style="visibility:@(this.AllowSearch ? "visible" : "hidden");">
+    <DxTextBox CssClass="inline-search-icon" SizeMode="SizeMode.Medium" BindValueMode="BindValueMode.OnDelayedInput" InputDelay="500" @bind-Text="this.SearchTerm" NullText="Search..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto">
+    </DxTextBox>
+</div>
 <div class="drop-area-color @(this.dragOverNode == this.TreeView && this.AllowNodeDrop && this.AllowDrop ? "treeview-drag-over" : "")"
      dropzone="@(this.AllowDrop ? "move" : "")"
      ondragover="@(this.AllowDrop ? "event.preventDefault();" : "")"
      @ondragenter="@(() => this.DragEnterAsync(this.TreeView))"
      @ondragleave="@(() => this.DragLeaveAsync(this.TreeView))"
-     @ondrop="@(() => this.DropAsync(null))"
+     @ondrop="@(async (DragEventArgs e) => await this.DropAsync(null, e))"
      style="padding:2px;border:dotted 1px;border-radius: 5px;height:25px;@(this.AllowDrop ? "" : "visibility:hidden;")">
     Drop here to create new element...
 </div>
-<div class="@this.ScrollableAreaCssClass" style="overflow-y:auto;">
+<div class="@this.ScrollableAreaCssClass" style="overflow:auto;">
     <DxTreeView @ref="this.TreeView" Data="@this.ViewModel.Rows"
                 FilterString="@this.SearchTerm"
                 FilterMinLength="1"
@@ -81,6 +75,8 @@ else
                     <ElementDefinitionTreeItem
                         CssClass="@($"{cssClass} {(this.AllowDrop && this.dragOverNode == dataItem && this.AllowNodeDrop ? "treeview-item-drag-over" : "")}")"
                         ElementBaseTreeRowViewModel="@dataItem"
+                        ShowOwner="@this.ShowOwner"
+                        ShowCategories="@this.ShowCategories"
                         draggable="@(this.AllowDrag ? "true" : "false")"
                         dropzone="@(this.AllowDrop && this.dragOverNode == dataItem && this.AllowNodeDrop ? "move" : "")"
                         @ondragstart="@(async () => await this.DragStartAsync(dataItem))"
@@ -88,11 +84,15 @@ else
                         ondragover="@(this.AllowDrop && this.dragOverNode == dataItem && this.AllowNodeDrop ? "event.preventDefault();" : "")"
                         @ondragenter="@(async () => await this.DragEnterAsync(dataItem))"
                         @ondragleave="@(async () => await this.DragLeaveAsync(dataItem))"
-                        @ondrop="@(async () => await this.DropAsync(dataItem))"/>
+                        @ondrop="@(async (DragEventArgs e) => await this.DropAsync(dataItem, e))"/>
                 }
                 else
                 {
-                    <ElementDefinitionTreeItem CssClass="@cssClass" ElementBaseTreeRowViewModel="@dataItem"/>
+                    <ElementDefinitionTreeItem
+                        CssClass="@cssClass"
+                        ElementBaseTreeRowViewModel="@dataItem"
+                        ShowOwner="@this.ShowOwner"
+                        ShowCategories="@this.ShowCategories"/>
                 }
             </CascadingValue>
 

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-//  <copyright file="ElementDefinitionTable.razor.cs" company="Starion Group S.A.">
+//  <copyright file="ElementDefinitionTree.razor.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 // 
 //     This file is part of COMET WEB Community Edition
@@ -30,6 +30,7 @@ namespace COMETwebapp.Components.ModelEditor
     using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
 
     /// <summary>
     /// Support class for the <see cref="ElementDefinitionTree" /> component
@@ -61,6 +62,18 @@ namespace COMETwebapp.Components.ModelEditor
         public bool IsModelSelectionEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the owning domain of expertise pill is shown on each node
+        /// </summary>
+        [Parameter]
+        public bool ShowOwner { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown on each node
+        /// </summary>
+        [Parameter]
+        public bool ShowCategories { get; set; } = true;
+
+        /// <summary>
         /// Fires after node selection has been changed for a specific item.
         /// </summary>
         [Parameter]
@@ -79,10 +92,11 @@ namespace COMETwebapp.Components.ModelEditor
         public EventCallback<(ElementDefinitionTree, ElementBaseTreeRowViewModel)> OnDragEnd { get; set; } = new();
 
         /// <summary>
-        /// Fires after node drop has been executed on a specific item.
+        /// Fires after node drop has been executed on a specific item. The <see cref="DragEventArgs" /> is passed along so that
+        /// the handler can read the modifier keys that were held, which select the copy mode.
         /// </summary>
         [Parameter]
-        public EventCallback<(ElementDefinitionTree, ElementBaseTreeRowViewModel)> OnDrop { get; set; } = new();
+        public EventCallback<(ElementDefinitionTree, ElementBaseTreeRowViewModel, DragEventArgs)> OnDrop { get; set; } = new();
 
         /// <summary>
         /// Fires after node drag-over has been started for a specific item.
@@ -234,14 +248,15 @@ namespace COMETwebapp.Components.ModelEditor
         /// Is executed when a node has been dropped onto another node
         /// </summary>
         /// <param name="node">The node where the dragged node has been dropped onto</param>
+        /// <param name="eventArgs">The <see cref="DragEventArgs"/> of the drop, which carries the modifier keys that were held</param>
         /// <returns>an awaitable <see cref="Task"/></returns>
-        private async Task DropAsync(ElementBaseTreeRowViewModel node)
+        private async Task DropAsync(ElementBaseTreeRowViewModel node, DragEventArgs eventArgs)
         {
             this.dragOverNode = null;
 
             if (this.AllowDrop)
             {
-                await this.OnDrop.InvokeAsync((this, node));
+                await this.OnDrop.InvokeAsync((this, node, eventArgs));
                 await this.OnCalculateDropIsAllowed.InvokeAsync(this);
                 this.Logger.LogDebug("Drop");
             }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
@@ -1,5 +1,13 @@
-﻿.sticky-scrollable-column {
+/* ::deep is required: the class sits on DxTreeView, which is a child component, so a plain scoped
+   rule would never reach it. */
+::deep .sticky-scrollable-column {
     position: sticky;
     top: 0px;
-    overflow: hidden;
+    /* Lay the tree out at its natural width so that a deeply nested or long-named node overflows the
+       panel and the scroll area scrolls to it, rather than being squeezed into the panel width (issue #742). */
+    min-width: max-content;
+}
+
+::deep .sticky-scrollable-column .dxbl-treeview-item-text {
+    white-space: nowrap;
 }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
@@ -17,21 +17,37 @@
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
+@using COMETwebapp.Extensions
+@using COMETwebapp.Utilities
+
 <div class="@this.CssClass" style="display: flex; justify-content: space-between; align-items: center;" @attributes="this.AdditionalAttributes">
     <span>
         <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="ElementName" />
     </span>
     <span style="text-align: end;">
-        <span>
-            <button class="starion-pill" title="Owning Domain Of Expertise: @this.ElementBaseTreeRowViewModel.OwnerShortName"><CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="OwnerShortName" /></button>
-        </span>
-        @foreach (var categoryShortName in this.ElementBaseTreeRowViewModel.ElementBase.GetAllCategories().Select(x => x.ShortName))
+        @if (this.ShowOwner)
         {
             <span>
-                <button class="starion-pill" style="background-color:aliceblue !important;" title="Category: @categoryShortName">
-                    <CardField Context="@categoryShortName" />
+                <button class="starion-pill"
+                        title="Owning Domain Of Expertise: @this.ElementBaseTreeRowViewModel.OwnerShortName"
+                        style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.ElementBaseTreeRowViewModel.OwnerShortName}") !important;">
+                    <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="OwnerShortName"/>
                 </button>
             </span>
+        }
+     
+        @if (this.ShowCategories)
+        {
+            @foreach (var categoryShortName in this.ElementBaseTreeRowViewModel.ElementBase.GetDisplayCategories().Select(x => x.ShortName))
+            {
+                <span>
+                    <button class="starion-pill"
+                            title="Category: @categoryShortName"
+                            style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{categoryShortName}") !important;">
+                        <CardField Context="@categoryShortName"/>
+                    </button>
+                </span>
+            }
         }
     </span>
 </div>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
@@ -40,7 +40,7 @@
         {
             @foreach (var categoryShortName in this.ElementBaseTreeRowViewModel.ElementBase.GetDisplayCategories().Select(x => x.ShortName))
             {
-                <span>
+                <span @key="categoryShortName">
                     <button class="starion-pill"
                             title="Category: @categoryShortName"
                             style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{categoryShortName}") !important;">

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor.cs
@@ -44,6 +44,18 @@ namespace COMETwebapp.Components.ModelEditor
         public ElementBaseTreeRowViewModel ElementBaseTreeRowViewModel { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the owning domain of expertise pill is shown
+        /// </summary>
+        [Parameter]
+        public bool ShowOwner { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown
+        /// </summary>
+        [Parameter]
+        public bool ShowCategories { get; set; } = true;
+
+        /// <summary>
         /// Handle unmatched values, like "draggable" html attribute, so no error is thrown
         /// </summary>
         [Parameter(CaptureUnmatchedValues = true)]

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -25,23 +25,43 @@
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
     <div class="model-editor-root">
     <div style="padding-bottom:5px;">
-        @if (!this.ViewModel.IsSourceModelSameAsTargetModel)
+        @if (this.ViewModel.IsSourceModelSameAsTargetModel)
+        {
+            <span title="Copy mode for copying ElementDefinitions inside the same Iteration. The modifier keys do not apply here: the SDK cannot copy an ElementDefinition into its own Iteration, so this copy always resets the parameter values and keeps the original owner.">
+                Copy mode to same Iteration: @(new CopyOperationKinds().CopyToSameModelDefaultText)
+            </span>
+        }
+        else
         {
             <span title="Select copy mode settings for copying ElementDefinitions from one model to the other">
                 <DxButton Click="() => { this.ViewModel.OpenCopySettingsPopup(); }" CssClass="drop-area-background-color" title="Open drop settings" IconCssClass="oi oi-transfer"></DxButton>
             </span>
-            <span title="Selected copy mode for copying ElementDefinitions to another Iteration">
-                Copy mode to different Iteration: @this.ViewModel.CopySettingsViewModel.SelectedOperationKindDescription,
+            <span title="Selected copy mode for copying ElementDefinitions to another Iteration. Hold Ctrl while dropping to keep the parameter values and take ownership, Shift to keep the original owner, or Ctrl+Shift for both.">
+                Copy mode to different Iteration: @this.ViewModel.CopySettingsViewModel.SelectedOperationKindDescription
+                <span class="model-editor-modifier-hint">(hold Ctrl / Shift / Ctrl+Shift while dropping to override)</span>
             </span>
         }
-        <span title="Copy mode for copying ElementDefinitions inside the same Iteration">
-            Copy mode to same Iteration: @(new CopyOperationKinds().CopyToSameModelDefaultText)
+        @* One setting for both trees, so that the two panels always show the same kind of node. *@
+        <span class="model-editor-display-options">
+            <DxCheckBox @bind-Checked="@this.ShowOwner">Owner</DxCheckBox>
+            <DxCheckBox @bind-Checked="@this.ShowCategories">Categories</DxCheckBox>
         </span>
     </div>
     <ValidationMessageComponent ValidationMessage="@(this.ErrorMessage)" />
     <div class="selected-data-item-page" style="flex-wrap:nowrap!important;">
-        <div class="selected-data-item-table d-flex" style="flex: 1 1 50%!important;gap: 10px;min-width:600px;">
-            <div style="width:50%; height:100%; border: dashed 1px;padding:15px;border-radius: 10px;max-width: fit-content;display:flex;flex-direction:column;min-height:0;">
+        <div class="selected-data-item-table d-flex" style="flex: 1 1 50%!important;gap: 10px;">
+            @* The panels are hidden with CSS rather than removed from the render tree: ElementDefinitionTree
+               injects a transient ViewModel that it never disposes, so unmounting it would leak that
+               ViewModel's message bus and DynamicData subscriptions on every collapse. *@
+            <div id="sourcePanel" class="model-editor-panel @(this.IsSourcePanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
+                <div class="model-editor-panel-header">
+                    <DxButton Id="collapseSourcePanel"
+                              IconCssClass="oi oi-chevron-left"
+                              RenderStyle="ButtonRenderStyle.Link"
+                              SizeMode="SizeMode.Small"
+                              Click="@(() => this.IsSourcePanelCollapsed = true)"
+                              title="Minimize the source model panel"/>
+                </div>
                 <ElementDefinitionTree
                     @ref="this.SourceTree"
                     ScrollableAreaCssClass="treeview-scrollarea"
@@ -62,11 +82,21 @@
                     OnDragStart="@(async x => await this.OnDragStartAsync(x))"
                     OnDragEnd="@(async x => await this.OnDragEndAsync())"
                     OnDrop="@(async x => await this.OnDropAsync(x))"
+                    ShowOwner="@this.ShowOwner"
+                    ShowCategories="@this.ShowCategories"
                     AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel"
                     IsModelSelectionEnabled="true">
                 </ElementDefinitionTree>
             </div>
-            <div style="width:50%; height:100%; border: dashed 1px;padding:15px;border-radius: 10px;max-width: fit-content;display:flex;flex-direction:column;min-height:0;">
+            @if (this.IsSourcePanelCollapsed)
+            {
+                <div id="expandSourcePanel" class="model-editor-collapsed-strip" title="Restore the source model panel" @onclick="@(() => this.IsSourcePanelCollapsed = false)">
+                    <span class="oi oi-chevron-right"></span>
+                    <span class="model-editor-collapsed-strip-text">Source model</span>
+                </div>
+            }
+            <div id="source-resizer" class="model-editor-resizer @(this.IsSourcePanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)" title="Drag to resize"></div>
+            <div id="targetPanel" class="model-editor-panel">
                 <ElementDefinitionTree
                     @ref="this.TargetTree"
                     ScrollableAreaCssClass="treeview-scrollarea"
@@ -87,16 +117,36 @@
                     OnDragStart="@(async x => await this.OnDragStartAsync(x))"
                     OnDragEnd="@(async x => await this.OnDragEndAsync())"
                     OnDrop="@(async x => await this.OnDropAsync(x))"
+                    ShowOwner="@this.ShowOwner"
+                    ShowCategories="@this.ShowCategories"
                     AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel"
                     IsModelSelectionEnabled="false">
                 </ElementDefinitionTree>
             </div>
-            <DataItemDetailsComponent IsSelected="@(this.ViewModel.DetailsPanelViewModel.SelectedElementDefinition is not null)"
-                                      NotSelectedText="Select an item to view or edit"
-                                      Width="100%"
-                                      CssClass="model-editor-details">
-                <ElementDetailsPanel ViewModel="this.ViewModel.DetailsPanelViewModel" />
-            </DataItemDetailsComponent>
+            <div id="target-resizer" class="model-editor-resizer @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)" title="Drag to resize"></div>
+            <div id="detailsPanel" class="model-editor-panel model-editor-panel-borderless @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
+                <div class="model-editor-panel-header model-editor-panel-header-end">
+                    <DxButton Id="collapseDetailsPanel"
+                              IconCssClass="oi oi-chevron-right"
+                              RenderStyle="ButtonRenderStyle.Link"
+                              SizeMode="SizeMode.Small"
+                              Click="@(() => this.IsDetailsPanelCollapsed = true)"
+                              title="Minimize the details panel"/>
+                </div>
+                <DataItemDetailsComponent IsSelected="@(this.ViewModel.DetailsPanelViewModel.SelectedElementDefinition is not null)"
+                                          NotSelectedText="Select an item to view or edit"
+                                          Width="100%"
+                                          CssClass="model-editor-details">
+                    <ElementDetailsPanel ViewModel="this.ViewModel.DetailsPanelViewModel"/>
+                </DataItemDetailsComponent>
+            </div>
+            @if (this.IsDetailsPanelCollapsed)
+            {
+                <div id="expandDetailsPanel" class="model-editor-collapsed-strip" title="Restore the details panel" @onclick="@(() => this.IsDetailsPanelCollapsed = false)">
+                    <span class="oi oi-chevron-left"></span>
+                    <span class="model-editor-collapsed-strip-text">Details</span>
+                </div>
+            }
         </div>
     </div>
     </div>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -24,12 +24,19 @@
 
 namespace COMETwebapp.Components.ModelEditor
 {
+    using System.ComponentModel;
+
     using CDP4Common.EngineeringModelData;
 
     using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
 
+    using COMETwebapp.Utilities;
     using COMETwebapp.ViewModels.Components.ModelEditor.Rows;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
+    using Microsoft.JSInterop;
 
     using ReactiveUI;
 
@@ -38,6 +45,16 @@ namespace COMETwebapp.Components.ModelEditor
     /// </summary>
     public partial class ModelEditor
     {
+        /// <summary>
+        /// The minimum width, in pixels, that a panel can be dragged down to
+        /// </summary>
+        private const int MinimumPanelWidth = 260;
+
+        /// <summary>
+        /// The maximum width, in pixels, that a panel can be dragged up to
+        /// </summary>
+        private const int MaximumPanelWidth = 900;
+
         /// <summary>
         /// Holds a reference to the data of the node where another node is dragged over
         /// </summary>
@@ -64,6 +81,95 @@ namespace COMETwebapp.Components.ModelEditor
         public ElementDefinitionTree TargetTree { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the source model panel is minimized, so that the target model tree gets more space
+        /// </summary>
+        public bool IsSourcePanelCollapsed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the details panel is minimized, so that the trees get more space
+        /// </summary>
+        public bool IsDetailsPanelCollapsed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owning domain of expertise pill is shown on the nodes of both trees.
+        /// The setting is held here, and not per tree, so that the source and the target panel always show the same thing.
+        /// </summary>
+        public bool ShowOwner { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown on the nodes of both trees
+        /// </summary>
+        public bool ShowCategories { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the <see cref="IJSRuntime" /> used to initialise the column resizers
+        /// </summary>
+        [Inject]
+        public IJSRuntime JsRuntime { get; set; }
+
+        /// <summary>
+        /// Subscribes to the iteration of both trees and initialises the drag-to-resize handles that sit between the source tree,
+        /// the target tree and the details panel, on first render
+        /// </summary>
+        /// <param name="firstRender"><see langword="true" /> on the first render cycle.</param>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (!firstRender)
+            {
+                return;
+            }
+
+            this.SubscribeToTreeIterations();
+
+            await this.InitialiseResizerAsync("source-resizer", "sourcePanel");
+            await this.InitialiseResizerAsync("target-resizer", "targetPanel");
+        }
+
+        /// <summary>
+        /// Subscribes to the <see cref="IElementDefinitionTreeViewModel.Iteration" /> of both trees, so that the ViewModel knows
+        /// which iteration each panel shows and can tell whether a copy between the panels crosses iterations.
+        /// This has to happen on the first render and not in <see cref="OnViewModelAssigned" />: the trees are captured with
+        /// @ref, so they are still null while the parameters are set, and a component is not an
+        /// <see cref="INotifyPropertyChanged" />, which means a WhenAnyValue over this.SourceTree would read that null once and
+        /// never see the tree appear.
+        /// </summary>
+        private void SubscribeToTreeIterations()
+        {
+            this.Disposables.Add(this.SourceTree.ViewModel.WhenAnyValue(x => x.Iteration).SubscribeAsync(x =>
+            {
+                this.ViewModel.SourceIteration = x;
+                return this.InvokeAsync(this.StateHasChanged);
+            }));
+
+            this.Disposables.Add(this.TargetTree.ViewModel.WhenAnyValue(x => x.Iteration).SubscribeAsync(x =>
+            {
+                this.ViewModel.TargetIteration = x;
+                return this.InvokeAsync(this.StateHasChanged);
+            }));
+        }
+
+        /// <summary>
+        /// Initialises a single drag-to-resize handle, tolerating the JS interop being unavailable
+        /// </summary>
+        /// <param name="resizerId">The id of the resize handle</param>
+        /// <param name="panelId">The id of the panel that the handle resizes</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task InitialiseResizerAsync(string resizerId, string panelId)
+        {
+            try
+            {
+                await this.JsRuntime.InvokeVoidAsync("cometResizer.init", resizerId, panelId, MinimumPanelWidth, MaximumPanelWidth);
+            }
+            catch (Exception)
+            {
+                // JS interop failures during pre-rendering or test environments are non-fatal.
+            }
+        }
+
+        /// <summary>
         /// Handles the post-assignement flow of the <see cref="ApplicationBase{TViewModel}.ViewModel" /> property
         /// </summary>
         protected override void OnViewModelAssigned()
@@ -72,18 +178,6 @@ namespace COMETwebapp.Components.ModelEditor
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnCopySettingsMode).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsSourceModelSameAsTargetModel).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
-
-            this.Disposables.Add(this.WhenAnyValue(x => x.SourceTree.ViewModel.Iteration).SubscribeAsync(x =>
-            {
-                this.ViewModel.SourceIteration = x;
-                return this.InvokeAsync(this.StateHasChanged);
-            }));
-
-            this.Disposables.Add(this.WhenAnyValue(x => x.TargetTree.ViewModel.Iteration).SubscribeAsync(x =>
-            {
-                this.ViewModel.TargetIteration = x;
-                return this.InvokeAsync(this.StateHasChanged);
-            }));
         }
 
         /// <summary>
@@ -127,9 +221,12 @@ namespace COMETwebapp.Components.ModelEditor
         /// <summary>
         /// Is executed when a dragged node (<see cref="ElementBaseTreeRowViewModel"/>) has been dropped onto another element in a specific <see cref="ElementDefinitionTree"/>
         /// </summary>
-        /// <param name="nodeData">A <see cref="Tuple"/> that contains the specific <see cref="ElementDefinitionTree"/> and the specific node (<see cref="ElementBaseTreeRowViewModel"/>)</param>
+        /// <param name="nodeData">
+        /// A <see cref="Tuple"/> that contains the specific <see cref="ElementDefinitionTree"/>, the specific node
+        /// (<see cref="ElementBaseTreeRowViewModel"/>) and the <see cref="DragEventArgs"/> of the drop
+        /// </param>
         /// <returns>an awaitable <see cref="Task"/></returns>
-        private async Task OnDropAsync((ElementDefinitionTree, ElementBaseTreeRowViewModel) nodeData)
+        private async Task OnDropAsync((ElementDefinitionTree, ElementBaseTreeRowViewModel, DragEventArgs) nodeData)
         {
             this.ErrorMessage = string.Empty;
 
@@ -143,7 +240,7 @@ namespace COMETwebapp.Components.ModelEditor
                 if (nodeData.Item2 == null)
                 {
                     // Drop in the same model
-                    await this.ViewModel.CopyAndAddNewElementAsync(nodeData.Item1, elementDefinitionTreeRowViewModel.ElementBase);
+                    await this.ViewModel.CopyAndAddNewElementAsync(nodeData.Item1, elementDefinitionTreeRowViewModel.ElementBase, nodeData.Item3.GetCopyOperationKind());
                 }
                 else
                 {

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -32,6 +32,7 @@ namespace COMETwebapp.Components.ModelEditor
     using COMET.Web.Common.Extensions;
 
     using COMETwebapp.Utilities;
+    using COMETwebapp.ViewModels.Components.ModelEditor;
     using COMETwebapp.ViewModels.Components.ModelEditor.Rows;
 
     using Microsoft.AspNetCore.Components;

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
@@ -18,6 +18,128 @@
     min-height: 0;
 }
 
+.model-editor-modifier-hint {
+    color: #64748b;
+    font-size: 0.8rem;
+}
+
+/* The Owner / Categories check boxes sit inline in the toolbar, next to the copy mode text. */
+.model-editor-display-options {
+    display: inline-flex;
+    gap: 8px;
+    margin-left: 16px;
+    font-size: 0.875rem;
+    vertical-align: middle;
+}
+
+/* The source tree, the target tree and the details panel are equal-share flex columns, so that
+   minimizing one of them hands its space to the ones that stay open (see issue #742). */
+.model-editor-panel {
+    flex: 1 1 0;
+    min-width: 260px;
+    min-height: 0;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    border: dashed 1px;
+    padding: 15px;
+    border-radius: 10px;
+}
+
+.model-editor-panel-borderless {
+    border: none;
+    padding: 0;
+}
+
+/* A minimized panel stays mounted (its ViewModel owns subscriptions that nothing would dispose on
+   unmount) and is only hidden, so its space goes to the panels that are still open. */
+.model-editor-panel-collapsed {
+    display: none;
+}
+
+.model-editor-panel-header {
+    flex: 0 0 auto;
+    display: flex;
+}
+
+.model-editor-panel-header-end {
+    justify-content: flex-end;
+}
+
+/* A minimized panel collapses to a clickable vertical strip that restores it. */
+.model-editor-collapsed-strip {
+    flex: 0 0 28px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 4px;
+    cursor: pointer;
+    border: dashed 1px;
+    border-radius: 10px;
+    background: #f8fafc;
+}
+
+.model-editor-collapsed-strip:hover {
+    background: #e2e8f0;
+}
+
+.model-editor-collapsed-strip-text {
+    writing-mode: vertical-rl;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    color: #475569;
+}
+
+/* Drag-to-resize handle between two panels, driven by wwwroot/js/columnResizer.js — the same handle the
+   System Representation page uses between the product tree and the details panel. */
+.model-editor-resizer {
+    flex: 0 0 6px;
+    align-self: stretch;
+    cursor: col-resize;
+    background: #e2e8f0;
+    border-radius: 3px;
+}
+
+.model-editor-resizer:hover {
+    background: #94a3b8;
+}
+
+/* Narrow window (a half or quarter-screen browser): three side-by-side panels no longer fit, so they stack
+   vertically and the whole row scrolls, instead of being squeezed past the point of usability. */
+@media (max-width: 1200px) {
+    ::deep .selected-data-item-table {
+        flex-direction: column;
+        overflow-y: auto;
+    }
+
+    .model-editor-panel {
+        /* !important is needed because columnResizer.js writes flex and max-width as inline styles on the
+           panel, and an inline style would otherwise win over this rule once the panels stack. */
+        flex: 0 0 auto !important;
+        max-width: none !important;
+        width: 100%;
+        min-width: 0;
+        height: auto;
+        min-height: 320px;
+    }
+
+    .model-editor-resizer {
+        display: none;
+    }
+
+    .model-editor-collapsed-strip {
+        flex-direction: row;
+        width: 100%;
+        justify-content: flex-start;
+        gap: 6px;
+    }
+
+    .model-editor-collapsed-strip-text {
+        writing-mode: horizontal-tb;
+    }
+}
+
 /* Tree scroll area fills its (flex-column) column instead of a fixed vh height. */
 ::deep .treeview-scrollarea {
     flex: 1 1 auto;
@@ -32,8 +154,8 @@
 /* Details panel: a fixed-height flex column so the Add buttons, element summary and parameter
    search bar stay put and only the parameter groups scroll (mirrors the System Representation panel). */
 ::deep .data-items-panel-container.model-editor-details {
-    height: 100%;
-    max-height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     position: static;
     display: flex;
     flex-direction: column;

--- a/COMETwebapp/Shared/SideBar.razor
+++ b/COMETwebapp/Shared/SideBar.razor
@@ -19,13 +19,15 @@
 ------------------------------------------------------------------------------->
 @using COMET.Web.Common.Shared.TopMenuEntry
 
-<nav class="@($"{(this.Collapsed ? "collapsed" : "")} main-side-bar")">
-    <div class="@(this.Collapsed ? "text-center" : "text-end")">
+<DxLayoutBreakpoint MaxWidth="1200" @bind-IsActive="@this.IsNarrowViewport"/>
+
+<nav class="@($"{(this.IsCollapsed ? "collapsed" : "")} main-side-bar")">
+    <div class="@(this.IsCollapsed ? "text-center" : "text-end")">
         <DxButton Text="Collapse"
-                  Click="@(() => this.Collapsed = !this.Collapsed)"
+                  Click="@this.ToggleCollapsed"
                   RenderStyle="ButtonRenderStyle.None"
                   Id="side-bar-collapse-button">
-            @if (this.Collapsed)
+            @if (this.IsCollapsed)
             {
                 <FeatherArrowRight Size="24"
                                    Color="currentColor"

--- a/COMETwebapp/Shared/SideBar.razor.cs
+++ b/COMETwebapp/Shared/SideBar.razor.cs
@@ -38,8 +38,49 @@ namespace COMETwebapp.Shared
         public IRegistrationService RegistrationService { get; set; }
 
         /// <summary>
-        /// Gets or sets the value to check if the sidebar is collapsed
+        /// Backing field for <see cref="IsNarrowViewport" />
         /// </summary>
-        public bool Collapsed { get; private set; }
+        private bool isNarrowViewport;
+
+        /// <summary>
+        /// The collapsed state that the user explicitly chose with the toggle, or null while they have not overruled the state
+        /// that the viewport width implies
+        /// </summary>
+        private bool? userCollapsed;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the viewport is too narrow to afford the full width menu, for instance when
+        /// the browser only takes a quarter of the screen. Crossing that threshold drops any earlier manual override, so that
+        /// the side bar collapses on its own when the window shrinks and expands again when it grows.
+        /// </summary>
+        public bool IsNarrowViewport
+        {
+            get => this.isNarrowViewport;
+
+            set
+            {
+                if (this.isNarrowViewport == value)
+                {
+                    return;
+                }
+
+                this.isNarrowViewport = value;
+                this.userCollapsed = null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the sidebar is rendered collapsed. A narrow viewport collapses it by default, but the
+        /// user can always overrule that with the toggle, in either direction (issue #742)
+        /// </summary>
+        public bool IsCollapsed => this.userCollapsed ?? this.IsNarrowViewport;
+
+        /// <summary>
+        /// Toggles the collapsed state of the side bar
+        /// </summary>
+        public void ToggleCollapsed()
+        {
+            this.userCollapsed = !this.IsCollapsed;
+        }
     }
 }

--- a/COMETwebapp/Shared/SideBar.razor.cs
+++ b/COMETwebapp/Shared/SideBar.razor.cs
@@ -57,16 +57,23 @@ namespace COMETwebapp.Shared
         {
             get => this.isNarrowViewport;
 
-            set
-            {
-                if (this.isNarrowViewport == value)
-                {
-                    return;
-                }
+            set => this.SetNarrowViewport(value);
+        }
 
-                this.isNarrowViewport = value;
-                this.userCollapsed = null;
+        /// <summary>
+        /// Sets the <see cref="IsNarrowViewport" /> backing field. Crossing the threshold drops any earlier manual
+        /// override so that the side bar follows the viewport width again.
+        /// </summary>
+        /// <param name="value">The new narrow-viewport state</param>
+        private void SetNarrowViewport(bool value)
+        {
+            if (this.isNarrowViewport == value)
+            {
+                return;
             }
+
+            this.isNarrowViewport = value;
+            this.userCollapsed = null;
         }
 
         /// <summary>

--- a/COMETwebapp/Utilities/DragEventArgsExtensions.cs
+++ b/COMETwebapp/Utilities/DragEventArgsExtensions.cs
@@ -1,0 +1,54 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DragEventArgsExtensions.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Utilities
+{
+    using CDP4DalCommon.Protocol.Operations;
+
+    using Microsoft.AspNetCore.Components.Web;
+
+    /// <summary>
+    /// Extension methods for the <see cref="DragEventArgs" />
+    /// </summary>
+    public static class DragEventArgsExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="OperationKind" /> that the modifier keys held during a drag-and-drop operation ask for.
+        /// The mapping mirrors the COMET IME, so that the muscle memory of its users carries over.
+        /// </summary>
+        /// <param name="eventArgs">The <see cref="DragEventArgs" /> of the drop</param>
+        /// <returns>
+        /// The requested <see cref="OperationKind" />, or null when no modifier key is held, in which case the copy mode
+        /// that the user selected in the copy settings applies
+        /// </returns>
+        public static OperationKind? GetCopyOperationKind(this DragEventArgs eventArgs)
+        {
+            return (eventArgs.CtrlKey, eventArgs.ShiftKey) switch
+            {
+                (true, false) => OperationKind.CopyKeepValuesChangeOwner,
+                (false, true) => OperationKind.Copy,
+                (true, true) => OperationKind.CopyKeepValues,
+                _ => null
+            };
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
@@ -88,6 +88,13 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
         public bool IsCurrentModelOpened => this.sessionService.OpenEngineeringModels.Any(x => x.EngineeringModelSetup == this.SelectedEngineeringModel);
 
         /// <summary>
+        /// Gets a value indicating that an already open <see cref="Iteration" /> may be selected. Opening a tab on an iteration
+        /// that is already open is the normal way to show that same iteration in another view, for instance the Model Editor and
+        /// the System Representation side by side, so the iteration is not opened again, only a new tab is created.
+        /// </summary>
+        protected override bool CanSelectAlreadyOpenIteration => true;
+
+        /// <summary>
         /// Gets the <see cref="DomainOfExpertise" /> from the <see cref="OpenModelViewModel.SelectedIterationSetup" />
         /// </summary>
         public DomainOfExpertise SelectedIterationDomainOfExpertise => this.sessionService.GetDomainOfExpertise(this.SelectedEngineeringModelIteration);

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModel.cs
@@ -77,7 +77,6 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         {
             this.sessionService = sessionService;
             this.RegisterViewModelWithReusableRows(this);
-            this.Iterations.Add(null);
 
             this.Disposables.Add(this.WhenAnyValue(x => x.SelectedIterationData).Subscribe(x => this.Iteration = this.sessionService.OpenIterations.Items.SingleOrDefault(y => y.IterationSetup.Iid == x?.IterationSetupId)));
 

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
@@ -24,6 +24,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
 {
     using CDP4Common.EngineeringModelData;
 
+    using CDP4DalCommon.Protocol.Operations;
+
     using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Components.ModelEditor;
@@ -75,7 +77,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// </summary>
         /// <param name="elementDefinitionTree">The <see cref="ElementDefinitionTree"/> to copy the node to</param>
         /// <param name="elementBase">The <see cref="ElementBase"/> to copy</param>
-        Task CopyAndAddNewElementAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase);
+        /// <param name="operationKind">
+        /// The <see cref="OperationKind"/> requested by the modifier keys that were held during the drop, or null to use the
+        /// copy mode that the user selected in the copy settings
+        /// </param>
+        Task CopyAndAddNewElementAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase, OperationKind? operationKind = null);
 
         /// <summary>
         /// Add a new <see cref="ElementUsage"/> based on an existing <see cref="ElementBase"/>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -177,12 +177,16 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// </summary>
         /// <param name="elementDefinitionTree">The <see cref="ElementDefinitionTree"/> to copy the node to</param>
         /// <param name="elementBase">The <see cref="ElementBase"/> to copy</param>
-        public Task CopyAndAddNewElementAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase)
+        /// <param name="operationKind">
+        /// The <see cref="OperationKind"/> requested by the modifier keys that were held during the drop, or null to use the
+        /// copy mode that the user selected in the copy settings
+        /// </param>
+        public Task CopyAndAddNewElementAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase, OperationKind? operationKind = null)
         {
             ArgumentNullException.ThrowIfNull(elementDefinitionTree);
             ArgumentNullException.ThrowIfNull(elementBase);
 
-            return this.CopyAndAddNewElementImplAsync(elementDefinitionTree, elementBase);
+            return this.CopyAndAddNewElementImplAsync(elementDefinitionTree, elementBase, operationKind);
         }
 
         /// <summary>
@@ -190,30 +194,46 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// </summary>
         /// <param name="elementDefinitionTree">The <see cref="ElementDefinitionTree"/> to copy the node to</param>
         /// <param name="elementBase">The <see cref="ElementBase"/> to copy</param>
-        private async Task CopyAndAddNewElementImplAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase)
+        /// <param name="requestedOperationKind">
+        /// The <see cref="OperationKind"/> requested by the modifier keys that were held during the drop, or null to use the
+        /// copy mode that the user selected in the copy settings
+        /// </param>
+        private async Task CopyAndAddNewElementImplAsync(ElementDefinitionTree elementDefinitionTree, ElementBase elementBase, OperationKind? requestedOperationKind)
         {
             this.IsLoading = true;
 
             try
             {
-                if (elementBase.GetContainerOfType<Iteration>() == elementDefinitionTree.ViewModel.Iteration)
+                var targetIteration = elementDefinitionTree.ViewModel.Iteration;
+                
+                if (elementBase.GetContainerOfType<Iteration>() == targetIteration)
                 {
-                    var copyCreator = new CopyElementDefinitionCreator(this.sessionService.Session);
-                    await copyCreator.CopyAsync((ElementDefinition)elementBase, true);
+                    var copyElementDefinitionCreator = new CopyElementDefinitionCreator(this.sessionService.Session);
+                    await copyElementDefinitionCreator.CopyAsync((ElementDefinition)elementBase, true);
                 }
                 else
                 {
                     var copyCreator = new CopyCreator(this.sessionService.Session);
 
-                    this.cacheService.TryGetOrAddBrowserSessionSetting(BrowserSessionSettingKey.CopyElementDefinitionOperationKind, OperationKind.Copy, out var selectedOperationKind);
-
-                    await copyCreator.CopyAsync((ElementDefinition)elementBase, elementDefinitionTree.ViewModel.Iteration, selectedOperationKind is OperationKind operationKind ? operationKind : OperationKind.Copy);
+                    await copyCreator.CopyAsync((ElementDefinition)elementBase, targetIteration, requestedOperationKind ?? this.GetSelectedCopyOperationKind());
                 }
             }
             finally
             {
                 this.IsLoading = false;
             }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="OperationKind"/> that the user selected in the copy settings, which applies when a drop is
+        /// performed without holding any modifier key
+        /// </summary>
+        /// <returns>The selected <see cref="OperationKind"/></returns>
+        private OperationKind GetSelectedCopyOperationKind()
+        {
+            this.cacheService.TryGetOrAddBrowserSessionSetting(BrowserSessionSettingKey.CopyElementDefinitionOperationKind, OperationKind.Copy, out var selectedOperationKind);
+
+            return selectedOperationKind is OperationKind operationKind ? operationKind : OperationKind.Copy;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -204,9 +204,9 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
 
             try
             {
-                var targetIteration = elementDefinitionTree.ViewModel.Iteration;
-                
-                if (elementBase.GetContainerOfType<Iteration>() == targetIteration)
+                var iterationOfTargetTree = elementDefinitionTree.ViewModel.Iteration;
+
+                if (elementBase.GetContainerOfType<Iteration>() == iterationOfTargetTree)
                 {
                     var copyElementDefinitionCreator = new CopyElementDefinitionCreator(this.sessionService.Session);
                     await copyElementDefinitionCreator.CopyAsync((ElementDefinition)elementBase, true);
@@ -215,7 +215,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 {
                     var copyCreator = new CopyCreator(this.sessionService.Session);
 
-                    await copyCreator.CopyAsync((ElementDefinition)elementBase, targetIteration, requestedOperationKind ?? this.GetSelectedCopyOperationKind());
+                    await copyCreator.CopyAsync((ElementDefinition)elementBase, iterationOfTargetTree, requestedOperationKind ?? this.GetSelectedCopyOperationKind());
                 }
             }
             finally


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Completes the outstanding Model Editor work #742 #726 #727 #735 #739 #740 and made it look more similar to the system representation page.: user-adaptable panel layout, IME-style copy modifiers,
coloured owner/category pills, and fixes to opening models and tabs. Also fixes three latent bugs
found along the way that already existed on `development`.

Fix #742
Fix #726
Fix #739

---

### #742: Screen layout adaptions by the user

- The source tree, target tree and details panel are now **equal-share flex columns** with
  **drag-to-resize dividers** between them, reusing the existing `cometResizer` helper
  (`COMETwebapp/wwwroot/js/columnResizer.js`) that the System Representation product tree already uses.
- The source panel and the details panel can each be **minimized to a clickable strip**, giving the
  target model the space.
- Both trees now **scroll horizontally**, so deeply nested and long-named nodes stay reachable.
- The layout **stacks vertically below 1200px**, so a half-screen or quarter-screen window remains usable.
- Addresses the issue's *"please investigate to make the application menu less wide"*: the side bar
  **auto-collapses to its icon-only rail on narrow viewports** (310px to 130px), using the
  `DxLayoutBreakpoint` that `SidebarLayout.razor` already declared but never bound. It stays manually
  expandable, and resizing the window drops the manual override.

### #726: Allow a user to select the source model

The source-model selector already existed. The **IME copy modifiers** did not, and are now added:

| Drag with | OperationKind | Values | Owner |
|---|---|---|---|
| *(no modifier)* | the Copy Settings choice | n/a | n/a |
| `Ctrl` | `CopyKeepValuesChangeOwner` | kept | becomes yours |
| `Shift` | `Copy` | reset to default | original kept |
| `Ctrl` + `Shift` | `CopyKeepValues` | kept | original kept |

The mapping mirrors the IME exactly (`CDP4Composition/DragDrop/DragDropKeyStatesExtensions.cs`), which uses
Ctrl/Shift. All four `OperationKind`s already existed in the SDK and in `CopySettingsViewModel`,
so this is wiring rather than new copy logic. With no modifier held the drop still uses the Copy Settings
choice, so existing behaviour is unchanged.

**Known limitation (by design):** Same-iteration drops keep using `CopyElementDefinitionCreator`, which has a single fixed mode: values reset, owner kept. The toolbar now states which mode applies to the current pair of panels.

### #739: Prevent opening an already-open Iteration

Two independent causes:

1. `OpenModel.razor` bound the button straight to `Click="@(this.ViewModel.OpenSession)"`. Blazor's
   `EventCallback` **silently discards the returned `Task<Result>`**, so the "already opened" failure was
   being computed and then thrown away. That is why clicking Open appeared to do nothing. It is now surfaced
   through `ValidationMessageComponent`.
2. The already-open iteration was still being restored from the `LastUsedIterationData` browser-session
   cache, bypassing the availability filter. That is now guarded.

**Opening a second _view_ on an already-open iteration still works** (Model Editor, System Representation and
Parameter Editor side by side). `OpenTabViewModel` extends `OpenModelViewModel` but has the opposite
requirement, so the rule is now an explicit `protected virtual bool CanSelectAlreadyOpenIteration`: `false`
for Open Model, overridden to `true` for Open Tab.

---

### Other changes

- **Owner and category pills** on tree nodes use `TagColorGenerator` (the same hashed palette as the details
  panel) and `GetDisplayCategories()`, so **super categories are no longer shown**. A single pair of
  Owner/Categories check boxes in the toolbar toggles them for **both** trees.
- The source-model dropdown no longer contains an **empty entry** (`ElementDefinitionTreeViewModel` was
  seeding `Iterations` with a `null`).

### Pre-existing bugs fixed

- **`WhenAnyValue` over a Blazor `@ref` never fires.** `ModelEditor.razor.cs` subscribed via
  `WhenAnyValue(x => x.SourceTree.ViewModel.Iteration)` from `OnViewModelAssigned()`, which runs *before* the
  first render. A component is not `INotifyPropertyChanged` and the `@ref` is still `null` at that point, so
  ReactiveUI read `null` once and never re-attached. `SourceIteration` stayed null, so the Model Editor
  announced the *different*-Iteration copy mode even when both panels held the same iteration. It was
  intermittent, depending on render timing, and reliably wrong after closing and reopening the tab. It is now
  subscribed on the first render, against the tree's ViewModel.
- **Invalid markup in `ElementDefinitionTree.razor`**: the search box was wrapped in
  `<p><table><tr><td>...</td></tr></table></p>`. A `<p>` cannot contain a `<table>`, so the parser implicitly
  closed the paragraph and the `</p>` matched nothing. Replaced with a `<div>`. The same line used
  `visibility:block`, which is not a valid `visibility` value, meaning `AllowSearch="false"` would not
  actually have hidden the search box. It is now `visibility:visible`.

### Also closeable: already implemented on `development`, never closed

Not changed by this PR. Listed so they can be closed with evidence rather than credited here.

| Issue | Evidence |
|---|---|
| **#727** Replace the ED/EU grid with a tree | `COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor` is a `DxTreeView` of ElementDefinitions with nested ElementUsages. Selecting a node drives the parameter, override and subscription panel. |
| **#735** Show the selected ED/EU's own properties | The summary card in `COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor` renders name, shortname, owner and definition[0], which is all four boxes ticked in the issue. Closed in #786  |
| **#740** System Representation parameter table scrolls out of view | The System Representation refactor made both columns sticky flex columns that scroll internally, so the parameter table no longer leaves the viewport. Closed in #786  |

<img width="940" height="553" alt="image" src="https://github.com/user-attachments/assets/d9e82375-6d64-4f82-a52a-a433235e48e3" />




