### PR TITLE
Fix #799 Fixed the 4 causes that panels in splitview dit not refresh when updates where made.

### DIFF
--- a/COMET.Web.Common/Components/Applications/ApplicationBase.razor.cs
+++ b/COMET.Web.Common/Components/Applications/ApplicationBase.razor.cs
@@ -81,15 +81,16 @@ namespace COMET.Web.Common.Components.Applications
         {
             base.OnParametersSet();
 
-            if (this.ViewModel != null && this.ParameterizedViewModel == null)
+            if (this.ViewModel != null && (this.ParameterizedViewModel == null || ReferenceEquals(this.ViewModel, this.ParameterizedViewModel)))
             {
                 return;
             }
 
             this.ViewModel = this.ParameterizedViewModel ?? this.InjectedViewModel;
 
-            if (this.ParameterizedViewModel != null && this.InjectedViewModel != null)
+            if (this.InjectedViewModel != null && !ReferenceEquals(this.InjectedViewModel, this.ViewModel))
             {
+                this.InjectedViewModel.IsAllowedToDispose = true;
                 this.InjectedViewModel.Dispose();
                 this.InjectedViewModel = default;
             }

--- a/COMETwebapp.Tests/Components/Tabs/TabsPanelComponentTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Tabs/TabsPanelComponentTestFixture.cs
@@ -101,7 +101,7 @@ namespace COMETwebapp.Tests.Components.Tabs
 
             this.mainPanel = new TabPanelInformation();
             this.mainPanel.OpenTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
-            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items.First();
+            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items[0];
 
             this.viewModel.Setup(x => x.MainPanel).Returns(this.mainPanel);
             this.viewModel.Setup(x => x.SidePanel).Returns(this.sidePanel);
@@ -167,8 +167,8 @@ namespace COMETwebapp.Tests.Components.Tabs
             {
                 Assert.That(this.mainPanel.OpenTabs, Has.Count.EqualTo(2));
                 Assert.That(this.sidePanel.OpenTabs, Has.Count.EqualTo(0));
-                Assert.That(this.mainPanel.OpenTabs.Items.First(), Is.Not.EqualTo(newTab));
-                Assert.That(this.mainPanel.OpenTabs.Items.ElementAt(1), Is.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[0], Is.Not.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[1], Is.EqualTo(newTab));
             });
 
             var sortableList = this.renderer.FindComponent<SortableList<TabbedApplicationInformation>>();
@@ -177,19 +177,19 @@ namespace COMETwebapp.Tests.Components.Tabs
             Assert.Multiple(() =>
             {
                 Assert.That(this.mainPanel.OpenTabs, Has.Count.EqualTo(2));
-                Assert.That(this.mainPanel.OpenTabs.Items.First(), Is.EqualTo(newTab));
-                Assert.That(this.mainPanel.OpenTabs.Items.ElementAt(1), Is.Not.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[0], Is.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[1], Is.Not.EqualTo(newTab));
             });
 
             await this.renderer.InvokeAsync(() => sortableList.Instance.OnRemove.InvokeAsync((0, 0)));
-            this.sidePanel.CurrentTab = this.sidePanel.OpenTabs.Items.First();
+            this.sidePanel.CurrentTab = this.sidePanel.OpenTabs.Items[0];
 
             Assert.Multiple(() =>
             {
                 Assert.That(this.mainPanel.OpenTabs, Has.Count.EqualTo(1));
                 Assert.That(this.sidePanel.OpenTabs, Has.Count.EqualTo(1));
-                Assert.That(this.mainPanel.OpenTabs.Items.First(), Is.Not.EqualTo(newTab));
-                Assert.That(this.sidePanel.OpenTabs.Items.First(), Is.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[0], Is.Not.EqualTo(newTab));
+                Assert.That(this.sidePanel.OpenTabs.Items[0], Is.EqualTo(newTab));
             });
 
             this.renderer.Render(parameters =>
@@ -204,7 +204,7 @@ namespace COMETwebapp.Tests.Components.Tabs
             {
                 Assert.That(this.mainPanel.OpenTabs, Has.Count.EqualTo(2));
                 Assert.That(this.sidePanel.OpenTabs, Has.Count.EqualTo(0));
-                Assert.That(this.mainPanel.OpenTabs.Items.First(), Is.EqualTo(newTab));
+                Assert.That(this.mainPanel.OpenTabs.Items[0], Is.EqualTo(newTab));
             });
         }
     }

--- a/COMETwebapp.Tests/Components/Tabs/TabsPanelComponentTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Tabs/TabsPanelComponentTestFixture.cs
@@ -76,6 +76,7 @@ namespace COMETwebapp.Tests.Components.Tabs
             optionsTableViewModel.Setup(x => x.Rows).Returns(new SourceList<OptionRowViewModel>());
             optionsTableViewModel.Setup(x => x.CurrentThing).Returns(new Option());
             this.engineeringModelBodyViewModel = new Mock<IEngineeringModelBodyViewModel>();
+            this.engineeringModelBodyViewModel.SetupProperty(x => x.IsAllowedToDispose, false);
             this.engineeringModelBodyViewModel.Setup(x => x.OptionsTableViewModel).Returns(optionsTableViewModel.Object);
 
             var engineeringModelSetup = new EngineeringModelSetup();
@@ -96,15 +97,11 @@ namespace COMETwebapp.Tests.Components.Tabs
             configuration.Setup(x => x.ServerConfiguration).Returns(new ServerConfiguration());
 
             this.viewModel = new Mock<ITabsViewModel>();
-            var openTabs = new SourceList<TabbedApplicationInformation>();
-            openTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
             this.sidePanel = new TabPanelInformation();
 
-            this.mainPanel = new TabPanelInformation
-            {
-                OpenTabs = openTabs,
-                CurrentTab = openTabs.Items.First()
-            };
+            this.mainPanel = new TabPanelInformation();
+            this.mainPanel.OpenTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
+            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items.First();
 
             this.viewModel.Setup(x => x.MainPanel).Returns(this.mainPanel);
             this.viewModel.Setup(x => x.SidePanel).Returns(this.sidePanel);
@@ -145,6 +142,7 @@ namespace COMETwebapp.Tests.Components.Tabs
                 Assert.That(this.viewModel.Object.SidePanel.OpenTabs, Has.Count.GreaterThan(0));
                 Assert.That(this.viewModel.Object.SidePanel.CurrentTab, Is.Not.Null);
                 Assert.That(this.viewModel.Object.MainPanel.OpenTabs, Has.Count.EqualTo(0));
+                Assert.That(this.engineeringModelBodyViewModel.Object.IsAllowedToDispose, Is.False);
             });
         }
 

--- a/COMETwebapp.Tests/Model/TabPanelInformationTestFixture.cs
+++ b/COMETwebapp.Tests/Model/TabPanelInformationTestFixture.cs
@@ -1,0 +1,141 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="TabPanelInformationTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Model
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.ViewModels.Components.Applications;
+
+    using COMETwebapp.Components.EngineeringModel;
+    using COMETwebapp.Model;
+
+    using DynamicData;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TabPanelInformationTestFixture
+    {
+        private TabPanelInformation panel;
+        private Mock<IApplicationBaseViewModel> applicationBaseViewModel;
+        private TabbedApplicationInformation tab;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.applicationBaseViewModel = new Mock<IApplicationBaseViewModel>();
+            this.applicationBaseViewModel.SetupProperty(x => x.IsAllowedToDispose, false);
+
+            var engineeringModelSetup = new EngineeringModelSetup();
+
+            var iteration = new Iteration
+            {
+                IterationSetup = new IterationSetup
+                {
+                    Container = engineeringModelSetup
+                },
+                Container = new EngineeringModel
+                {
+                    EngineeringModelSetup = engineeringModelSetup
+                }
+            };
+
+            this.tab = new TabbedApplicationInformation(this.applicationBaseViewModel.Object, typeof(EngineeringModelBody), iteration);
+
+            this.panel = new TabPanelInformation();
+            this.panel.OpenTabs.Add(this.tab);
+            this.panel.CurrentTab = this.tab;
+        }
+
+        [Test]
+        public void VerifyCloseTab()
+        {
+            this.panel.CloseTab(this.tab);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.applicationBaseViewModel.Object.IsAllowedToDispose, Is.True);
+                Assert.That(this.panel.OpenTabs.Items, Is.Empty);
+                Assert.That(this.panel.CurrentTab, Is.Null);
+            });
+
+            var otherViewModel = new Mock<IApplicationBaseViewModel>();
+            otherViewModel.SetupProperty(x => x.IsAllowedToDispose, false);
+            var remainingTab = new TabbedApplicationInformation(otherViewModel.Object, typeof(EngineeringModelBody), null);
+            var tabToClose = new TabbedApplicationInformation(this.applicationBaseViewModel.Object, typeof(EngineeringModelBody), null);
+
+            this.panel.OpenTabs.Add(remainingTab);
+            this.panel.OpenTabs.Add(tabToClose);
+            this.panel.CurrentTab = tabToClose;
+
+            this.panel.CloseTab(tabToClose);
+
+            Assert.That(this.panel.CurrentTab, Is.EqualTo(remainingTab));
+        }
+
+        [Test]
+        public void VerifyCloseTabs()
+        {
+            var otherViewModel = new Mock<IApplicationBaseViewModel>();
+            otherViewModel.SetupProperty(x => x.IsAllowedToDispose, false);
+
+            var remainingViewModel = new Mock<IApplicationBaseViewModel>();
+            remainingViewModel.SetupProperty(x => x.IsAllowedToDispose, false);
+
+            var otherTab = new TabbedApplicationInformation(otherViewModel.Object, typeof(EngineeringModelBody), null);
+            var remainingTab = new TabbedApplicationInformation(remainingViewModel.Object, typeof(EngineeringModelBody), null);
+
+            this.panel.OpenTabs.Add(otherTab);
+            this.panel.OpenTabs.Add(remainingTab);
+            this.panel.CurrentTab = this.tab;
+
+            this.panel.CloseTabs([this.tab, otherTab]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.applicationBaseViewModel.Object.IsAllowedToDispose, Is.True);
+                Assert.That(otherViewModel.Object.IsAllowedToDispose, Is.True);
+                Assert.That(remainingViewModel.Object.IsAllowedToDispose, Is.False);
+                Assert.That(this.panel.OpenTabs.Items, Has.Exactly(1).Items);
+                Assert.That(this.panel.OpenTabs.Items, Does.Contain(remainingTab));
+                Assert.That(this.panel.CurrentTab, Is.EqualTo(remainingTab));
+            });
+        }
+
+        [Test]
+        public void VerifyOpenTabsRemoveDoesNotAllowDisposal()
+        {
+            this.panel.OpenTabs.Remove(this.tab);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.panel.OpenTabs.Items, Is.Empty);
+                Assert.That(this.panel.CurrentTab, Is.Null);
+                Assert.That(this.applicationBaseViewModel.Object.IsAllowedToDispose, Is.False);
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Pages/TabsTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/TabsTestFixture.cs
@@ -94,7 +94,7 @@ namespace COMETwebapp.Tests.Pages
 
             this.mainPanel = new TabPanelInformation();
             this.mainPanel.OpenTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
-            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items.First();
+            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items[0];
 
             this.viewModel = new Mock<ITabsViewModel>();
             this.viewModel.Setup(x => x.MainPanel).Returns(this.mainPanel);
@@ -147,7 +147,7 @@ namespace COMETwebapp.Tests.Pages
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.Object.MainPanel.CurrentTab, Is.EqualTo(this.mainPanel.OpenTabs.Items.First()));
+                Assert.That(this.viewModel.Object.MainPanel.CurrentTab, Is.EqualTo(this.mainPanel.OpenTabs.Items[0]));
                 Assert.That(this.renderer.Instance.IsOpenTabVisible, Is.False);
             });
 

--- a/COMETwebapp.Tests/Pages/TabsTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/TabsTestFixture.cs
@@ -92,14 +92,9 @@ namespace COMETwebapp.Tests.Pages
             this.engineeringModelBodyViewModel = new Mock<IEngineeringModelBodyViewModel>();
             this.engineeringModelBodyViewModel.Setup(x => x.OptionsTableViewModel).Returns(optionsTableViewModel.Object);
 
-            var openTabs = new SourceList<TabbedApplicationInformation>();
-            openTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
-
-            this.mainPanel = new TabPanelInformation
-            {
-                OpenTabs = openTabs,
-                CurrentTab = openTabs.Items.First()
-            };
+            this.mainPanel = new TabPanelInformation();
+            this.mainPanel.OpenTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
+            this.mainPanel.CurrentTab = this.mainPanel.OpenTabs.Items.First();
 
             this.viewModel = new Mock<ITabsViewModel>();
             this.viewModel.Setup(x => x.MainPanel).Returns(this.mainPanel);
@@ -131,24 +126,41 @@ namespace COMETwebapp.Tests.Pages
         }
 
         [Test]
+        public void VerifySidePanelIsOnlyAvailableWithMoreThanOneOpenTab()
+        {
+            Assert.That(this.renderer.FindComponents<DxButton>().Any(x => x.Instance.Id == "new-side-panel-button"), Is.False);
+
+            this.mainPanel.OpenTabs.Add(new TabbedApplicationInformation(this.engineeringModelBodyViewModel.Object, typeof(EngineeringModelBody), this.iteration));
+            this.renderer.Render();
+
+            Assert.That(this.renderer.FindComponents<DxButton>().Any(x => x.Instance.Id == "new-side-panel-button"), Is.True);
+        }
+
+        [Test]
         public async Task VerifyTabComponents()
         {
             var tabComponents = this.renderer.FindComponents<TabComponent>();
             var firstTab = tabComponents[0];
+            var selectModelTab = tabComponents[1];
 
             await this.renderer.InvokeAsync(firstTab.Instance.OnClick.Invoke);
-            Assert.That(this.viewModel.Object.MainPanel.CurrentTab, Is.EqualTo(this.mainPanel.OpenTabs.Items.First()));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Object.MainPanel.CurrentTab, Is.EqualTo(this.mainPanel.OpenTabs.Items.First()));
+                Assert.That(this.renderer.Instance.IsOpenTabVisible, Is.False);
+            });
+
+            await this.renderer.InvokeAsync(selectModelTab.Instance.OnClick.Invoke);
+            Assert.That(this.renderer.Instance.IsOpenTabVisible, Is.True);
+
             await this.renderer.InvokeAsync(firstTab.Instance.OnIconClick.Invoke);
 
             Assert.Multiple(() =>
             {
                 Assert.That(this.viewModel.Object.MainPanel.OpenTabs, Has.Count.EqualTo(0));
-                Assert.That(this.renderer.Instance.IsOpenTabVisible, Is.False);
+                Assert.That(this.viewModel.Object.MainPanel.CurrentTab, Is.Null);
             });
-
-            var secondTab = tabComponents[1];
-            await this.renderer.InvokeAsync(secondTab.Instance.OnClick.Invoke);
-            Assert.That(this.renderer.Instance.IsOpenTabVisible, Is.True);
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/Common/ElementDetailsPanelViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/ElementDetailsPanelViewModelTestFixture.cs
@@ -44,6 +44,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
 
     using NUnit.Framework;
 
+    using ReactiveUI;
+
     [TestFixture]
     public class ElementDetailsPanelViewModelTestFixture
     {
@@ -1092,6 +1094,21 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
 
             Assert.That(this.viewModel.SelectedElement, Is.SameAs(this.referencedElementDefinition),
                 "When the selected element still exists, RefreshSelectedElement must keep it selected.");
+        }
+        
+        [Test]
+        public void VerifyRefreshSelectedElementRaisesIsLoading()
+        {
+            this.viewModel.SelectElement(this.referencedElementDefinition);
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            this.viewModel.RefreshSelectedElement();
+
+            Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                "RefreshSelectedElement rebuilds the rows but never toggles IsLoading, so a host mirroring this " +
+                "property (e.g. ModelEditorViewModel.IsLoading) never receives a re-render signal.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModelTestFixture.cs
@@ -1,0 +1,149 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ModelDashboardBodyViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.ViewModels.Components.ModelDashboard
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using CDP4Web.Enumerations;
+
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.ViewModels.Components.ModelDashboard;
+    using COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class ModelDashboardBodyViewModelTestFixture
+    {
+        /// <summary>
+        /// The view model under test.
+        /// </summary>
+        private ModelDashboardBodyViewModel viewModel;
+
+        /// <summary>
+        /// The mocked <see cref="ISessionService" />.
+        /// </summary>
+        private Mock<ISessionService> sessionService;
+
+        /// <summary>
+        /// The mocked <see cref="IParameterDashboardViewModel" />.
+        /// </summary>
+        private Mock<IParameterDashboardViewModel> parameterDashboard;
+
+        /// <summary>
+        /// The message bus used by the view model.
+        /// </summary>
+        private CDPMessageBus messageBus;
+
+        /// <summary>
+        /// The iteration providing the test fixture's element graph.
+        /// </summary>
+        private Iteration iteration;
+
+        /// <summary>
+        /// Builds the iteration and the view model with mocked dependencies.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.messageBus = new CDPMessageBus();
+            this.sessionService = new Mock<ISessionService>();
+            this.parameterDashboard = new Mock<IParameterDashboardViewModel>();
+
+            var session = new Mock<ISession>();
+            this.sessionService.Setup(x => x.Session).Returns(session.Object);
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+            this.sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(domain);
+            this.sessionService.Setup(x => x.GetModelDomains(It.IsAny<EngineeringModelSetup>())).Returns([domain]);
+
+            var modelSetup = new EngineeringModelSetup { Name = "ModelName", ShortName = "ModelShortName" };
+
+            this.iteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                IterationSetup = new IterationSetup { IterationNumber = 1, Container = modelSetup }
+            };
+
+            this.viewModel = new ModelDashboardBodyViewModel(this.sessionService.Object, this.parameterDashboard.Object, this.messageBus)
+            {
+                CurrentThing = this.iteration
+            };
+        }
+
+        /// <summary>
+        /// Tears down the message bus and disposes of the view model.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.messageBus.ClearSubscriptions();
+            this.viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyExternalParameterChangeIsReflectedAfterEndUpdate()
+        {
+            var elementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid()
+            };
+
+            this.iteration.Element.Add(elementDefinition);
+
+            // Clear the invocation recorded by the initial CurrentThing assignment in SetUp, so that Verify below
+            // proves a NEW refresh happened in reaction to EndUpdate, not the one from initialisation.
+            this.parameterDashboard.Invocations.Clear();
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
+            this.messageBus.SendMessage(new SessionEvent(this.sessionService.Object.Session, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the external write");
+
+            Assert.Multiple(() =>
+            {
+                this.parameterDashboard.Verify(x => x.UpdateProperties(It.IsAny<Iteration>(), It.IsAny<Option>(),
+                        It.IsAny<ActualFiniteState>(), It.IsAny<ParameterType>(), It.IsAny<DomainOfExpertise>(), It.IsAny<IEnumerable<DomainOfExpertise>>()),
+                    Times.AtLeastOnce,
+                    "ModelDashboardBodyViewModel has no OnEndUpdate override, so a cross-panel write's EndUpdate never " +
+                    "reaches OnSessionRefreshed/UpdateDashboards.");
+
+                Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                    "IsLoading must toggle so the Model Dashboard re-renders.");
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModelTestFixture.cs
@@ -42,6 +42,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 
     using NUnit.Framework;
 
+    using ReactiveUI;
+
     [TestFixture]
     public class ElementDefinitionTreeViewModelTestFixture
     {
@@ -239,6 +241,63 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             this.messageBus.SendMessage(SessionServiceEvent.SessionRefreshed, this.sessionService.Object.Session);
 
             Assert.That(this.viewModel.Rows.Single(x => x.IsTopElement).ElementName, Is.EqualTo(this.topElement.Name));
+        }
+
+        [Test]
+        public async Task VerifyExternalRemovalOfRowElementPropagatesAfterEndUpdate()
+        {
+            this.viewModel.Iteration = this.iteration;
+
+            Assert.That(this.viewModel.Rows.Any(x => x.ElementBase.Iid == this.topElement.Iid), Is.True);
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            // Simulate the other panel's write: the ElementDefinition is removed from the iteration and the
+            // corresponding events reach this session's message bus.
+            this.iteration.Element.Remove(this.topElement);
+            this.messageBus.SendObjectChangeEvent(this.topElement, EventKind.Removed);
+            this.messageBus.SendMessage(new SessionEvent(this.sessionService.Object.Session, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the external removal");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Rows.Any(x => x.ElementBase.Iid == this.topElement.Iid), Is.False,
+                    "A Removed ObjectChangedEvent for a row's ElementDefinition, followed by EndUpdate, must remove the row.");
+
+                Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                    "IsLoading must toggle so the tree component re-renders.");
+            });
+        }
+
+        /// <summary>
+        /// Regression test for GH799 symptom B: renaming an <see cref="ElementUsage" /> nested under a row must be
+        /// reflected in the tree. <see cref="ElementDefinitionTreeViewModel.AddRows" />,
+        /// <see cref="ElementDefinitionTreeViewModel.UpdateRows" /> and <see cref="ElementDefinitionTreeViewModel.RemoveRows" />
+        /// all filter their input to <c>.OfType&lt;ElementDefinition&gt;()</c>, so an <see cref="ObjectChangedEvent" />
+        /// for a renamed <see cref="ElementUsage" /> is recorded but silently discarded when the rows are refreshed.
+        /// </summary>
+        [Test]
+        public void VerifyExternalRenameOfElementUsagePropagatesAfterEndUpdate()
+        {
+            this.viewModel.Iteration = this.iteration;
+            var usage = this.topElement.ContainedElement.Single();
+
+            Assert.That(this.viewModel.Rows.Single(x => x.IsTopElement).Rows.Single(x => x.ElementBase.Iid == usage.Iid).ElementName,
+                Is.EqualTo("Box1"));
+
+            // Simulate another panel's write: the usage is renamed and the corresponding events reach this
+            // session's message bus.
+            usage.Name = "Renamed";
+            this.messageBus.SendObjectChangeEvent(usage, EventKind.Updated);
+            this.messageBus.SendMessage(new SessionEvent(this.sessionService.Object.Session, SessionStatus.EndUpdate));
+
+            Assert.That(() => this.viewModel.Rows.Single(x => x.IsTopElement).Rows.Single(x => x.ElementBase.Iid == usage.Iid).ElementName == "Renamed",
+                Is.True.After(2000, 25),
+                "An ElementUsage rename followed by EndUpdate must be reflected in its nested tree row, " +
+                "but AddRows/UpdateRows/RemoveRows only handle ElementDefinition changes.");
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -24,8 +24,12 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 {
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using CDP4Web.Enumerations;
 
     using COMET.Web.Common.Services.Cache;
     using COMET.Web.Common.Services.SessionManagement;
@@ -40,6 +44,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
     using Moq;
 
     using NUnit.Framework;
+
+    using ReactiveUI;
 
     [TestFixture]
     public class ModelEditorViewModelTestFixture
@@ -204,6 +210,55 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 
                 Assert.That(async () => await this.viewModel.AddNewElementUsageAsync(elementDefinition, null),
                     Throws.TypeOf<ArgumentNullException>());
+            });
+        }
+
+        [Test]
+        public async Task VerifyExternalParameterChangeIsReflectedAfterEndUpdate()
+        {
+            this.viewModel.DetailsPanelViewModel.SelectElement(this.topElement);
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Mass", ShortName = "m" };
+
+            var newParameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain,
+                ParameterType = parameterType
+            };
+
+            newParameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(["-"]),
+                Computed = new ValueArray<string>(["-"]),
+                Reference = new ValueArray<string>(["-"]),
+                Formula = new ValueArray<string>(["-"]),
+                Published = new ValueArray<string>(["-"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            this.topElement.Parameter.Add(newParameter);
+
+            // Simulate the other panel's write reaching this session's message bus.
+            this.messageBus.SendObjectChangeEvent(this.topElement, EventKind.Updated);
+            this.messageBus.SendMessage(new SessionEvent(this.sessionService.Object.Session, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the external write");
+
+            var rows = this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rows.Any(r => r.Parameter.Iid == newParameter.Iid), Is.True,
+                    "ModelEditorViewModel.OnEndUpdate must refresh the details panel so a cross-panel Parameter write becomes visible.");
+
+                Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                    "IsLoading must toggle so that the Blazor component subscribed to it knows to re-render.");
             });
         }
     }

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
@@ -46,6 +46,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
     using NUnit.Framework;
 
+    using ReactiveUI;
+
     [TestFixture]
     public class ParameterEditorBodyViewModelTestFixture
     {
@@ -318,6 +320,35 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
             this.tableViewModel.Verify(x => x.RemoveRows(It.Is<IEnumerable<Thing>>(c => c.Any())), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyExternalElementChangeIsReflectedAfterEndUpdateOnly()
+        {
+            var elementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid()
+            };
+
+            this.iteration.Element.Add(elementDefinition);
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.Multiple(() =>
+            {
+                this.tableViewModel.Verify(x => x.AddRows(It.Is<IEnumerable<Thing>>(c => c.Any())), Times.Once,
+                    "ParameterEditorBodyViewModel has no OnEndUpdate override, so it only refreshes on " +
+                    "SessionServiceEvent.SessionRefreshed — a cross-panel write's EndUpdate is silently ignored.");
+
+                Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                    "IsLoading must toggle so the Parameter Editor re-renders.");
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModelTestFixture.cs
@@ -41,6 +41,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.SubscriptionDashboard
 
     using NUnit.Framework;
 
+    using ReactiveUI;
+
     [TestFixture]
     public class SubscriptionDashboardBodyViewModelTestFixture
     {
@@ -92,6 +94,45 @@ namespace COMETwebapp.Tests.ViewModels.Components.SubscriptionDashboard
 
             this.subscribedTableViewModel.Verify(x => x.UpdateProperties(It.IsAny<IEnumerable<ParameterSubscription>>(),
                 It.IsAny<IEnumerable<Option>>(), null), Times.Once);
+        }
+        
+        [Test]
+        public async Task VerifyExternalParameterChangeIsReflectedAfterEndUpdate()
+        {
+            var domain = new DomainOfExpertise();
+            this.sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(domain);
+            this.viewModel.CurrentThing = new Iteration();
+
+            var elementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid()
+            };
+
+            this.viewModel.CurrentThing.Element.Add(elementDefinition);
+
+            // Clear the invocation recorded by the initial CurrentThing assignment above, so that Verify below
+            // proves a NEW refresh happened in reaction to EndUpdate, not the one from initialisation.
+            this.subscribedTableViewModel.Invocations.Clear();
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            this.messageBus.SendObjectChangeEvent(elementDefinition, EventKind.Added);
+            this.messageBus.SendMessage(new SessionEvent(this.sessionService.Object.Session, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the external write");
+
+            Assert.Multiple(() =>
+            {
+                this.subscribedTableViewModel.Verify(x => x.UpdateProperties(It.IsAny<IEnumerable<ParameterSubscription>>(),
+                        It.IsAny<IEnumerable<Option>>(), It.IsAny<Iteration>()), Times.AtLeastOnce,
+                    "SubscriptionDashboardBodyViewModel has no OnEndUpdate override, so a cross-panel write's EndUpdate " +
+                    "never reaches OnSessionRefreshed/UpdateTables.");
+
+                Assert.That(isLoadingValues, Has.Some.EqualTo(true),
+                    "IsLoading must toggle so the Subscription Dashboard re-renders.");
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModelTestFixture.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
@@ -31,6 +32,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 
     using CDP4Web.Enumerations;
 
+    using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.SessionManagement;
 
     using COMETwebapp.ViewModels.Components.Common;
@@ -38,11 +40,15 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 
     using DynamicData;
 
+    using FluentResults;
+
     using Microsoft.Extensions.Logging;
 
     using Moq;
 
     using NUnit.Framework;
+
+    using ReactiveUI;
 
     [TestFixture]
     public class SystemRepresentationBodyViewModelTestFixture
@@ -197,6 +203,221 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
             Assert.That(rows.Any(r => r.Parameter.Iid == newParameter.Iid), Is.True,
                 "After EndUpdate the panel's rows must include the newly-added parameter, " +
                 "proving OnEndUpdate → OnSessionRefreshed → RefreshSelectedElement re-resolves from the live cache.");
+        }
+        
+        [Test]
+        public async Task VerifyOwnParameterOverrideWritePropagatesToOwnPanelAfterEndUpdate()
+        {
+            var referencedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.currentDomain
+            };
+
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Mass", ShortName = "m" };
+
+            var parameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain,
+                ParameterType = parameterType
+            };
+
+            parameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(["1"]),
+                Computed = new ValueArray<string>(["1"]),
+                Reference = new ValueArray<string>(["-"]),
+                Formula = new ValueArray<string>(["-"]),
+                Published = new ValueArray<string>(["1"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            referencedElementDefinition.Parameter.Add(parameter);
+
+            var elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = referencedElementDefinition,
+                Owner = this.currentDomain
+            };
+
+            this.topElement.ContainedElement.Add(elementUsage);
+            this.iteration.Element.Add(referencedElementDefinition);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            // Genuinely load the iteration, as the real application does, so RefreshProductTree runs for real
+            // instead of being skipped because CurrentThing is null.
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.Elements.Any(e => e.Iid == elementUsage.Iid), Is.True.After(2000, 25),
+                "the initial load never finished building the product tree");
+
+            var usageNode = this.viewModel.ProductTreeViewModel.RootViewModel.GetFlatListOfDescendants(true)
+                .Single(n => n.Thing.Iid == elementUsage.Iid);
+
+            // Select the ElementUsage, as the System Representation product tree does.
+            this.viewModel.SelectElement(usageNode);
+
+            Assert.That(this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.SelectedSystemNode,
+                Is.SameAs(elementUsage),
+                "Panel must have the ElementUsage selected before the write.");
+
+            Assert.That(this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows.Single(r => r.Parameter.Iid == parameter.Iid).HasOverride,
+                Is.False,
+                "The row must not report an override before one is created.");
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            // Simulate the write performed by this panel's own "Create Override" popup: the session updates the
+            // live, already-selected ElementUsage in place and notifies the message bus.
+            var parameterOverride = new ParameterOverride
+            {
+                Iid = Guid.NewGuid(),
+                Parameter = parameter,
+                Owner = this.currentDomain
+            };
+
+            elementUsage.ParameterOverride.Add(parameterOverride);
+
+            this.messageBus.SendObjectChangeEvent(parameterOverride, EventKind.Added);
+            this.messageBus.SendObjectChangeEvent(elementUsage, EventKind.Updated);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to its own write");
+
+            Assert.That(this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows.Single(r => r.Parameter.Iid == parameter.Iid).HasOverride,
+                Is.True,
+                "After EndUpdate, the panel that performed the ParameterOverride write must show the override on its own rows.");
+        }
+        
+        [Test]
+        public async Task VerifyCreateOverrideAsyncOwnFinallyDoesNotClobberEndUpdateRefresh()
+        {
+            var referencedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.currentDomain
+            };
+
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Mass", ShortName = "m" };
+
+            var parameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                Owner = this.currentDomain,
+                ParameterType = parameterType
+            };
+
+            parameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(["1"]),
+                Computed = new ValueArray<string>(["1"]),
+                Reference = new ValueArray<string>(["-"]),
+                Formula = new ValueArray<string>(["-"]),
+                Published = new ValueArray<string>(["1"]),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            referencedElementDefinition.Parameter.Add(parameter);
+
+            var elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = referencedElementDefinition,
+                Owner = this.currentDomain
+            };
+
+            this.topElement.ContainedElement.Add(elementUsage);
+            this.iteration.Element.Add(referencedElementDefinition);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.Elements.Any(e => e.Iid == elementUsage.Iid), Is.True.After(2000, 25),
+                "the initial load never finished building the product tree");
+
+            var usageNode = this.viewModel.ProductTreeViewModel.RootViewModel.GetFlatListOfDescendants(true)
+                .Single(n => n.Thing.Iid == elementUsage.Iid);
+
+            this.viewModel.SelectElement(usageNode);
+
+            var parameterOverride = new ParameterOverride
+            {
+                Iid = Guid.NewGuid(),
+                Parameter = parameter,
+                Owner = this.currentDomain
+            };
+
+            // The mocked write performs its side effects — and publishes the events a real ISession.Write would —
+            // from inside the callback, i.e. before CreateOverrideAsync's own await resumes.
+            this.sessionService
+                .Setup(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()))
+                .Callback(() =>
+                {
+                    elementUsage.ParameterOverride.Add(parameterOverride);
+                    this.messageBus.SendObjectChangeEvent(parameterOverride, EventKind.Added);
+                    this.messageBus.SendObjectChangeEvent(elementUsage, EventKind.Updated);
+                    this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+                })
+                .ReturnsAsync(Result.Ok());
+
+            this.viewModel.DetailsPanelViewModel.OpenCreateOverridePopup(parameter, elementUsage);
+            await this.viewModel.DetailsPanelViewModel.CreateOverridePopupViewModel.OnConfirm.InvokeAsync();
+
+            Assert.That(() => this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows.Single(r => r.Parameter.Iid == parameter.Iid).HasOverride,
+                Is.True.After(2000, 25),
+                "After CreateOverrideAsync's own write-and-close sequence completes, the panel that performed it must show the override on its own rows.");
+        }
+        
+        [Test]
+        public void VerifyRefreshProductTreeUpdatesRootNodeOnTopElementRename()
+        {
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.ProductTreeViewModel.RootViewModel != null, Is.True.After(2000, 25),
+                "the initial load never finished building the product tree");
+
+            var rootNode = this.viewModel.ProductTreeViewModel.RootViewModel;
+            var originalTitle = rootNode.Title;
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            // Rename the top ElementDefinition, as a rename performed by this or another panel would.
+            this.topElement.Name = "Renamed Container";
+
+            this.messageBus.SendObjectChangeEvent(this.topElement, EventKind.Updated);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the rename");
+
+            Assert.That(() => rootNode.Title != originalTitle && rootNode.Title == this.topElement.UserFriendlyName, Is.True.After(2000, 25),
+                "After EndUpdate, the ROOT node must reflect the renamed top ElementDefinition, " +
+                "not just the ElementUsage nodes below it.");
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Pages/TabsViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Pages/TabsViewModelTestFixture.cs
@@ -109,7 +109,7 @@ namespace COMETwebapp.Tests.ViewModels.Pages
             this.viewModel.CreateNewTab(engineeringModelApplication1, Guid.Empty, this.viewModel.MainPanel);
             this.viewModel.CreateNewTab(engineeringModelApplication2, Guid.Empty, this.viewModel.MainPanel);
 
-            var removedTab = this.viewModel.MainPanel.OpenTabs.Items.ElementAt(1);
+            var removedTab = this.viewModel.MainPanel.OpenTabs.Items[1];
 
             Assert.That(this.viewModel.MainPanel.CurrentTab, Is.EqualTo(removedTab));
             this.viewModel.MainPanel.OpenTabs.Remove(removedTab);

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.cs
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor.cs
@@ -113,7 +113,7 @@ namespace COMETwebapp.Components.Tabs
         /// <param name="newIndex">The dragged tab new panel index</param>
         private void OnMovedTab(int oldIndex, int newIndex)
         {
-            var tab = this.Panel.OpenTabs.Items.ElementAt(oldIndex);
+            var tab = this.Panel.OpenTabs.Items[oldIndex];
 
             if (this.Panel == this.ViewModel.MainPanel)
             {

--- a/COMETwebapp/Model/TabPanelInformation.cs
+++ b/COMETwebapp/Model/TabPanelInformation.cs
@@ -23,6 +23,7 @@
 namespace COMETwebapp.Model
 {
     using COMET.Web.Common.Utilities.DisposableObject;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using DynamicData;
 
@@ -58,7 +59,37 @@ namespace COMETwebapp.Model
         /// <summary>
         /// Gets the collection of all <see cref="TabbedApplicationInformation" /> contained by the panel
         /// </summary>
-        public SourceList<TabbedApplicationInformation> OpenTabs { get; set; } = new();
+        public SourceList<TabbedApplicationInformation> OpenTabs { get; } = new();
+
+        /// <summary>
+        /// Closes the provided tab, allowing its <see cref="IApplicationBaseViewModel" /> to be disposed
+        /// </summary>
+        /// <param name="tab">The <see cref="TabbedApplicationInformation" /> to close</param>
+        /// <remarks>
+        /// Removing a tab from <see cref="OpenTabs" /> without going through this method only moves it out of the panel and
+        /// keeps its <see cref="IApplicationBaseViewModel" /> alive, which is required when the tab is moved to another panel
+        /// </remarks>
+        public void CloseTab(TabbedApplicationInformation tab)
+        {
+            tab.ApplicationBaseViewModel.IsAllowedToDispose = true;
+            this.OpenTabs.Remove(tab);
+        }
+
+        /// <summary>
+        /// Closes the provided tabs, allowing their <see cref="IApplicationBaseViewModel" /> to be disposed
+        /// </summary>
+        /// <param name="tabs">The collection of <see cref="TabbedApplicationInformation" /> to close</param>
+        public void CloseTabs(IEnumerable<TabbedApplicationInformation> tabs)
+        {
+            var tabsToClose = tabs.ToList();
+
+            foreach (var tab in tabsToClose)
+            {
+                tab.ApplicationBaseViewModel.IsAllowedToDispose = true;
+            }
+
+            this.OpenTabs.RemoveMany(tabsToClose);
+        }
 
         /// <summary>
         /// Method executed when one or more open tabs are removed
@@ -66,26 +97,11 @@ namespace COMETwebapp.Model
         /// <param name="changeSet">The change set containing the removed <see cref="TabbedApplicationInformation" /></param>
         private void OnOpenTabRemoved(IChangeSet<TabbedApplicationInformation> changeSet)
         {
-            foreach (var result in changeSet.ToList())
-            {
-                if (result.Range.Count > 0)
-                {
-                    foreach (var tabToRemove in result.Range)
-                    {
-                        tabToRemove.ApplicationBaseViewModel.IsAllowedToDispose = true;
-                    }
-                }
-                else
-                {
-                    result.Item.Current.ApplicationBaseViewModel.IsAllowedToDispose = true;
-                }
-            }
+            var removedTabs = changeSet
+                .SelectMany(change => change.Range.Count > 0 ? change.Range.ToList() : [change.Item.Current])
+                .ToList();
 
-            var wasCurrentTabRemoved = changeSet
-                .Select(x => x.Item.Current)
-                .Contains(this.CurrentTab);
-
-            if (wasCurrentTabRemoved)
+            if (removedTabs.Contains(this.CurrentTab))
             {
                 this.CurrentTab = this.OpenTabs.Items.FirstOrDefault();
             }

--- a/COMETwebapp/Pages/Tabs.razor
+++ b/COMETwebapp/Pages/Tabs.razor
@@ -32,7 +32,7 @@
                             OnCreateTabForModel="@(tab => this.OnCreateTabForModel(tab))"
                             OnRemoveTabClick="@(tab => OnRemoveTabClick(tab, this.ViewModel.MainPanel))"
                             OnOpenTabClick="@(() => this.OnOpenTabClick(this.ViewModel.MainPanel))"
-                            IsSidePanelAvailable="@(this.ViewModel.SidePanel.OpenTabs.Count == 0)"/>
+                            IsSidePanelAvailable="@(this.ViewModel.SidePanel.OpenTabs.Count == 0 && this.ViewModel.MainPanel.OpenTabs.Count > 1)"/>
 
         @if (this.ViewModel.SidePanel.CurrentTab is not null)
         {

--- a/COMETwebapp/Pages/Tabs.razor.cs
+++ b/COMETwebapp/Pages/Tabs.razor.cs
@@ -113,7 +113,7 @@ namespace COMETwebapp.Pages
         /// <param name="panel">The tab panel to handle the tab click</param>
         private static void OnRemoveTabClick(TabbedApplicationInformation tabbedApplicationInformation, TabPanelInformation panel)
         {
-            panel.OpenTabs.Remove(tabbedApplicationInformation);
+            panel.CloseTab(tabbedApplicationInformation);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
@@ -596,6 +596,10 @@ namespace COMETwebapp.ViewModels.Components.Common
                 var fresh = current is null ? null : this.ResolveFromIteration(current);
                 this.SelectElement(fresh);
             }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "An error occurred while refreshing the selected element");
+            }
             finally
             {
                 this.IsLoading = false;

--- a/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
@@ -581,18 +581,25 @@ namespace COMETwebapp.ViewModels.Components.Common
         /// in-place mutations (e.g. a newly-added <see cref="Parameter" />) are reflected. When the element
         /// no longer exists in the iteration (e.g. because another user deleted it) the selection is cleared.
         /// </summary>
+        /// <remarks>
+        /// <see cref="IsLoading" /> is toggled around the refresh because the hosting application component only
+        /// re-renders when it changes. Without it the rows are rebuilt but the panel keeps showing stale content,
+        /// which is what made changes written by another open application invisible in this one.
+        /// </remarks>
         public void RefreshSelectedElement()
         {
-            var current = this.SelectedElement ?? this.SelectedElementDefinition;
+            this.IsLoading = true;
 
-            if (current is null)
+            try
             {
-                this.SelectElement(null);
-                return;
+                var current = this.SelectedElement ?? this.SelectedElementDefinition;
+                var fresh = current is null ? null : this.ResolveFromIteration(current);
+                this.SelectElement(fresh);
             }
-
-            var fresh = this.ResolveFromIteration(current);
-            this.SelectElement(fresh);
+            finally
+            {
+                this.IsLoading = false;
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Common/IElementDetailsPanelViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/IElementDetailsPanelViewModel.cs
@@ -237,6 +237,10 @@ namespace COMETwebapp.ViewModels.Components.Common
         /// Re-selects the currently selected element, refreshing the details rows. Typically called when the
         /// session is refreshed.
         /// </summary>
+        /// <remarks>
+        /// This toggles <see cref="IsLoading" /> so that the hosting application component re-renders. A caller that
+        /// mirrors <see cref="IsLoading" /> onto its own must not invoke this from inside its own loading bracket.
+        /// </remarks>
         void RefreshSelectedElement();
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModel.cs
@@ -98,6 +98,16 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard
         }
 
         /// <summary>
+        /// Handles the <c>SessionStatus.EndUpdate</c> message received, so that a change written by another open
+        /// application is reflected here as well
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnEndUpdate()
+        {
+            return this.OnSessionRefreshed();
+        }
+
+        /// <summary>
         /// Handles the refresh of the current <see cref="ISession" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModel.cs
@@ -130,10 +130,14 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// <param name="addedThings">A collection of added <see cref="Thing" /></param>
         public void AddRows(IEnumerable<Thing> addedThings)
         {
-            var listOfAddedElementBases = addedThings.OfType<ElementDefinition>().Where(x => this.Iteration?.Element.Contains(x) ?? false).ToList();
+            var things = addedThings.ToList();
+
+            var listOfAddedElementBases = things.OfType<ElementDefinition>().Where(x => this.Iteration?.Element.Contains(x) ?? false).ToList();
             this.Rows.AddRange(listOfAddedElementBases.Select(e => new ElementDefinitionTreeRowViewModel(e)));
 
-            if (listOfAddedElementBases.Count > 0)
+            var refreshedContainers = this.RefreshRowsContaining(things.OfType<ElementUsage>());
+
+            if (listOfAddedElementBases.Count > 0 || refreshedContainers)
             {
                 this.SortRows();
             }
@@ -145,9 +149,10 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// <param name="updatedThings">A collection of updated <see cref="ElementDefinition" /></param>
         public void UpdateRows(IEnumerable<Thing> updatedThings)
         {
+            var things = updatedThings.ToList();
             var sortCollection = false;
 
-            foreach (var element in updatedThings.OfType<ElementDefinition>().Where(x => this.Iteration?.Element.Contains(x) ?? false).ToList())
+            foreach (var element in things.OfType<ElementDefinition>().Where(x => this.Iteration?.Element.Contains(x) ?? false).ToList())
             {
                 var row = this.Rows.FirstOrDefault(x => x.ElementBase.Iid == element.Iid);
 
@@ -157,6 +162,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                     row.UpdateProperties(new ElementDefinitionTreeRowViewModel(element));
                 }
             }
+
+            sortCollection |= this.RefreshRowsContaining(things.OfType<ElementUsage>());
 
             if (sortCollection)
             {
@@ -170,9 +177,10 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// <param name="deletedThings">A collection of deleted <see cref="ElementDefinition" /></param>
         public void RemoveRows(IEnumerable<Thing> deletedThings)
         {
+            var things = deletedThings.ToList();
             var sortCollection = false;
 
-            foreach (var elementId in deletedThings.OfType<ElementDefinition>().Select(x => x.Iid))
+            foreach (var elementId in things.OfType<ElementDefinition>().Select(x => x.Iid))
             {
                 var row = this.Rows.FirstOrDefault(x => x.ElementBase.Iid == elementId);
 
@@ -183,10 +191,47 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 }
             }
 
+            sortCollection |= this.RefreshRowsContaining(things.OfType<ElementUsage>());
+
             if (sortCollection)
             {
                 this.SortRows();
             }
+        }
+
+        /// <summary>
+        /// Refreshes the rows of the <see cref="ElementDefinition" />s that contain the supplied
+        /// <see cref="ElementUsage" />s
+        /// </summary>
+        /// <param name="elementUsages">A collection of <see cref="ElementUsage" /> that has changed</param>
+        /// <returns>A value asserting whether at least one row was refreshed</returns>
+        /// <remarks>
+        /// An <see cref="ElementUsage" /> is rendered as a nested row rather than as a top level one, so a change to
+        /// one is applied by re-diffing the row of its containing <see cref="ElementDefinition" /> against the live
+        /// object graph. Without this, every usage add, rename and delete is recorded and then silently discarded.
+        /// </remarks>
+        private bool RefreshRowsContaining(IEnumerable<ElementUsage> elementUsages)
+        {
+            var containers = elementUsages
+                .Select(x => x.Container as ElementDefinition)
+                .Where(x => x != null && (this.Iteration?.Element.Contains(x) ?? false))
+                .DistinctBy(x => x.Iid)
+                .ToList();
+
+            var refreshed = false;
+
+            foreach (var container in containers)
+            {
+                var row = this.Rows.FirstOrDefault(x => x.ElementBase.Iid == container.Iid);
+
+                if (row != null)
+                {
+                    row.UpdateProperties(new ElementDefinitionTreeRowViewModel(container));
+                    refreshed = true;
+                }
+            }
+
+            return refreshed;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModel.cs
@@ -108,6 +108,16 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.Rows
                 }
             }
 
+            foreach (var survivingRow in this.Rows)
+            {
+                var liveUsage = containedElements.FirstOrDefault(x => x.Iid == survivingRow.ElementBase.Iid);
+
+                if (liveUsage != null)
+                {
+                    survivingRow.UpdateProperties(new ElementUsageTreeRowViewModel(liveUsage));
+                }
+            }
+
             var existingIids = this.Rows.Select(r => r.ElementBase.Iid).ToHashSet();
 
             var toAdd = containedElements

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
@@ -135,6 +135,16 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         }
 
         /// <summary>
+        /// Handles the <c>SessionStatus.EndUpdate</c> message received, so that a change written by another open
+        /// application is reflected here as well
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnEndUpdate()
+        {
+            return this.OnSessionRefreshed();
+        }
+
+        /// <summary>
         /// Handles the refresh of the current <see cref="ISession" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModel.cs
@@ -118,6 +118,16 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         }
 
         /// <summary>
+        /// Handles the <c>SessionStatus.EndUpdate</c> message received, so that a change written by another open
+        /// application is reflected here as well
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override Task OnEndUpdate()
+        {
+            return this.OnSessionRefreshed();
+        }
+
+        /// <summary>
         /// Handles the refresh of the current <see cref="ISession" />
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
@@ -238,15 +238,13 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         }
 
         /// <summary>
-        /// Handles the <see cref="COMET.Web.Common.Enumerations.SessionStatus.EndUpdate" /> message received.
-        /// Refreshes the product tree so that a completed write (e.g. add Element Definition with its
-        /// auto-created usage) appears immediately, then refreshes the details panel.
+        /// Handles the <c>SessionStatus.EndUpdate</c> message received, so that a change written by this or another
+        /// open application is reflected here as well
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
-        protected override async Task OnEndUpdate()
+        protected override Task OnEndUpdate()
         {
-            await this.OnSessionRefreshed();
-            this.DetailsPanelViewModel.RefreshSelectedElement();
+            return this.OnSessionRefreshed();
         }
 
         /// <summary>
@@ -255,16 +253,27 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         /// <returns>A <see cref="Task" /></returns>
         protected override Task OnSessionRefreshed()
         {
-            if (this.AddedThings.Count == 0 && this.UpdatedThings.Count == 0 && this.DeletedThings.Count == 0)
+            if (this.AddedThings.Count != 0 || this.UpdatedThings.Count != 0 || this.DeletedThings.Count != 0)
             {
-                return Task.CompletedTask;
+                this.RefreshProductTree();
             }
+            
+            this.DetailsPanelViewModel.RefreshSelectedElement();
 
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Applies the recorded <see cref="ElementUsage" /> changes to the product tree
+        /// </summary>
+        private void RefreshProductTree()
+        {
             this.IsLoading = true;
 
             var addedElements = this.AddedThings.OfType<ElementUsage>().ToList();
             var deletedElements = this.DeletedThings.OfType<ElementUsage>().ToList();
             var updatedElements = this.UpdatedThings.OfType<ElementUsage>().ToList();
+            var updatedElementBases = this.UpdatedThings.OfType<ElementBase>().ToList();
 
             this.Elements.AddRange(addedElements);
             this.Elements.RemoveMany(deletedElements);
@@ -289,16 +298,12 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
             {
                 this.ProductTreeViewModel.AddElementsToTree(addedElements, selectedOption, []);
                 this.ProductTreeViewModel.RemoveElementsFromTree(deletedElements);
-                this.ProductTreeViewModel.UpdateElementsFromTree(updatedElements);
+                this.ProductTreeViewModel.UpdateElementsFromTree(updatedElementBases);
                 this.ProductTreeViewModel.RootViewModel.OrderAllDescendantsByShortName();
             }
 
-            this.DetailsPanelViewModel.RefreshSelectedElement();
-
             this.ClearRecordedChanges();
             this.IsLoading = false;
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
+++ b/COMETwebapp/ViewModels/Pages/TabsViewModel.cs
@@ -193,8 +193,8 @@ namespace COMETwebapp.ViewModels.Pages
                 .ToList();
 
             List<TabbedApplicationInformation> thingTabsToClose = [.. iterationTabsToClose, .. engineeringModelTabsToClose];
-            this.MainPanel.OpenTabs.RemoveMany(thingTabsToClose);
-            this.SidePanel.OpenTabs.RemoveMany(thingTabsToClose);
+            this.MainPanel.CloseTabs(thingTabsToClose);
+            this.SidePanel.CloseTabs(thingTabsToClose);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #799

## Problem

In split view, changes made in one panel did not appear in the other, and often not
even in the panel that made them. Reported against Model Editor + System Representation
side by side, but the causes are shared and affect other applications too.

Investigation turned up **four independent defects**. 

## Root causes and fixes

### 1. Moving a tab between panels disposed its ViewModel

`TabPanelInformation.OnOpenTabRemoved` set `IsAllowedToDispose = true` on **any** tab
removed from a panel. Splitting a tab into the side panel (and drag-moving a tab between
panels) is a removal from one panel and an insert into the other, so the ViewModel was
flagged as disposable and Blazor tore down every one of its message bus subscriptions when
the old component unmounted. The side panel was rendering a ViewModel that could no longer
react to anything.

Removal from a panel is now distinguished from an actual tab close.

- `COMETwebapp/Model/TabPanelInformation.cs`
- `COMETwebapp/ViewModels/Pages/TabsViewModel.cs`
- `COMETwebapp/Pages/Tabs.razor`, `COMETwebapp/Pages/Tabs.razor.cs`
- `COMET.Web.Common/Components/Applications/ApplicationBase.razor.cs`

### 2. The shared element details panel never signalled a re-render

`ElementDetailsPanelViewModel.RefreshSelectedElement()` correctly re-resolved the selected
element and rebuilt its rows from the live session cache, but never toggled `IsLoading`.
`ApplicationBase` calls `StateHasChanged` **only** when `IsLoading` changes, so the panel
held correct data behind a stale screen. This is what hid parameter add/edit/delete,
parameter group changes, and element definition/usage edits, in both directions.

`RefreshSelectedElement()` now toggles `IsLoading`.

- `COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs`
- `COMETwebapp/ViewModels/Components/Common/IElementDetailsPanelViewModel.cs`
- `COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs`

### 3. Three applications never reacted to another panel's write at all

`ParameterEditorBodyViewModel`, `ModelDashboardBodyViewModel` and
`SubscriptionDashboardBodyViewModel` had no `OnEndUpdate()` override, and the base
implementation is a no-op. A write arrives as `ObjectChangedEvent` + `SessionEvent(EndUpdate)`;
`SessionServiceEvent.SessionRefreshed` only fires on an explicit session reload. These three
therefore ignored every write made by any other open application.

Each now overrides `OnEndUpdate()` to route into its existing `OnSessionRefreshed()`.

- `COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs`
- `COMETwebapp/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModel.cs`
- `COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModel.cs`

### 4. Tree ViewModels silently discarded child-type changes

Two mirror-image bugs:

- **Model Editor tree**: `ElementDefinitionTreeViewModel` registers `typeof(ElementBase)`, so
  `ElementUsage` events *were* recorded, but `AddRows`/`UpdateRows`/`RemoveRows` then filtered
  with `.OfType<ElementDefinition>()` and threw them away. Every usage add, rename and delete
  was invisible. Underneath that, `ElementDefinitionTreeRowViewModel.UpdateProperties` diffed
  its child rows by adding and removing them but **never updated a surviving child**, so a
  rename would have been dropped even once it got through. Both halves are fixed: usage changes
  now route to the containing definition's row via `Container` and re-diff against the live
  object graph, and the child diff updates survivors.

- **System Representation product tree**: `RefreshProductTree` passed only
  `.OfType<ElementUsage>()` to `UpdateElementsFromTree`. Every tree node except the root wraps
  a usage; the root wraps the top `ElementDefinition`. Renaming the top element therefore never
  updated the root node. It now passes `ElementBase` (usages and definitions).

- `COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionTreeViewModel.cs`
- `COMETwebapp/ViewModels/Components/ModelEditor/Rows/ElementDefinitionTreeRowViewModel.cs`
- `COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs`

## Known gaps, deliberately not addressed here

- `ParameterEditorBodyViewModel` registers only `ElementBase`, `ParameterOrOverrideBase` and
  `ParameterValueSetBase`. A **ParameterGroup** change made elsewhere still will not surface in
  the Parameter Editor, and `ParameterTableViewModel` has no row handling for that type. Closing
  this means new row logic, which is a feature change rather than a wiring fix.
- `ParameterSubscriptionValueSet` extends `Thing` directly, not `ParameterValueSetBase`, so the
  Parameter Editor's registration does not catch subscription value edits. No current symptom
  (it renders no per-subscription values), but any future column there would inherit the gap.

