### PR TITLE
features #803 and #807 link parametric constraints and drag n drop groups in ToC and cosmetic fixes

### DIFF
--- a/COMETwebapp.Tests/Components/RequirementsEditor/DeprecateThingButtonTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/DeprecateThingButtonTestFixture.cs
@@ -1,0 +1,97 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DeprecateThingButtonTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using DevExpress.Blazor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DeprecateThingButtonTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<DeprecateThingButton> Render(Thing thing)
+        {
+            return this.context.Render<DeprecateThingButton>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Thing, thing));
+        }
+
+        [Test]
+        public void VerifyIconAndTooltipReflectTheDeprecationState()
+        {
+            var active = new Requirement { Iid = Guid.NewGuid() };
+            var deprecated = new RequirementsSpecification { Iid = Guid.NewGuid(), IsDeprecated = true };
+
+            var activeButton = this.Render(active).FindComponent<DxButton>().Instance;
+            var deprecatedButton = this.Render(deprecated).FindComponent<DxButton>().Instance;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(activeButton.IconCssClass, Is.EqualTo("oi oi-ban"));
+                Assert.That(activeButton.Attributes["title"], Is.EqualTo("Deprecate requirement"));
+                Assert.That(deprecatedButton.IconCssClass, Is.EqualTo("oi oi-action-undo"));
+                Assert.That(deprecatedButton.Attributes["title"], Is.EqualTo("Restore specification"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyClickConfirmsDeprecation()
+        {
+            var requirement = new Requirement { Iid = Guid.NewGuid() };
+            var component = this.Render(requirement);
+
+            await component.InvokeAsync(component.FindComponent<DxButton>().Instance.Click.InvokeAsync);
+
+            this.viewModel.Verify(x => x.ConfirmDeprecation(requirement), Times.Once);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/EditThingButtonTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/EditThingButtonTestFixture.cs
@@ -1,0 +1,94 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditThingButtonTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using DevExpress.Blazor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class EditThingButtonTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<EditThingButton> Render(Thing thing)
+        {
+            return this.context.Render<EditThingButton>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Thing, thing));
+        }
+
+        [Test]
+        public void VerifyTooltipReflectsTheThingKind()
+        {
+            var requirement = new Requirement { Iid = Guid.NewGuid() };
+            var specification = new RequirementsSpecification { Iid = Guid.NewGuid() };
+            var group = new RequirementsGroup { Iid = Guid.NewGuid() };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.Render(requirement).FindComponent<DxButton>().Instance.Attributes["title"], Is.EqualTo("Edit requirement"));
+                Assert.That(this.Render(specification).FindComponent<DxButton>().Instance.Attributes["title"], Is.EqualTo("Edit specification"));
+                Assert.That(this.Render(group).FindComponent<DxButton>().Instance.Attributes["title"], Is.EqualTo("Edit group"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyClickOpensTheEditForm()
+        {
+            var requirement = new Requirement { Iid = Guid.NewGuid() };
+            var component = this.Render(requirement);
+
+            await component.InvokeAsync(component.FindComponent<DxButton>().Instance.Click.InvokeAsync);
+
+            this.viewModel.Verify(x => x.OpenEdit(requirement), Times.Once);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDefinitionCellTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDefinitionCellTestFixture.cs
@@ -1,0 +1,168 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementDefinitionCellTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components.Web;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementDefinitionCellTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private Requirement requirement;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.requirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R1" };
+            this.requirement.Definition.Add(new Definition { Iid = Guid.NewGuid(), LanguageCode = "en", Content = "Initial definition" });
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<RequirementDefinitionCell> Render()
+        {
+            return this.context.Render<RequirementDefinitionCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement));
+        }
+
+        [Test]
+        public void VerifyDisplayShowsDefinitionContent()
+        {
+            var cell = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.Markup, Does.Contain("req-def-display"));
+                Assert.That(cell.Markup, Does.Contain("Initial definition"));
+                Assert.That(cell.Markup, Does.Not.Contain("req-def-editor"));
+            });
+        }
+
+        [Test]
+        public void VerifyDisplayShowsPlaceholderWhenNoDefinition()
+        {
+            var undefinedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R2" };
+
+            var cell = this.context.Render<RequirementDefinitionCell>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, undefinedRequirement));
+
+            Assert.That(cell.Markup, Does.Contain("Click to add a definition"));
+        }
+
+        [Test]
+        public async Task VerifyClickingDisplayEntersEditModeAndShowsDirtyOnChange()
+        {
+            var cell = this.Render();
+
+            cell.Find(".req-def-display").Click();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.Markup, Does.Contain("req-def-editor"));
+                Assert.That(cell.Markup, Does.Not.Contain("req-def-editor-dirty"), "the editor is not dirty right after opening");
+            });
+
+            var memo = cell.FindComponent<DxMemo>();
+            await cell.InvokeAsync(() => memo.Instance.TextChanged.InvokeAsync("Updated definition"));
+
+            Assert.That(cell.Markup, Does.Contain("req-def-editor-dirty"), "an unsaved change marks the editor dirty");
+        }
+
+        [Test]
+        public async Task VerifySaveCommitsAndLeavesEditMode()
+        {
+            var cell = this.Render();
+
+            cell.Find(".req-def-display").Click();
+            var saveButton = cell.Find(".req-def-save");
+
+            await cell.InvokeAsync(() => saveButton.Click());
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.SaveInlineDefinitionAsync(this.requirement, "Initial definition"), Times.Once);
+                Assert.That(cell.Markup, Does.Not.Contain("req-def-editor"), "edit mode is left after saving");
+            });
+        }
+
+        [Test]
+        public void VerifyEscapeCancelsEdit()
+        {
+            var cell = this.Render();
+
+            cell.Find(".req-def-display").Click();
+            Assert.That(cell.Markup, Does.Contain("req-def-editor"));
+
+            cell.Find(".req-def-editor").KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.SaveInlineDefinitionAsync(It.IsAny<Requirement>(), It.IsAny<string>()), Times.Never);
+                Assert.That(cell.Markup, Does.Not.Contain("req-def-editor"));
+            });
+        }
+
+        [Test]
+        public void VerifyCancelButtonLeavesEditModeWithoutSaving()
+        {
+            var cell = this.Render();
+
+            cell.Find(".req-def-display").Click();
+            cell.Find(".req-def-cancel").Click();
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.SaveInlineDefinitionAsync(It.IsAny<Requirement>(), It.IsAny<string>()), Times.Never);
+                Assert.That(cell.Markup, Does.Not.Contain("req-def-editor"));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
@@ -247,5 +247,150 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
             mockedViewModel.Verify(x => x.UpdateParameterLinksAsync(relational, It.IsAny<IReadOnlyCollection<ParameterOrOverrideBase>>()), Times.Once);
             Assert.That(component.Instance.IsLinkDialogOpen, Is.False, "confirming closes the picker");
         }
+
+        [Test]
+        public async Task VerifyTogglingACandidateStagesAndUnstagesIt()
+        {
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = relational };
+            constraint.Expression.Add(relational);
+
+            var linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R3", Name = "Third requirement" };
+            linkedRequirement.ParametricConstraint.Add(constraint);
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" };
+            var boundParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = massType };
+            var unboundParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = massType };
+            elementDefinition.Parameter.AddRange([boundParameter, unboundParameter]);
+
+            IReadOnlyCollection<ParameterOrOverrideBase> capturedSelection = null;
+
+            var mockedViewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            mockedViewModel.Setup(x => x.ShowParametricConstraints).Returns(true);
+            mockedViewModel.Setup(x => x.GetTopExpressions(constraint)).Returns([relational]);
+            mockedViewModel.Setup(x => x.GetBoundParameters(relational)).Returns([boundParameter]);
+            mockedViewModel.Setup(x => x.GetPublishedValue(It.IsAny<ParameterOrOverrideBase>())).Returns((string)null);
+            mockedViewModel.Setup(x => x.GetLinkableParameters(relational)).Returns([boundParameter, unboundParameter]);
+            mockedViewModel.Setup(x => x.UpdateParameterLinksAsync(relational, It.IsAny<IReadOnlyCollection<ParameterOrOverrideBase>>()))
+                .Callback<RelationalExpression, IReadOnlyCollection<ParameterOrOverrideBase>>((_, selected) => capturedSelection = selected)
+                .Returns(Task.FromResult(Result.Ok()));
+
+            var component = this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, mockedViewModel.Object)
+                .Add(p => p.Requirement, linkedRequirement));
+
+            component.Find("button.req-expr-link").Click();
+
+            Assert.That(component.Markup, Does.Contain("(Satellite)"), "the picker labels each candidate with its owning element");
+
+            await component.InvokeAsync(() => component.FindComponents<DxCheckBox<bool>>()[1].Instance.CheckedChanged.InvokeAsync(true));
+            Assert.That(component.FindComponents<DxCheckBox<bool>>()[1].Instance.Checked, Is.True, "checking a candidate stages it");
+
+            await component.InvokeAsync(() => component.FindComponents<DxCheckBox<bool>>()[1].Instance.CheckedChanged.InvokeAsync(false));
+            Assert.That(component.FindComponents<DxCheckBox<bool>>()[1].Instance.Checked, Is.False, "unchecking a candidate unstages it");
+
+            var okButton = component.FindComponents<DxButton>().First(x => x.Instance.Text == "OK");
+            await component.InvokeAsync(okButton.Instance.Click.InvokeAsync);
+
+            Assert.That(capturedSelection, Is.EquivalentTo(new ParameterOrOverrideBase[] { boundParameter }), "only the still-bound parameter is submitted after staging then unstaging the other candidate");
+        }
+
+        [Test]
+        public async Task VerifyCancelLinksClosesPickerWithoutSaving()
+        {
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = relational };
+            constraint.Expression.Add(relational);
+
+            var linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R3", Name = "Third requirement" };
+            linkedRequirement.ParametricConstraint.Add(constraint);
+
+            var mockedViewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            mockedViewModel.Setup(x => x.ShowParametricConstraints).Returns(true);
+            mockedViewModel.Setup(x => x.GetTopExpressions(constraint)).Returns([relational]);
+            mockedViewModel.Setup(x => x.GetBoundParameters(relational)).Returns([]);
+            mockedViewModel.Setup(x => x.GetPublishedValue(It.IsAny<ParameterOrOverrideBase>())).Returns((string)null);
+            mockedViewModel.Setup(x => x.GetLinkableParameters(relational)).Returns([]);
+
+            var component = this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, mockedViewModel.Object)
+                .Add(p => p.Requirement, linkedRequirement));
+
+            component.Find("button.req-expr-link").Click();
+            Assert.That(component.Instance.IsLinkDialogOpen, Is.True);
+
+            var cancelButton = component.FindComponents<DxButton>().First(x => x.Instance.Text == "Cancel");
+            await component.InvokeAsync(cancelButton.Instance.Click.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Instance.IsLinkDialogOpen, Is.False, "cancelling closes the picker");
+                mockedViewModel.Verify(x => x.UpdateParameterLinksAsync(It.IsAny<RelationalExpression>(), It.IsAny<IReadOnlyCollection<ParameterOrOverrideBase>>()), Times.Never);
+            });
+        }
+
+        [Test]
+        public async Task VerifyClosingPickerViaPopupVisibleChanged()
+        {
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = relational };
+            constraint.Expression.Add(relational);
+
+            var linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R3", Name = "Third requirement" };
+            linkedRequirement.ParametricConstraint.Add(constraint);
+
+            var mockedViewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            mockedViewModel.Setup(x => x.ShowParametricConstraints).Returns(true);
+            mockedViewModel.Setup(x => x.GetTopExpressions(constraint)).Returns([relational]);
+            mockedViewModel.Setup(x => x.GetBoundParameters(relational)).Returns([]);
+            mockedViewModel.Setup(x => x.GetPublishedValue(It.IsAny<ParameterOrOverrideBase>())).Returns((string)null);
+            mockedViewModel.Setup(x => x.GetLinkableParameters(relational)).Returns([]);
+
+            var component = this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, mockedViewModel.Object)
+                .Add(p => p.Requirement, linkedRequirement));
+
+            component.Find("button.req-expr-link").Click();
+            Assert.That(component.Instance.IsLinkDialogOpen, Is.True);
+
+            var popup = component.FindComponent<DxPopup>();
+            await component.InvokeAsync(() => popup.Instance.VisibleChanged.InvokeAsync(false));
+
+            Assert.That(component.Instance.IsLinkDialogOpen, Is.False, "closing the popup via its close button closes the picker");
+        }
+
+        [Test]
+        public void VerifyEmptyCandidatesShowsPlaceholder()
+        {
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = relational };
+            constraint.Expression.Add(relational);
+
+            var linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R3", Name = "Third requirement" };
+            linkedRequirement.ParametricConstraint.Add(constraint);
+
+            var mockedViewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            mockedViewModel.Setup(x => x.ShowParametricConstraints).Returns(true);
+            mockedViewModel.Setup(x => x.GetTopExpressions(constraint)).Returns([relational]);
+            mockedViewModel.Setup(x => x.GetBoundParameters(relational)).Returns([]);
+            mockedViewModel.Setup(x => x.GetPublishedValue(It.IsAny<ParameterOrOverrideBase>())).Returns((string)null);
+            mockedViewModel.Setup(x => x.GetLinkableParameters(relational)).Returns([]);
+
+            var component = this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, mockedViewModel.Object)
+                .Add(p => p.Requirement, linkedRequirement));
+
+            component.Find("button.req-expr-link").Click();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Markup, Does.Contain("No element has a parameter of this type."));
+                Assert.That(component.FindComponents<DxCheckBox<bool>>(), Is.Empty);
+            });
+        }
     }
 }

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementDetailsTestFixture.cs
@@ -37,6 +37,10 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
 
+    using DevExpress.Blazor;
+
+    using FluentResults;
+
     using Microsoft.Extensions.Logging;
 
     using Moq;
@@ -58,6 +62,8 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
         public void SetUp()
         {
             this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
             this.messageBus = new CDPMessageBus();
 
             var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
@@ -194,6 +200,52 @@ namespace COMETwebapp.Tests.Components.RequirementsEditor
             component.Find(".req-link-req").Click();
 
             Assert.That(this.viewModel.ScrollTarget, Is.Not.Null, "clicking a requirement link navigates to it");
+        }
+
+        [Test]
+        public async Task VerifyParameterLinkPicker()
+        {
+            var massType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            var relational = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = massType, RelationalOperator = RelationalOperatorKind.LE, Value = new ValueArray<string>(["100"]) };
+            var constraint = new ParametricConstraint { Iid = Guid.NewGuid(), TopExpression = relational };
+            constraint.Expression.Add(relational);
+
+            var linkedRequirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R3", Name = "Third requirement" };
+            linkedRequirement.ParametricConstraint.Add(constraint);
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT", Name = "Satellite" };
+            var boundParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = massType };
+            var unboundParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = massType };
+            elementDefinition.Parameter.AddRange([boundParameter, unboundParameter]);
+
+            var mockedViewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            mockedViewModel.Setup(x => x.ShowParametricConstraints).Returns(true);
+            mockedViewModel.Setup(x => x.GetTopExpressions(constraint)).Returns([relational]);
+            mockedViewModel.Setup(x => x.GetBoundParameters(relational)).Returns([boundParameter]);
+            mockedViewModel.Setup(x => x.GetPublishedValue(It.IsAny<ParameterOrOverrideBase>())).Returns((string)null);
+            mockedViewModel.Setup(x => x.GetLinkableParameters(relational)).Returns([boundParameter, unboundParameter]);
+            mockedViewModel.Setup(x => x.UpdateParameterLinksAsync(relational, It.IsAny<IReadOnlyCollection<ParameterOrOverrideBase>>())).Returns(Task.FromResult(Result.Ok()));
+
+            var component = this.context.Render<RequirementDetails>(parameters => parameters
+                .Add(p => p.ViewModel, mockedViewModel.Object)
+                .Add(p => p.Requirement, linkedRequirement));
+
+            var linkButton = component.Find("button.req-expr-link");
+            linkButton.Click();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Instance.IsLinkDialogOpen, Is.True);
+                Assert.That(component.FindComponents<DxCheckBox<bool>>(), Has.Count.EqualTo(2), "both candidates are offered by the picker");
+                Assert.That(component.FindComponents<DxCheckBox<bool>>()[0].Instance.Checked, Is.True, "the already-bound parameter is pre-checked");
+                Assert.That(component.FindComponents<DxCheckBox<bool>>()[1].Instance.Checked, Is.False, "the unbound candidate is not pre-checked");
+            });
+
+            var okButton = component.FindComponents<DxButton>().First(x => x.Instance.Text == "OK");
+            await component.InvokeAsync(okButton.Instance.Click.InvokeAsync);
+
+            mockedViewModel.Verify(x => x.UpdateParameterLinksAsync(relational, It.IsAny<IReadOnlyCollection<ParameterOrOverrideBase>>()), Times.Once);
+            Assert.That(component.Instance.IsLinkDialogOpen, Is.False, "confirming closes the picker");
         }
     }
 }

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementPillsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementPillsTestFixture.cs
@@ -1,0 +1,102 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementPillsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementPillsTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private DomainOfExpertise owner;
+        private Category category;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.category = new Category { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements" };
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<RequirementPills> Render()
+        {
+            return this.context.Render<RequirementPills>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Owner, this.owner)
+                .Add(p => p.Categories, [this.category]));
+        }
+
+        [Test]
+        public void VerifyPillsRenderWhenEnabled()
+        {
+            this.viewModel.Setup(x => x.ShowOwner).Returns(true);
+            this.viewModel.Setup(x => x.ShowCategory).Returns(true);
+
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Markup, Does.Contain("SYS"), "the owner pill renders");
+                Assert.That(component.Markup, Does.Contain("KUR"), "the category pill renders");
+            });
+        }
+
+        [Test]
+        public void VerifyPillsAreHiddenWhenDisabled()
+        {
+            this.viewModel.Setup(x => x.ShowOwner).Returns(false);
+            this.viewModel.Setup(x => x.ShowCategory).Returns(false);
+
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Markup, Does.Not.Contain("SYS"), "the owner pill is hidden");
+                Assert.That(component.Markup, Does.Not.Contain("KUR"), "the category pill is hidden");
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementRowActionsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementRowActionsTestFixture.cs
@@ -1,0 +1,158 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRowActionsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using DevExpress.Blazor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementRowActionsTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private Requirement requirement;
+        private DomainOfExpertise owner;
+        private Category category;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.category = new Category { Iid = Guid.NewGuid(), ShortName = "KUR", Name = "Key-User Requirements" };
+
+            this.requirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R1", Name = "First requirement", Owner = this.owner };
+            this.requirement.Category.Add(this.category);
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            this.viewModel.Setup(x => x.ShowOwner).Returns(true);
+            this.viewModel.Setup(x => x.ShowCategory).Returns(true);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<RequirementRowActions> Render()
+        {
+            return this.context.Render<RequirementRowActions>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement));
+        }
+
+        [Test]
+        public void VerifyPillActionRowsRender()
+        {
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.FindAll(".req-pill-action-row"), Has.Count.EqualTo(2));
+                Assert.That(component.Markup, Does.Contain("SYS"), "the owner pill is shown");
+                Assert.That(component.Markup, Does.Contain("KUR"), "the category pill is shown");
+                Assert.That(component.Markup, Does.Not.Contain("req-deprecated-badge"), "a non-deprecated requirement has no badge");
+            });
+        }
+
+        [Test]
+        public void VerifyInlineLayoutRendersPillsAndBothActionsOnOneRow()
+        {
+            var component = this.context.Render<RequirementRowActions>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.Inline, true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.FindAll(".req-pill-action-row"), Is.Empty, "the inline layout does not use the stacked pill-action rows");
+                Assert.That(component.FindAll(".req-pills"), Has.Count.EqualTo(1), "the inline layout uses a single RequirementPills block");
+                Assert.That(component.Markup, Does.Contain("SYS").And.Contain("KUR"));
+                Assert.That(component.FindComponents<DxButton>().Select(x => x.Instance.IconCssClass), Does.Contain("oi oi-pencil").And.Contain("oi oi-ban"));
+            });
+        }
+
+        [Test]
+        public void VerifyDeprecatedBadgeShowsWhenRequirementIsDeprecated()
+        {
+            this.requirement.IsDeprecated = true;
+
+            var component = this.Render();
+
+            Assert.That(component.Markup, Does.Contain("req-deprecated-badge"));
+        }
+
+        [Test]
+        public void VerifyPillsAreHiddenWhenDisabled()
+        {
+            this.viewModel.Setup(x => x.ShowOwner).Returns(false);
+            this.viewModel.Setup(x => x.ShowCategory).Returns(false);
+
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Markup, Does.Not.Contain("SYS"));
+                Assert.That(component.Markup, Does.Not.Contain("KUR"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyEditButtonOpensEdit()
+        {
+            var component = this.Render();
+            var editButton = component.FindComponents<DxButton>().First(x => x.Instance.IconCssClass == "oi oi-pencil");
+
+            await component.InvokeAsync(editButton.Instance.Click.InvokeAsync);
+
+            this.viewModel.Verify(x => x.OpenEdit(this.requirement), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyDeprecateButtonConfirmsDeprecation()
+        {
+            var component = this.Render();
+            var deprecateButton = component.FindComponents<DxButton>().First(x => x.Instance.IconCssClass == "oi oi-ban");
+
+            await component.InvokeAsync(deprecateButton.Instance.Click.InvokeAsync);
+
+            this.viewModel.Verify(x => x.ConfirmDeprecation(this.requirement), Times.Once);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementRowTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementRowTestFixture.cs
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRowTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementRowTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private Requirement requirement;
+        private SimpleQuantityKind parameterType;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+            this.context.Services.AddSingleton<ICDPMessageBus>(new CDPMessageBus());
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            this.parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), ShortName = "m", Name = "mass" };
+            this.requirement = new Requirement { Iid = Guid.NewGuid(), ShortName = "R1", Name = "First requirement", Owner = domain };
+            this.requirement.Definition.Add(new Definition { Iid = Guid.NewGuid(), LanguageCode = "en", Content = "The system shall do it." });
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            this.viewModel.Setup(x => x.DisplayMode).Returns(RequirementRowDisplayMode.ShortNameNameAndDefinition);
+            this.viewModel.Setup(x => x.ShowOwner).Returns(true);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<RequirementRow> Render(bool valuesBelow = false)
+        {
+            return this.context.Render<RequirementRow>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object)
+                .Add(p => p.Requirement, this.requirement)
+                .Add(p => p.VisibleParameterTypes, [this.parameterType])
+                .Add(p => p.ValuesBelow, valuesBelow));
+        }
+
+        [Test]
+        public void VerifyDisplayModesRenderTheIdentityAndDefinition()
+        {
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Setup(x => x.DisplayMode).Returns(RequirementRowDisplayMode.ShortNameNameAndDefinition);
+                Assert.That(this.Render().Markup, Does.Contain("req-row-header").And.Contain("The system shall do it."));
+
+                this.viewModel.Setup(x => x.DisplayMode).Returns(RequirementRowDisplayMode.ShortNameAndDefinition);
+                Assert.That(this.Render().Markup, Does.Contain("R1").And.Contain("req-def-display"));
+
+                this.viewModel.Setup(x => x.DisplayMode).Returns(RequirementRowDisplayMode.NameAndDefinition);
+                Assert.That(this.Render().Markup, Does.Contain("First requirement"));
+            });
+        }
+
+        [Test]
+        public void VerifyValueColumnsRenderInlineAndBelow()
+        {
+            this.viewModel.Setup(x => x.ShowSimpleParameterValues).Returns(true);
+
+            var inline = this.Render();
+            var below = this.Render(valuesBelow: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(inline.FindAll(".req-value-cell"), Is.Not.Empty, "a value cell renders for the visible parameter type");
+                Assert.That(inline.FindAll(".req-pills-cell"), Has.Count.EqualTo(1), "the pills trail the values inline");
+                Assert.That(below.FindAll(".req-pills-corner"), Has.Count.EqualTo(1), "with values-below the pills move to the corner");
+            });
+        }
+
+        [Test]
+        public void VerifyPillsAndActionsRenderWhenValuesAreHidden()
+        {
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.FindAll(".req-value-cell"), Is.Empty);
+                Assert.That(component.Markup, Does.Contain("SYS"), "the inline owner pill renders");
+                Assert.That(component.FindComponent<RequirementRowActions>().Instance.Inline, Is.True);
+            });
+        }
+
+        [Test]
+        public void VerifyConstraintsAndTraceabilitySectionRendersWhenEnabled()
+        {
+            this.viewModel.Setup(x => x.ShowTraceability).Returns(true);
+            this.viewModel.Setup(x => x.GetTraceability(this.requirement)).Returns([]);
+
+            Assert.That(this.Render().FindComponents<RequirementDetails>(), Has.Count.EqualTo(1));
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsTreeTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RequirementsEditor/RequirementsTreeTestFixture.cs
@@ -1,0 +1,176 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementsTreeTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.RequirementsEditor
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.RequirementsEditor;
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using FluentResults;
+
+    using Microsoft.AspNetCore.Components.Web;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RequirementsTreeTestFixture
+    {
+        private BunitContext context;
+        private Mock<IRequirementsEditorBodyViewModel> viewModel;
+        private RequirementsSpecification specification;
+        private RequirementsGroup groupA;
+        private RequirementsGroup groupB;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.specification = new RequirementsSpecification { Iid = Guid.NewGuid(), ShortName = "SPEC", Name = "Specification" };
+            this.groupA = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "GA", Name = "Group A" };
+            this.groupB = new RequirementsGroup { Iid = Guid.NewGuid(), ShortName = "GB", Name = "Group B" };
+            this.specification.Group.Add(this.groupA);
+            this.groupA.Group.Add(this.groupB);
+
+            this.viewModel = new Mock<IRequirementsEditorBodyViewModel>();
+            this.viewModel.Setup(x => x.AvailableSpecifications).Returns([this.specification]);
+            this.viewModel.Setup(x => x.SelectedSpecification).Returns(this.specification);
+            this.viewModel.Setup(x => x.TreeUsesShortName).Returns(true);
+            this.viewModel.Setup(x => x.GetGroups(this.specification)).Returns([this.groupA]);
+            this.viewModel.Setup(x => x.GetGroups(this.groupA)).Returns([this.groupB]);
+            this.viewModel.Setup(x => x.GetGroups(this.groupB)).Returns([]);
+            this.viewModel.Setup(x => x.IsTreeNodeCollapsed(It.IsAny<Guid>())).Returns(false);
+            this.viewModel.Setup(x => x.CanMoveGroup(It.IsAny<RequirementsGroup>(), It.IsAny<RequirementsContainer>())).Returns(false);
+            this.viewModel.SetupProperty(x => x.DraggedGroup, null);
+            this.viewModel.SetupProperty(x => x.DragOverContainer, null);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        private IRenderedComponent<RequirementsTree> Render()
+        {
+            return this.context.Render<RequirementsTree>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel.Object));
+        }
+
+        [Test]
+        public void VerifyTreeRendersSpecificationAndGroupHierarchy()
+        {
+            var component = this.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(component.Markup, Does.Contain("SPEC"));
+                Assert.That(component.Markup, Does.Contain("GA"));
+                Assert.That(component.Markup, Does.Contain("GB"));
+                Assert.That(component.FindAll(".req-tree-group-row"), Has.Count.EqualTo(2), "both the parent and nested group are rendered");
+            });
+        }
+
+        [Test]
+        public async Task VerifyOnGroupDragStart()
+        {
+            var component = this.Render();
+            var groupRow = component.Find(".req-tree-group-row");
+
+            await component.InvokeAsync(() => groupRow.DragStartAsync(new DragEventArgs()));
+
+            Assert.That(this.viewModel.Object.DraggedGroup, Is.EqualTo(this.groupA));
+        }
+
+        [Test]
+        public async Task VerifyOnDragEnter()
+        {
+            var component = this.Render();
+            var groupRows = component.FindAll(".req-tree-group-row");
+
+            await component.InvokeAsync(() => groupRows[1].DragEnterAsync(new DragEventArgs()));
+            Assert.That(this.viewModel.Object.DragOverContainer, Is.EqualTo(this.groupB), "hovering the nested group row marks it as the drag-over container");
+
+            var specRow = component.Find(".req-tree-spec");
+            await component.InvokeAsync(() => specRow.DragEnterAsync(new DragEventArgs()));
+            Assert.That(this.viewModel.Object.DragOverContainer, Is.EqualTo(this.specification), "hovering the specification row marks it as the drag-over container");
+        }
+
+        [Test]
+        public async Task VerifyOnGroupDragEnd()
+        {
+            this.viewModel.Object.DraggedGroup = this.groupA;
+            this.viewModel.Object.DragOverContainer = this.groupB;
+
+            var component = this.Render();
+            var groupRow = component.Find(".req-tree-group-row");
+
+            await component.InvokeAsync(() => groupRow.DragEndAsync(new DragEventArgs()));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.Object.DraggedGroup, Is.Null, "the drag ending clears the dragged group");
+                Assert.That(this.viewModel.Object.DragOverContainer, Is.Null, "the drag ending clears the drag-over container");
+            });
+        }
+
+        [Test]
+        public async Task VerifyOnDropOnContainer()
+        {
+            this.viewModel.Object.DraggedGroup = this.groupB;
+            this.viewModel.Object.DragOverContainer = this.groupA;
+            this.viewModel.Setup(x => x.CanMoveGroup(this.groupB, this.groupA)).Returns(true);
+            this.viewModel.Setup(x => x.MoveGroupAsync(this.groupB, this.groupA)).Returns(Task.FromResult(Result.Ok()));
+
+            var component = this.Render();
+            var dropTargetRow = component.Find(".req-tree-group-row");
+
+            Assert.That(dropTargetRow.ClassList, Does.Contain("req-tree-droptarget"), "the hovered, allowed drop target is highlighted");
+
+            await component.InvokeAsync(() => dropTargetRow.DropAsync(new DragEventArgs()));
+
+            Assert.Multiple(() =>
+            {
+                this.viewModel.Verify(x => x.MoveGroupAsync(this.groupB, this.groupA), Times.Once, "an allowed drop moves the group");
+                Assert.That(this.viewModel.Object.DraggedGroup, Is.Null, "the drag state is cleared after the drop");
+            });
+
+            this.viewModel.Invocations.Clear();
+            this.viewModel.Object.DraggedGroup = this.groupB;
+            this.viewModel.Setup(x => x.CanMoveGroup(this.groupB, this.groupA)).Returns(false);
+
+            var secondComponent = this.Render();
+            await secondComponent.InvokeAsync(() => secondComponent.Find(".req-tree-group-row").DropAsync(new DragEventArgs()));
+
+            this.viewModel.Verify(x => x.MoveGroupAsync(It.IsAny<RequirementsGroup>(), It.IsAny<RequirementsContainer>()), Times.Never, "a disallowed drop must not move the group");
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModelTestFixture.cs
@@ -132,6 +132,24 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
         }
 
         [Test]
+        public void VerifyCanSaveRequiresADefinitionForRequirements()
+        {
+            var requirement = new Requirement { Iid = Guid.NewGuid(), Owner = this.domain };
+            this.viewModel.InitializeViewModel(requirement, this.iteration, []);
+
+            Assert.That(this.viewModel.CanSave, Is.False, "A requirement without a definition cannot be saved.");
+
+            this.viewModel.PrimaryDefinitionContent = "The system shall do something.";
+            Assert.That(this.viewModel.CanSave, Is.True, "A requirement with a non-empty definition can be saved.");
+
+            this.viewModel.PrimaryDefinitionContent = "   ";
+            Assert.That(this.viewModel.CanSave, Is.False, "A whitespace-only definition does not count.");
+
+            this.viewModel.InitializeViewModel(this.group, this.iteration, []);
+            Assert.That(this.viewModel.CanSave, Is.True, "A group is always saveable without a definition.");
+        }
+
+        [Test]
         public void VerifyRequirementExposesParameterTypesAndItself()
         {
             var requirement = new Requirement { Iid = Guid.NewGuid(), Owner = this.domain };

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
@@ -508,6 +508,163 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
         }
 
         [Test]
+        public async Task VerifyGetBoundParameters()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            Assert.That(this.viewModel.GetBoundParameters(relationalExpression), Is.Empty);
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT" };
+            var parameterA = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            var parameterB = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            elementDefinition.Parameter.AddRange([parameterA, parameterB]);
+
+            this.iteration.Relationship.AddRange([
+                new BinaryRelationship { Iid = Guid.NewGuid(), Source = relationalExpression, Target = parameterA },
+                new BinaryRelationship { Iid = Guid.NewGuid(), Source = parameterB, Target = relationalExpression }
+            ]);
+
+            Assert.That(this.viewModel.GetBoundParameters(relationalExpression), Is.EquivalentTo(new ParameterOrOverrideBase[] { parameterA, parameterB }));
+
+            this.viewModel.CurrentThing = null;
+            Assert.That(this.viewModel.GetBoundParameters(relationalExpression), Is.Empty);
+        }
+
+        [Test]
+        public async Task VerifyGetLinkableParameters()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            Assert.That(this.viewModel.GetLinkableParameters(new RelationalExpression { Iid = Guid.NewGuid() }), Is.Empty, "a null parameter type yields no candidates");
+
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT" };
+            var matchingParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            var otherParameter = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.lengthParameterType };
+            elementDefinition.Parameter.AddRange([matchingParameter, otherParameter]);
+
+            var elementUsage = new ElementUsage { Iid = Guid.NewGuid(), ShortName = "sat_1", ElementDefinition = elementDefinition };
+            var matchingOverride = new ParameterOverride { Iid = Guid.NewGuid(), Parameter = matchingParameter };
+            elementUsage.ParameterOverride.Add(matchingOverride);
+            elementDefinition.ContainedElement.Add(elementUsage);
+
+            this.iteration.Element.Add(elementDefinition);
+
+            Assert.That(this.viewModel.GetLinkableParameters(relationalExpression), Is.EqualTo(new ParameterOrOverrideBase[] { matchingParameter, matchingOverride }));
+
+            this.viewModel.CurrentThing = null;
+            Assert.That(this.viewModel.GetLinkableParameters(relationalExpression), Is.Empty);
+        }
+
+        [Test]
+        public async Task VerifyUpdateParameterLinksAsync()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.sessionService.Setup(x => x.CreateUpdateAndDeleteThingsWithNotification(
+                It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>())).ReturnsAsync(Result.Ok());
+
+            var relationalExpression = new RelationalExpression { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            var elementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), ShortName = "SAT" };
+            var parameterA = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            var parameterB = new Parameter { Iid = Guid.NewGuid(), ParameterType = this.massParameterType };
+            elementDefinition.Parameter.AddRange([parameterA, parameterB]);
+            this.iteration.Element.Add(elementDefinition);
+
+            // Case A: expression currently unbound, select parameterA -> one create, no delete
+            var resultA = await this.viewModel.UpdateParameterLinksAsync(relationalExpression, [parameterA]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultA.IsSuccess, Is.True);
+
+                this.sessionService.Verify(x => x.CreateUpdateAndDeleteThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(things => things.OfType<BinaryRelationship>().Count() == 1
+                        && things.OfType<Iteration>().Count() == 1
+                        && things.OfType<BinaryRelationship>().Single().Source == parameterA
+                        && things.OfType<BinaryRelationship>().Single().Target == relationalExpression
+                        && things.OfType<BinaryRelationship>().Single().Owner == this.systemDomain),
+                    It.Is<IReadOnlyCollection<Thing>>(things => things.Count == 0),
+                    It.IsAny<NotificationDescription>()), Times.Once);
+            });
+
+            // simulate the created relationship now existing so the next calls diff against it
+            this.iteration.Relationship.Add(new BinaryRelationship { Iid = Guid.NewGuid(), Source = relationalExpression, Target = parameterA });
+            this.sessionService.Invocations.Clear();
+
+            // Case B: unchanged selection must not call the session
+            var resultB = await this.viewModel.UpdateParameterLinksAsync(relationalExpression, [parameterA]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultB.IsSuccess, Is.True);
+
+                this.sessionService.Verify(x => x.CreateUpdateAndDeleteThingsWithNotification(
+                    It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Never);
+            });
+
+            // Case C: swap parameterA for parameterB -> one create, one delete
+            var resultC = await this.viewModel.UpdateParameterLinksAsync(relationalExpression, [parameterB]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resultC.IsSuccess, Is.True);
+
+                this.sessionService.Verify(x => x.CreateUpdateAndDeleteThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(things => things.OfType<BinaryRelationship>().Count() == 1
+                        && things.OfType<BinaryRelationship>().Single().Source == parameterB),
+                    It.Is<IReadOnlyCollection<Thing>>(things => things.Count == 1),
+                    It.IsAny<NotificationDescription>()), Times.Once);
+            });
+        }
+
+        [Test]
+        public void VerifyCanMoveGroup()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.CanMoveGroup(this.c4iGroup, this.specification), Is.True, "a nested group can be promoted to the specification");
+                Assert.That(this.viewModel.CanMoveGroup(this.c4iGroup, this.operateGroup), Is.False, "moving onto the current parent is a no-op");
+                Assert.That(this.viewModel.CanMoveGroup(this.operateGroup, this.specification), Is.False, "the group is already directly under the specification");
+                Assert.That(this.viewModel.CanMoveGroup(this.operateGroup, this.c4iGroup), Is.False, "a group cannot be nested under its own descendant");
+                Assert.That(this.viewModel.CanMoveGroup(this.c4iGroup, this.c4iGroup), Is.False, "a group cannot be nested under itself");
+                Assert.That(this.viewModel.CanMoveGroup(null, this.specification), Is.False);
+            });
+        }
+
+        [Test]
+        public async Task VerifyMoveGroupAsync()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var invalid = await this.viewModel.MoveGroupAsync(this.operateGroup, this.c4iGroup);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(invalid.IsSuccess, Is.False, "a cyclic move is rejected");
+                this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(It.IsAny<Thing>(), It.IsAny<IReadOnlyCollection<Thing>>(), It.IsAny<NotificationDescription>()), Times.Never);
+            });
+
+            var result = await this.viewModel.MoveGroupAsync(this.c4iGroup, this.specification);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSuccess, Is.True);
+
+                // mirrors the IME: only the new container (the specification) is written, with the moved group added
+                this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(
+                    It.IsAny<Thing>(),
+                    It.Is<IReadOnlyCollection<Thing>>(things =>
+                        things.OfType<RequirementsSpecification>().Single(s => s.Iid == this.specification.Iid).Group.Any(g => g.Iid == this.c4iGroup.Iid)
+                        && things.All(t => t.Iid != this.operateGroup.Iid)),
+                    It.IsAny<NotificationDescription>()), Times.Once);
+            });
+        }
+
+        [Test]
         public async Task VerifyGetExpressionSummary()
         {
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
@@ -604,6 +761,27 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
                 Assert.That(this.viewModel.GetRequirements(this.c4iGroup), Does.Contain(this.c4iRequirement));
                 Assert.That(this.showHideService.ShowDeprecatedThings, Is.False, "a non-deprecated target does not flip the global toggle");
             });
+        }
+
+        [Test]
+        public async Task VerifySaveInlineDefinitionUsesDefaultLanguage()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            var requirementWithoutDefinition = new Requirement { Iid = Guid.NewGuid(), ShortName = "R99", Name = "No definition yet", Owner = this.systemDomain };
+            this.specification.Requirement.Add(requirementWithoutDefinition);
+
+            var siteDirectory = new SiteDirectory { Iid = Guid.NewGuid(), NaturalLanguage = { new NaturalLanguage { LanguageCode = "fr", Name = "French" } } };
+            this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+
+            Assert.That(requirementWithoutDefinition.Definition, Is.Empty);
+
+            await this.viewModel.SaveInlineDefinitionAsync(requirementWithoutDefinition, "Some new definition text.");
+
+            this.sessionService.Verify(x => x.CreateOrUpdateThingsWithNotification(
+                It.IsAny<Thing>(),
+                It.Is<IReadOnlyCollection<Thing>>(things => things.OfType<Definition>().Any(d => d.LanguageCode == "fr" && d.Content == "Some new definition text.")),
+                It.IsAny<NotificationDescription>()), Times.Once);
         }
 
         [Test]

--- a/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor
+++ b/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor
@@ -1,0 +1,24 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+<DxButton RenderStyle="ButtonRenderStyle.Light"
+          IconCssClass="@(this.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")"
+          title="@($"{(this.IsDeprecated ? "Restore" : "Deprecate")} {this.KindLabel}")"
+          Click="@(() => this.ViewModel.ConfirmDeprecation(this.Thing))" />

--- a/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor.cs
@@ -1,0 +1,66 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DeprecateThingButton.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// A compact deprecate/restore toggle button for a deprecatable <see cref="Requirement" /> or
+    /// <see cref="RequirementsSpecification" />; its icon and tooltip reflect the current deprecation state.
+    /// </summary>
+    public partial class DeprecateThingButton
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing" /> to deprecate or restore.
+        /// </summary>
+        [Parameter]
+        public Thing Thing { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Thing" /> is currently deprecated.
+        /// </summary>
+        private bool IsDeprecated => this.Thing is IDeprecatableThing { IsDeprecated: true };
+
+        /// <summary>
+        /// Gets the human-readable kind of the <see cref="Thing" /> used in the button tooltip.
+        /// </summary>
+        private string KindLabel => this.Thing switch
+        {
+            Requirement => "requirement",
+            RequirementsSpecification => "specification",
+            RequirementsGroup => "group",
+            _ => "item"
+        };
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/EditRequirementThing.razor
+++ b/COMETwebapp/Components/RequirementsEditor/EditRequirementThing.razor
@@ -97,7 +97,9 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </DxFormLayout>
         <ValidationSummary />
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true" />
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true"
+                      Enabled="@this.ViewModel.CanSave"
+                      title="@(this.ViewModel.CanSave ? null : "A requirement must have a definition")" />
         </div>
     </EditForm>
 }

--- a/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor
+++ b/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor
@@ -1,0 +1,21 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="@($"Edit {this.KindLabel}")" Click="@(() => this.ViewModel.OpenEdit(this.Thing))" />

--- a/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor.cs
@@ -1,0 +1,61 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EditThingButton.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// A compact edit button that opens the create/edit form for a <see cref="Requirement" />,
+    /// <see cref="RequirementsSpecification" /> or <see cref="RequirementsGroup" />.
+    /// </summary>
+    public partial class EditThingButton
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing" /> to edit.
+        /// </summary>
+        [Parameter]
+        public Thing Thing { get; set; }
+
+        /// <summary>
+        /// Gets the human-readable kind of the <see cref="Thing" /> used in the button tooltip.
+        /// </summary>
+        private string KindLabel => this.Thing switch
+        {
+            Requirement => "requirement",
+            RequirementsSpecification => "specification",
+            RequirementsGroup => "group",
+            _ => "item"
+        };
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor
@@ -1,0 +1,34 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@if (this.IsEditing)
+{
+    <span class="req-def-editor @(this.IsDirty ? "req-def-editor-dirty" : string.Empty)" @onkeydown="this.OnKeyDown">
+        <DxMemo @bind-Text="this.editingDefinition" BindValueMode="BindValueMode.OnInput" Rows="2" CssClass="req-def-memo" />
+        <span class="req-def-editor-actions">
+            <button type="button" class="req-def-save" title="Save" @onclick="this.ConfirmAsync">&#10003;</button>
+            <button type="button" class="req-def-cancel" title="Cancel (Esc)" @onclick="this.Cancel">&#10007;</button>
+        </span>
+    </span>
+}
+else
+{
+    <span class="req-def-display" title="Click to edit" @onclick="this.StartEdit">@this.GetDefinitionDisplay()</span>
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor.cs
@@ -1,0 +1,125 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementDefinitionCell.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
+
+    /// <summary>
+    /// The definition of a <see cref="Requirement" />: a click-to-edit display span that turns into a compact inline
+    /// editor. Each instance owns its own edit state, so only one cell is ever in edit mode at a time.
+    /// </summary>
+    public partial class RequirementDefinitionCell
+    {
+        /// <summary>
+        /// The staged definition text while editing, or <c>null</c> when this cell is not being edited.
+        /// </summary>
+        private string editingDefinition;
+
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> whose definition is rendered.
+        /// </summary>
+        [Parameter]
+        public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this cell is currently in edit mode.
+        /// </summary>
+        private bool IsEditing => this.editingDefinition != null;
+
+        /// <summary>
+        /// Gets whether the current inline edit has an unsaved change, so the editor can show the same "dirty"
+        /// highlight as the simple-parameter-value editor.
+        /// </summary>
+        private bool IsDirty => !string.Equals(this.editingDefinition ?? string.Empty, GetDefinition(this.Requirement), StringComparison.Ordinal);
+
+        /// <summary>
+        /// Gets the definition text of the given <paramref name="requirement" /> (its first definition).
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>The first definition's content, or an empty string</returns>
+        private static string GetDefinition(Requirement requirement)
+        {
+            return requirement.Definition.FirstOrDefault()?.Content ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the definition text of <see cref="Requirement" /> for display, or a placeholder when empty.
+        /// </summary>
+        /// <returns>The definition content, or a click-to-add placeholder</returns>
+        private string GetDefinitionDisplay()
+        {
+            var content = GetDefinition(this.Requirement);
+            return string.IsNullOrWhiteSpace(content) ? "Click to add a definition" : content;
+        }
+
+        /// <summary>
+        /// Starts the inline edit of this cell's definition.
+        /// </summary>
+        private void StartEdit()
+        {
+            this.editingDefinition = GetDefinition(this.Requirement);
+        }
+
+        /// <summary>
+        /// Cancels the current inline definition edit without saving.
+        /// </summary>
+        private void Cancel()
+        {
+            this.editingDefinition = null;
+        }
+
+        /// <summary>
+        /// Commits the current inline definition edit.
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task ConfirmAsync()
+        {
+            var content = this.editingDefinition;
+            this.editingDefinition = null;
+            await this.ViewModel.SaveInlineDefinitionAsync(this.Requirement, content);
+        }
+
+        /// <summary>
+        /// Cancels the inline definition edit when the Escape key is pressed.
+        /// </summary>
+        /// <param name="eventArgs">The <see cref="KeyboardEventArgs" /></param>
+        private void OnKeyDown(KeyboardEventArgs eventArgs)
+        {
+            if (eventArgs.Key == "Escape")
+            {
+                this.Cancel();
+            }
+        }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDefinitionCell.razor.css
@@ -1,0 +1,60 @@
+.req-def-display {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: pre-wrap;
+    cursor: text;
+    border-radius: 3px;
+    padding: 1px 3px;
+    transition: background-color 0.15s ease;
+}
+
+.req-def-display:hover {
+    background-color: #eef2ff;
+    box-shadow: inset 0 0 0 1px #c7d2fe;
+}
+
+.req-def-editor {
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+    align-items: flex-start;
+    gap: 4px;
+    max-width: 100%;
+}
+
+.req-def-editor-dirty {
+    outline: 2px solid #b9d0f0;
+    background: #e7f1ff;
+    border-radius: 4px;
+    padding: 2px;
+}
+
+.req-def-editor-actions {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 0 0 auto;
+}
+
+.req-def-save,
+.req-def-cancel {
+    border: none;
+    background: none;
+    padding: 0 3px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+.req-def-save {
+    color: #12805c;
+}
+
+.req-def-cancel {
+    color: #b42318;
+}
+
+::deep .req-def-memo {
+    flex: 1 1 auto;
+    min-width: 0;
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
@@ -107,6 +107,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <span class="req-section-title">Traceability</span>
                 @foreach (var row in traceabilityRows)
                 {
+                    var linkedDefinition = GetRequirementDefinitionText(row.RelatedThings.OfType<Requirement>().FirstOrDefault());
+
                     <div class="req-link-row">
                         <span class="req-link-direction" title="@GetDirectionTitle(row.Direction)">@GetDirectionSymbol(row.Direction)</span>
                         <span class="req-link-targets">
@@ -126,6 +128,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                                 }
                             }
                         </span>
+                        <span class="req-link-def" title="@linkedDefinition">@linkedDefinition</span>
                         <span class="req-pills">
                             @foreach (var ruleName in row.RuleNames)
                             {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
@@ -29,9 +29,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
         @<div class="req-expr">
             @if (expression is RelationalExpression relational)
             {
-                var boundModelCode = this.ViewModel.GetBoundParameterModelCode(relational);
-                var publishedValue = this.ViewModel.GetBoundParameterPublishedValue(relational);
-
                 <span class="req-expr-leaf">
                     <span class="req-expr-pt" title="@relational.ParameterType?.Name">@relational.ParameterType?.ShortName</span>
                     <span class="req-expr-op">@relational.RelationalOperator.ToScientificNotationString()</span>
@@ -40,14 +37,20 @@ Copyright (c) 2023-2026 Starion Group S.A.
                     {
                         <span class="req-expr-scale" title="@relational.Scale.Name">@relational.Scale.ShortName</span>
                     }
-                    @if (boundModelCode != null)
+                    @foreach (var boundParameter in this.ViewModel.GetBoundParameters(relational))
                     {
-                        <span class="req-expr-binding" title="Bound parameter">@boundModelCode</span>
+                        <span class="req-expr-binding" title="Bound parameter">@boundParameter.ModelCode()</span>
+                        var publishedValue = this.ViewModel.GetPublishedValue(boundParameter);
+
                         @if (publishedValue != null)
                         {
                             <span class="req-expr-published" title="Published value of the bound parameter">= @publishedValue</span>
                         }
                     }
+                    <button type="button" class="req-expr-link" title="Link to a parameter of an element"
+                            @onclick="@(() => this.OpenLinkDialog(relational))">
+                        <span class="oi oi-link-intact"></span>
+                    </button>
                 </span>
             }
             else
@@ -135,3 +138,36 @@ Copyright (c) 2023-2026 Starion Group S.A.
         }
     }
 </div>
+
+<DxPopup CloseOnOutsideClick="false"
+         ShowCloseButton="true"
+         HeaderText="Link to a Parameter"
+         Visible="@this.IsLinkDialogOpen"
+         VisibleChanged="@((bool visible) => this.OnLinkDialogVisibleChanged(visible))"
+         Width="min(420px, 92vw)">
+    <BodyContentTemplate>
+        @if (this.linkCandidates.Count == 0)
+        {
+            <p>No element has a parameter of this type.</p>
+        }
+        else
+        {
+            <div class="req-link-picker-list">
+                @foreach (var candidate in this.linkCandidates)
+                {
+                    <div class="req-link-picker-item">
+                        <DxCheckBox Checked="@this.IsStaged(candidate)"
+                                    CheckedChanged="@((bool isChecked) => this.ToggleStaged(candidate, isChecked))">
+                            @candidate.ModelCode() (@GetOwningElementName(candidate))
+                        </DxCheckBox>
+                    </div>
+                }
+            </div>
+        }
+
+        <div class="modal-footer m-top-10px">
+            <DxButton RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="@(() => this.CancelLinks())" />
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="OK" Click="@(() => this.ConfirmLinksAsync())" />
+        </div>
+    </BodyContentTemplate>
+</DxPopup>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
@@ -38,6 +38,22 @@ namespace COMETwebapp.Components.RequirementsEditor
     public partial class RequirementDetails
     {
         /// <summary>
+        /// The <see cref="RelationalExpression" /> currently linked through the parameter-link picker, or null when it
+        /// is closed.
+        /// </summary>
+        private RelationalExpression linkingExpression;
+
+        /// <summary>
+        /// The <see cref="ParameterOrOverrideBase" />s the picker offers for <see cref="linkingExpression" />.
+        /// </summary>
+        private List<ParameterOrOverrideBase> linkCandidates = [];
+
+        /// <summary>
+        /// The parameters staged as bound to <see cref="linkingExpression" /> until the picker is confirmed.
+        /// </summary>
+        private HashSet<ParameterOrOverrideBase> stagedLinks = [];
+
+        /// <summary>
         /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
         /// </summary>
         [Parameter]
@@ -48,6 +64,11 @@ namespace COMETwebapp.Components.RequirementsEditor
         /// </summary>
         [Parameter]
         public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the parameter-link picker is open.
+        /// </summary>
+        public bool IsLinkDialogOpen => this.linkingExpression != null;
 
         /// <summary>
         /// Gets the operator label of the given non-leaf <paramref name="expression" />.
@@ -122,6 +143,85 @@ namespace COMETwebapp.Components.RequirementsEditor
                 DefinedThing definedThing => $"{definedThing.ShortName} – {definedThing.Name}",
                 _ => thing.UserFriendlyName
             };
+        }
+
+        /// <summary>
+        /// Gets the name of the <see cref="ElementDefinition" /> owning the given <paramref name="parameter" />, for
+        /// display in the parameter-link picker.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /> candidate.</param>
+        /// <returns>The owning element's name</returns>
+        private static string GetOwningElementName(ParameterOrOverrideBase parameter)
+        {
+            return parameter.GetContainerOfType<ElementDefinition>()?.Name;
+        }
+
+        /// <summary>
+        /// Opens the parameter-link picker for the given relational expression, staging its currently bound parameters.
+        /// </summary>
+        /// <param name="relational">The <see cref="RelationalExpression" /> to link.</param>
+        private void OpenLinkDialog(RelationalExpression relational)
+        {
+            this.linkingExpression = relational;
+            this.linkCandidates = this.ViewModel.GetLinkableParameters(relational).ToList();
+            this.stagedLinks = [..this.ViewModel.GetBoundParameters(relational)];
+        }
+
+        /// <summary>
+        /// Gets whether the given <paramref name="parameter" /> is staged as bound in the picker.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /> candidate.</param>
+        /// <returns>true if staged</returns>
+        private bool IsStaged(ParameterOrOverrideBase parameter)
+        {
+            return this.stagedLinks.Contains(parameter);
+        }
+
+        /// <summary>
+        /// Adds or removes the given <paramref name="parameter" /> from the staged selection.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /> candidate.</param>
+        /// <param name="isChecked">true to stage it, false to unstage it.</param>
+        private void ToggleStaged(ParameterOrOverrideBase parameter, bool isChecked)
+        {
+            if (isChecked)
+            {
+                this.stagedLinks.Add(parameter);
+            }
+            else
+            {
+                this.stagedLinks.Remove(parameter);
+            }
+        }
+
+        /// <summary>
+        /// Persists the staged selection as the parameter links of <see cref="linkingExpression" /> and closes the
+        /// picker.
+        /// </summary>
+        private async Task ConfirmLinksAsync()
+        {
+            await this.ViewModel.UpdateParameterLinksAsync(this.linkingExpression, [..this.stagedLinks]);
+            this.linkingExpression = null;
+        }
+
+        /// <summary>
+        /// Closes the picker without applying the staged selection.
+        /// </summary>
+        private void CancelLinks()
+        {
+            this.linkingExpression = null;
+        }
+
+        /// <summary>
+        /// Handles the picker popup being closed via its close button.
+        /// </summary>
+        /// <param name="visible">The new visibility of the popup.</param>
+        private void OnLinkDialogVisibleChanged(bool visible)
+        {
+            if (!visible)
+            {
+                this.linkingExpression = null;
+            }
         }
     }
 }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.cs
@@ -118,14 +118,34 @@ namespace COMETwebapp.Components.RequirementsEditor
         }
 
         /// <summary>
-        /// Gets the link label of a related <see cref="Requirement" />: its specification's short name and its own.
+        /// Gets the link label of a related <see cref="Requirement" />: its specification's short name and its own
+        /// short name or name, matching the table-of-contents ID/Name toggle so the two correspond.
         /// </summary>
         /// <param name="requirement">The related <see cref="Requirement" /></param>
         /// <returns>The label</returns>
-        private static string GetRequirementLabel(Requirement requirement)
+        private string GetRequirementLabel(Requirement requirement)
         {
             var specification = requirement.GetContainerOfType<RequirementsSpecification>();
-            return specification == null ? requirement.ShortName : $"{specification.ShortName} · {requirement.ShortName}";
+            var requirementLabel = this.ViewModel.TreeUsesShortName ? requirement.ShortName : requirement.Name;
+
+            if (specification == null)
+            {
+                return requirementLabel;
+            }
+
+            var specificationLabel = this.ViewModel.TreeUsesShortName ? specification.ShortName : specification.Name;
+            return $"{specificationLabel} · {requirementLabel}";
+        }
+
+        /// <summary>
+        /// Gets the first definition text of a related <see cref="Requirement" />, shown after its link in the
+        /// remaining space (truncated) so a traceability row hints at what it points to.
+        /// </summary>
+        /// <param name="requirement">The related <see cref="Requirement" /></param>
+        /// <returns>The definition content, or an empty string</returns>
+        private static string GetRequirementDefinitionText(Requirement requirement)
+        {
+            return requirement?.Definition.FirstOrDefault()?.Content ?? string.Empty;
         }
 
         /// <summary>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor.css
@@ -1,0 +1,29 @@
+.req-expr-link {
+    border: none;
+    background: none;
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: #667085;
+    flex-shrink: 0;
+}
+
+.req-expr-link:hover {
+    color: #3b5b8c;
+}
+
+.req-link-picker-list {
+    max-height: 40vh;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.req-link-picker-item {
+    padding: 2px 0;
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor
@@ -1,0 +1,37 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using COMETwebapp.Utilities
+
+<span class="req-pills">
+    @if (this.ViewModel.ShowOwner && this.Owner != null)
+    {
+        <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.Owner.ShortName}") !important;" title="Owner: @this.Owner.Name">@this.Owner.ShortName</span>
+    }
+    <span class="req-pill-categories">
+        @if (this.ViewModel.ShowCategory)
+        {
+            @foreach (var category in this.Categories)
+            {
+                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+            }
+        }
+    </span>
+</span>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor.cs
@@ -1,0 +1,56 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementPills.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders the owner and category pills of a <see cref="CDP4Common.EngineeringModelData.RequirementsContainer" />
+    /// or <see cref="CDP4Common.EngineeringModelData.Requirement" />, gated by
+    /// <see cref="IRequirementsEditorBodyViewModel.ShowOwner" /> and <see cref="IRequirementsEditorBodyViewModel.ShowCategory" />.
+    /// </summary>
+    public partial class RequirementPills
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owner to render as a pill, or <c>null</c> when there is none.
+        /// </summary>
+        [Parameter]
+        public DomainOfExpertise Owner { get; set; }
+
+        /// <summary>
+        /// Gets or sets the categories to render as pills.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<Category> Categories { get; set; }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRow.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRow.razor
@@ -1,0 +1,77 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using COMETwebapp.ViewModels.Components.RequirementsEditor
+
+<div id="@RequirementsDocument.RequirementAnchorId(this.Requirement)" class="req-row @(this.Requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
+    <div class="req-row-top @(this.ValuesBelow ? "req-values-below" : string.Empty)">
+        <div class="req-row-main">
+            @switch (this.ViewModel.DisplayMode)
+            {
+                case RequirementRowDisplayMode.ShortNameAndDefinition:
+                    <div class="req-def"><strong class="req-id">@this.Requirement.ShortName</strong> &#8211; <RequirementDefinitionCell ViewModel="@this.ViewModel" Requirement="@this.Requirement" /></div>
+                    break;
+
+                case RequirementRowDisplayMode.NameAndDefinition:
+                    <div class="req-def"><strong class="req-id">@this.Requirement.Name</strong> &#8211; <RequirementDefinitionCell ViewModel="@this.ViewModel" Requirement="@this.Requirement" /></div>
+                    break;
+
+                default:
+                    <div class="req-row-header"><strong class="req-id">@this.Requirement.ShortName</strong> <span class="req-name">@this.Requirement.Name</span></div>
+                    <div class="req-def"><RequirementDefinitionCell ViewModel="@this.ViewModel" Requirement="@this.Requirement" /></div>
+                    break;
+            }
+        </div>
+        @if (this.ViewModel.ShowSimpleParameterValues && this.ValuesBelow)
+        {
+            <div class="req-row-pills req-pills-corner">
+                <RequirementRowActions ViewModel="@this.ViewModel" Requirement="@this.Requirement" />
+            </div>
+            <div class="req-row-values">
+                @foreach (var parameterType in this.VisibleParameterTypes)
+                {
+                    <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@this.Requirement" ParameterType="@parameterType" />
+                }
+            </div>
+        }
+        else if (this.ViewModel.ShowSimpleParameterValues)
+        {
+            <div class="req-row-values">
+                @foreach (var parameterType in this.VisibleParameterTypes)
+                {
+                    <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@this.Requirement" ParameterType="@parameterType" />
+                }
+                <div class="req-pills-cell">
+                    <RequirementRowActions ViewModel="@this.ViewModel" Requirement="@this.Requirement" />
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="req-row-pills">
+                <RequirementRowActions ViewModel="@this.ViewModel" Requirement="@this.Requirement" Inline="true" />
+            </div>
+        }
+    </div>
+    @if (this.ViewModel.ShowParametricConstraints || this.ViewModel.ShowTraceability)
+    {
+        <RequirementDetails ViewModel="@this.ViewModel" Requirement="@this.Requirement" />
+    }
+</div>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRow.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRow.razor.cs
@@ -1,0 +1,63 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRow.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders one <see cref="Requirement" /> as a document row: its identity and definition, the simple parameter
+    /// value columns with the pills/actions, and (when enabled) its parametric constraints and traceability.
+    /// </summary>
+    public partial class RequirementRow
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> to render.
+        /// </summary>
+        [Parameter]
+        public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets or sets the simple-parameter-value columns to render for the requirement, in display order.
+        /// </summary>
+        [Parameter]
+        public IReadOnlyList<ParameterType> VisibleParameterTypes { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the value columns are shown on their own full-width line below the
+        /// definition (true) or inline beside it (false).
+        /// </summary>
+        [Parameter]
+        public bool ValuesBelow { get; set; }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor
@@ -1,0 +1,57 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+@using COMETwebapp.Utilities
+
+@if (this.Requirement.IsDeprecated)
+{
+    <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+}
+
+@if (this.Inline)
+{
+    <RequirementPills ViewModel="@this.ViewModel" Owner="@this.Requirement.Owner" Categories="@this.Requirement.Category" />
+    <span class="req-actions">
+        <EditThingButton ViewModel="@this.ViewModel" Thing="@this.Requirement" />
+        <DeprecateThingButton ViewModel="@this.ViewModel" Thing="@this.Requirement" />
+    </span>
+}
+else
+{
+    <div class="req-pill-action-row">
+        @if (this.ViewModel.ShowOwner && this.Requirement.Owner != null)
+        {
+            <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.Requirement.Owner.ShortName}") !important;" title="Owner: @this.Requirement.Owner.Name">@this.Requirement.Owner.ShortName</span>
+        }
+        <span class="req-actions"><EditThingButton ViewModel="@this.ViewModel" Thing="@this.Requirement" /></span>
+    </div>
+    <div class="req-pill-action-row">
+        <span class="req-pill-categories">
+            @if (this.ViewModel.ShowCategory)
+            {
+                @foreach (var category in this.Requirement.Category)
+                {
+                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                }
+            }
+        </span>
+        <span class="req-actions"><DeprecateThingButton ViewModel="@this.ViewModel" Thing="@this.Requirement" /></span>
+    </div>
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor.cs
@@ -1,0 +1,58 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementRowActions.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.RequirementsEditor
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMETwebapp.ViewModels.Components.RequirementsEditor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders the deprecated badge (when applicable), the owner/category pills and the edit and deprecate/restore
+    /// buttons of a <see cref="Requirement" /> row. When <see cref="Inline" /> is false (the default) it stacks two
+    /// rows (owner + edit, then categories + deprecate) for the fixed-width pills column shown beside the value
+    /// columns; when true it renders a single inline row (pills then both buttons) for the row with no value columns.
+    /// </summary>
+    public partial class RequirementRowActions
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
+        /// </summary>
+        [Parameter]
+        public IRequirementsEditorBodyViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Requirement" /> to render the pills and actions for.
+        /// </summary>
+        [Parameter]
+        public Requirement Requirement { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the pills and actions are laid out on a single inline row (true) or
+        /// stacked as two pill-and-action rows (false, the default).
+        /// </summary>
+        [Parameter]
+        public bool Inline { get; set; }
+    }
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor.css
@@ -1,0 +1,7 @@
+.req-pill-action-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    gap: 6px;
+    width: 100%;
+}

--- a/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
@@ -36,8 +36,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <button type="button" class="req-value-save" title="Save (Enter)" @onclick="this.CommitAsync">&#10003;</button>
                 <button type="button" class="req-value-cancel" title="Cancel (Esc)" @onclick="this.Cancel">&#10007;</button>
             </div>
-            @* IsOnEditMode renders compound/array parameter types as an inline component form; without it the shared
-               editor only shows an "Edit" button that broadcasts an event no host in the Requirements Editor handles *@
             <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" IsOnEditMode="true" />
         </div>
     }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementValueCell.razor
@@ -36,7 +36,9 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <button type="button" class="req-value-save" title="Save (Enter)" @onclick="this.CommitAsync">&#10003;</button>
                 <button type="button" class="req-value-cancel" title="Cancel (Esc)" @onclick="this.Cancel">&#10007;</button>
             </div>
-            <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" />
+            @* IsOnEditMode renders compound/array parameter types as an inline component form; without it the shared
+               editor only shows an "Edit" button that broadcasts an event no host in the Requirements Editor handles *@
+            <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" IsOnEditMode="true" />
         </div>
     }
     else if (currentValue == null)

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -71,6 +71,24 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </div>
         </text>;
 
+    RenderFragment<Requirement> definitionPart = requirement =>
+        @<text>
+            @if (this.IsEditingDefinition(requirement))
+            {
+                <span class="req-def-editor @(this.IsDefinitionDirty(requirement) ? "req-def-editor-dirty" : string.Empty)" @onkeydown="this.OnDefinitionEditorKeyDown">
+                    <DxMemo @bind-Text="this.editingDefinition" BindValueMode="BindValueMode.OnInput" Rows="2" CssClass="req-def-memo" />
+                    <span class="req-def-editor-actions">
+                        <button type="button" class="req-def-save" title="Save" @onclick="@(() => this.ConfirmDefinitionEdit(requirement))">&#10003;</button>
+                        <button type="button" class="req-def-cancel" title="Cancel (Esc)" @onclick="this.CancelDefinitionEdit">&#10007;</button>
+                    </span>
+                </span>
+            }
+            else
+            {
+                <span class="req-def-display" title="Click to edit" @onclick="@(() => this.StartDefinitionEdit(requirement))">@GetDefinitionDisplay(requirement)</span>
+            }
+        </text>;
+
     IReadOnlyList<ParameterType> visibleParameterTypes = this.ViewModel.ShowSimpleParameterValues ? this.ViewModel.GetVisibleParameterTypes() : [];
     var valuesBelow = visibleParameterTypes.Count > MaxInlineValueColumns;
 
@@ -78,34 +96,20 @@ Copyright (c) 2023-2026 Starion Group S.A.
         @<div @key="requirement.Iid" id="@RequirementAnchorId(requirement)" class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
             <div class="req-row-top @(valuesBelow ? "req-values-below" : string.Empty)">
                 <div class="req-row-main">
-                    @if (this.IsEditingDefinition(requirement))
+                    @switch (this.ViewModel.DisplayMode)
                     {
-                        <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
-                        <div class="req-def-editor @(this.IsDefinitionDirty(requirement) ? "req-def-editor-dirty" : string.Empty)" @onkeydown="this.OnDefinitionEditorKeyDown">
-                            <div class="req-def-editor-actions">
-                                <button type="button" class="req-def-save" title="Save" @onclick="@(() => this.ConfirmDefinitionEdit(requirement))">&#10003;</button>
-                                <button type="button" class="req-def-cancel" title="Cancel (Esc)" @onclick="this.CancelDefinitionEdit">&#10007;</button>
-                            </div>
-                            <DxMemo @bind-Text="this.editingDefinition" BindValueMode="BindValueMode.OnInput" Rows="3" CssClass="req-def-memo" />
-                        </div>
-                    }
-                    else
-                    {
-                        @switch (this.ViewModel.DisplayMode)
-                        {
-                            case RequirementRowDisplayMode.ShortNameAndDefinition:
-                                <p class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @GetDefinition(requirement)</p>
-                                break;
+                        case RequirementRowDisplayMode.ShortNameAndDefinition:
+                            <div class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @definitionPart(requirement)</div>
+                            break;
 
-                            case RequirementRowDisplayMode.NameAndDefinition:
-                                <p class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @GetDefinition(requirement)</p>
-                                break;
+                        case RequirementRowDisplayMode.NameAndDefinition:
+                            <div class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @definitionPart(requirement)</div>
+                            break;
 
-                            default:
-                                <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
-                                <p class="req-def"><span class="req-def-display" title="Click to edit" @onclick="@(() => this.StartDefinitionEdit(requirement))">@GetDefinitionDisplay(requirement)</span></p>
-                                break;
-                        }
+                        default:
+                            <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
+                            <div class="req-def">@definitionPart(requirement)</div>
+                            break;
                     }
                 </div>
                 @if (this.ViewModel.ShowSimpleParameterValues && valuesBelow)

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -20,142 +20,11 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
 @using CDP4Common.EngineeringModelData
 @using CDP4Common.SiteDirectoryData
-@using COMETwebapp.Utilities
 @using COMETwebapp.ViewModels.Components.RequirementsEditor
 
 @{
-    RenderFragment<DomainOfExpertise> ownerPill = owner =>
-        @<text>
-            @if (this.ViewModel.ShowOwner && owner != null)
-            {
-                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{owner.ShortName}") !important;" title="Owner: @owner.Name">@owner.ShortName</span>
-            }
-        </text>;
-
-    RenderFragment<IEnumerable<Category>> categoryPills = categories =>
-        @<span class="req-pill-categories">
-            @if (this.ViewModel.ShowCategory)
-            {
-                @foreach (var category in categories)
-                {
-                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
-                }
-            }
-        </span>;
-
-    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
-        @<span class="req-pills">
-            @ownerPill(context.Owner)
-            @categoryPills(context.Categories)
-        </span>;
-
-    RenderFragment<Requirement> editButton = requirement =>
-        @<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit requirement" Click="@(() => this.ViewModel.OpenEdit(requirement))" />;
-
-    RenderFragment<Requirement> deprecateButton = requirement =>
-        @<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@(requirement.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")" title="@(requirement.IsDeprecated ? "Restore requirement" : "Deprecate requirement")" Click="@(() => this.ViewModel.ConfirmDeprecation(requirement))" />;
-
-    RenderFragment<Requirement> pillsAndActions = requirement =>
-        @<text>
-            @if (requirement.IsDeprecated)
-            {
-                <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
-            }
-            <div class="req-pill-action-row">
-                @ownerPill(requirement.Owner)
-                <span class="req-actions">@editButton(requirement)</span>
-            </div>
-            <div class="req-pill-action-row">
-                @categoryPills(requirement.Category)
-                <span class="req-actions">@deprecateButton(requirement)</span>
-            </div>
-        </text>;
-
-    RenderFragment<Requirement> definitionPart = requirement =>
-        @<text>
-            @if (this.IsEditingDefinition(requirement))
-            {
-                <span class="req-def-editor @(this.IsDefinitionDirty(requirement) ? "req-def-editor-dirty" : string.Empty)" @onkeydown="this.OnDefinitionEditorKeyDown">
-                    <DxMemo @bind-Text="this.editingDefinition" BindValueMode="BindValueMode.OnInput" Rows="2" CssClass="req-def-memo" />
-                    <span class="req-def-editor-actions">
-                        <button type="button" class="req-def-save" title="Save" @onclick="@(() => this.ConfirmDefinitionEdit(requirement))">&#10003;</button>
-                        <button type="button" class="req-def-cancel" title="Cancel (Esc)" @onclick="this.CancelDefinitionEdit">&#10007;</button>
-                    </span>
-                </span>
-            }
-            else
-            {
-                <span class="req-def-display" title="Click to edit" @onclick="@(() => this.StartDefinitionEdit(requirement))">@GetDefinitionDisplay(requirement)</span>
-            }
-        </text>;
-
     IReadOnlyList<ParameterType> visibleParameterTypes = this.ViewModel.ShowSimpleParameterValues ? this.ViewModel.GetVisibleParameterTypes() : [];
     var valuesBelow = visibleParameterTypes.Count > MaxInlineValueColumns;
-
-    RenderFragment<Requirement> requirementRow = requirement =>
-        @<div @key="requirement.Iid" id="@RequirementAnchorId(requirement)" class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
-            <div class="req-row-top @(valuesBelow ? "req-values-below" : string.Empty)">
-                <div class="req-row-main">
-                    @switch (this.ViewModel.DisplayMode)
-                    {
-                        case RequirementRowDisplayMode.ShortNameAndDefinition:
-                            <div class="req-def"><strong class="req-id">@requirement.ShortName</strong> &#8211; @definitionPart(requirement)</div>
-                            break;
-
-                        case RequirementRowDisplayMode.NameAndDefinition:
-                            <div class="req-def"><strong class="req-id">@requirement.Name</strong> &#8211; @definitionPart(requirement)</div>
-                            break;
-
-                        default:
-                            <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
-                            <div class="req-def">@definitionPart(requirement)</div>
-                            break;
-                    }
-                </div>
-                @if (this.ViewModel.ShowSimpleParameterValues && valuesBelow)
-                {
-                    <div class="req-row-pills req-pills-corner">
-                        @pillsAndActions(requirement)
-                    </div>
-                    <div class="req-row-values">
-                        @foreach (var parameterType in visibleParameterTypes)
-                        {
-                            <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" ParameterType="@parameterType" />
-                        }
-                    </div>
-                }
-                else if (this.ViewModel.ShowSimpleParameterValues)
-                {
-                    <div class="req-row-values">
-                        @foreach (var parameterType in visibleParameterTypes)
-                        {
-                            <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" ParameterType="@parameterType" />
-                        }
-                        <div class="req-pills-cell">
-                            @pillsAndActions(requirement)
-                        </div>
-                    </div>
-                }
-                else
-                {
-                    <div class="req-row-pills">
-                        @if (requirement.IsDeprecated)
-                        {
-                            <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
-                        }
-                        @pills((requirement.Owner, requirement.Category))
-                        <span class="req-actions">
-                            @editButton(requirement)
-                            @deprecateButton(requirement)
-                        </span>
-                    </div>
-                }
-            </div>
-            @if (this.ViewModel.ShowParametricConstraints || this.ViewModel.ShowTraceability)
-            {
-                <RequirementDetails ViewModel="@this.ViewModel" Requirement="@requirement" />
-            }
-        </div>;
 }
 
 @if (this.ViewModel.SelectedSpecification == null)
@@ -173,18 +42,18 @@ else if (this.Container == null)
         {
             <span class="req-deprecated-badge" title="This specification is deprecated">Deprecated</span>
         }
-        @pills((specification.Owner, specification.Category))
+        <RequirementPills ViewModel="@this.ViewModel" Owner="@specification.Owner" Categories="@specification.Category" />
         <span class="req-actions">
             <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-plus" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(specification))" />
             <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-folder" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
-            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit specification" Click="@(() => this.ViewModel.OpenEdit(specification))" />
-            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@(specification.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")" title="@(specification.IsDeprecated ? "Restore specification" : "Deprecate specification")" Click="@(() => this.ViewModel.ConfirmDeprecation(specification))" />
+            <EditThingButton ViewModel="@this.ViewModel" Thing="@specification" />
+            <DeprecateThingButton ViewModel="@this.ViewModel" Thing="@specification" />
         </span>
     </div>
 
     @foreach (var requirement in this.ViewModel.GetRequirements(specification))
     {
-        @requirementRow(requirement)
+        <RequirementRow @key="requirement.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" VisibleParameterTypes="@visibleParameterTypes" ValuesBelow="@valuesBelow" />
     }
 
     @foreach (var childGroup in this.ViewModel.GetGroups(specification))
@@ -205,11 +74,11 @@ else
             </button>
             <span class="req-group-id">@group.ShortName</span>
             <span class="req-group-name">@group.Name</span>
-            @pills((group.Owner, group.Category))
+            <RequirementPills ViewModel="@this.ViewModel" Owner="@group.Owner" Categories="@group.Category" />
             <span class="req-actions">
                 <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-plus" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(group))" />
                 <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-folder" title="Add sub-group" Click="@(() => this.ViewModel.OpenCreateGroup(group))" />
-                <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit group" Click="@(() => this.ViewModel.OpenEdit(group))" />
+                <EditThingButton ViewModel="@this.ViewModel" Thing="@group" />
                 <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-trash" title="Delete group" Click="@(() => this.ViewModel.ConfirmDeletion(group))" />
             </span>
         </div>
@@ -218,7 +87,7 @@ else
         {
             foreach (var requirement in this.ViewModel.GetRequirements(group))
             {
-                @requirementRow(requirement)
+                <RequirementRow @key="requirement.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" VisibleParameterTypes="@visibleParameterTypes" ValuesBelow="@valuesBelow" />
             }
 
             foreach (var childGroup in this.ViewModel.GetGroups(group))

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -24,38 +24,69 @@ Copyright (c) 2023-2026 Starion Group S.A.
 @using COMETwebapp.ViewModels.Components.RequirementsEditor
 
 @{
-    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
-        @<span class="req-pills">
-            @if (this.ViewModel.ShowOwner && context.Owner != null)
+    RenderFragment<DomainOfExpertise> ownerPill = owner =>
+        @<text>
+            @if (this.ViewModel.ShowOwner && owner != null)
             {
-                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{context.Owner.ShortName}") !important;" title="Owner: @context.Owner.Name">@context.Owner.ShortName</span>
+                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{owner.ShortName}") !important;" title="Owner: @owner.Name">@owner.ShortName</span>
             }
+        </text>;
+
+    RenderFragment<IEnumerable<Category>> categoryPills = categories =>
+        @<span class="req-pill-categories">
             @if (this.ViewModel.ShowCategory)
             {
-                <span class="req-pill-categories">
-                    @foreach (var category in context.Categories)
-                    {
-                        <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
-                    }
-                </span>
+                @foreach (var category in categories)
+                {
+                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                }
             }
         </span>;
 
+    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
+        @<span class="req-pills">
+            @ownerPill(context.Owner)
+            @categoryPills(context.Categories)
+        </span>;
+
+    RenderFragment<Requirement> editButton = requirement =>
+        @<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit requirement" Click="@(() => this.ViewModel.OpenEdit(requirement))" />;
+
+    RenderFragment<Requirement> deprecateButton = requirement =>
+        @<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@(requirement.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")" title="@(requirement.IsDeprecated ? "Restore requirement" : "Deprecate requirement")" Click="@(() => this.ViewModel.ConfirmDeprecation(requirement))" />;
+
+    RenderFragment<Requirement> pillsAndActions = requirement =>
+        @<text>
+            @if (requirement.IsDeprecated)
+            {
+                <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+            }
+            <div class="req-pill-action-row">
+                @ownerPill(requirement.Owner)
+                <span class="req-actions">@editButton(requirement)</span>
+            </div>
+            <div class="req-pill-action-row">
+                @categoryPills(requirement.Category)
+                <span class="req-actions">@deprecateButton(requirement)</span>
+            </div>
+        </text>;
+
     IReadOnlyList<ParameterType> visibleParameterTypes = this.ViewModel.ShowSimpleParameterValues ? this.ViewModel.GetVisibleParameterTypes() : [];
+    var valuesBelow = visibleParameterTypes.Count > MaxInlineValueColumns;
 
     RenderFragment<Requirement> requirementRow = requirement =>
         @<div @key="requirement.Iid" id="@RequirementAnchorId(requirement)" class="req-row @(requirement.IsDeprecated ? "req-row-deprecated" : string.Empty)">
-            <div class="req-row-top">
+            <div class="req-row-top @(valuesBelow ? "req-values-below" : string.Empty)">
                 <div class="req-row-main">
                     @if (this.IsEditingDefinition(requirement))
                     {
                         <div class="req-row-header"><strong class="req-id">@requirement.ShortName</strong> <span class="req-name">@requirement.Name</span></div>
-                        <div class="req-def-editor" @onkeydown="this.OnDefinitionEditorKeyDown">
+                        <div class="req-def-editor @(this.IsDefinitionDirty(requirement) ? "req-def-editor-dirty" : string.Empty)" @onkeydown="this.OnDefinitionEditorKeyDown">
                             <div class="req-def-editor-actions">
                                 <button type="button" class="req-def-save" title="Save" @onclick="@(() => this.ConfirmDefinitionEdit(requirement))">&#10003;</button>
                                 <button type="button" class="req-def-cancel" title="Cancel (Esc)" @onclick="this.CancelDefinitionEdit">&#10007;</button>
                             </div>
-                            <DxMemo @bind-Text="this.editingDefinition" Rows="3" CssClass="req-def-memo" />
+                            <DxMemo @bind-Text="this.editingDefinition" BindValueMode="BindValueMode.OnInput" Rows="3" CssClass="req-def-memo" />
                         </div>
                     }
                     else
@@ -77,8 +108,11 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         }
                     }
                 </div>
-                @if (this.ViewModel.ShowSimpleParameterValues)
+                @if (this.ViewModel.ShowSimpleParameterValues && valuesBelow)
                 {
+                    <div class="req-row-pills req-pills-corner">
+                        @pillsAndActions(requirement)
+                    </div>
                     <div class="req-row-values">
                         @foreach (var parameterType in visibleParameterTypes)
                         {
@@ -86,18 +120,32 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         }
                     </div>
                 }
-                <div class="req-row-pills @(this.ViewModel.ShowSimpleParameterValues ? "req-pills-stacked" : string.Empty)">
-                    @if (requirement.IsDeprecated)
-                    {
-                        <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
-                    }
-                    @pills((requirement.Owner, requirement.Category))
-                    <span class="req-actions">
-                        <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit requirement" Click="@(() => this.ViewModel.OpenEdit(requirement))" />
-                        <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@(requirement.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")" title="@(requirement.IsDeprecated ? "Restore requirement" : "Deprecate requirement")" Click="@(() => this.ViewModel.ConfirmDeprecation(requirement))" />
-                        <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-trash" title="Delete requirement" Click="@(() => this.ViewModel.ConfirmDeletion(requirement))" />
-                    </span>
-                </div>
+                else if (this.ViewModel.ShowSimpleParameterValues)
+                {
+                    <div class="req-row-values">
+                        @foreach (var parameterType in visibleParameterTypes)
+                        {
+                            <RequirementValueCell @key="parameterType.Iid" ViewModel="@this.ViewModel" Requirement="@requirement" ParameterType="@parameterType" />
+                        }
+                        <div class="req-pills-cell">
+                            @pillsAndActions(requirement)
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="req-row-pills">
+                        @if (requirement.IsDeprecated)
+                        {
+                            <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
+                        }
+                        @pills((requirement.Owner, requirement.Category))
+                        <span class="req-actions">
+                            @editButton(requirement)
+                            @deprecateButton(requirement)
+                        </span>
+                    </div>
+                }
             </div>
             @if (this.ViewModel.ShowParametricConstraints || this.ViewModel.ShowTraceability)
             {
@@ -127,7 +175,6 @@ else if (this.Container == null)
             <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-folder" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
             <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-pencil" title="Edit specification" Click="@(() => this.ViewModel.OpenEdit(specification))" />
             <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@(specification.IsDeprecated ? "oi oi-action-undo" : "oi oi-ban")" title="@(specification.IsDeprecated ? "Restore specification" : "Deprecate specification")" Click="@(() => this.ViewModel.ConfirmDeprecation(specification))" />
-            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="oi oi-trash" title="Delete specification" Click="@(() => this.ViewModel.ConfirmDeletion(specification))" />
         </span>
     </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
@@ -27,7 +27,6 @@ namespace COMETwebapp.Components.RequirementsEditor
     using COMETwebapp.ViewModels.Components.RequirementsEditor;
 
     using Microsoft.AspNetCore.Components;
-    using Microsoft.AspNetCore.Components.Web;
 
     /// <summary>
     /// Renders a <see cref="RequirementsSpecification" /> as a document: the specification header, its requirements,
@@ -80,102 +79,6 @@ namespace COMETwebapp.Components.RequirementsEditor
         public static string RequirementAnchorId(Requirement requirement)
         {
             return $"req-{requirement.Iid}";
-        }
-
-        /// <summary>
-        /// The <see cref="CDP4Common.CommonData.Thing.Iid" /> of the requirement whose definition is currently being edited inline, or null.
-        /// </summary>
-        private Guid? editingRequirementIid;
-
-        /// <summary>
-        /// The staged definition text of the requirement currently being edited inline.
-        /// </summary>
-        private string editingDefinition;
-
-        /// <summary>
-        /// Gets the definition text of the given <paramref name="requirement" /> (its first definition).
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /></param>
-        /// <returns>The first definition's content, or an empty string</returns>
-        private static string GetDefinition(Requirement requirement)
-        {
-            return requirement.Definition.FirstOrDefault()?.Content ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Gets the definition text of the given <paramref name="requirement" /> for display, or a placeholder when empty.
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /></param>
-        /// <returns>The definition content, or a click-to-add placeholder</returns>
-        private static string GetDefinitionDisplay(Requirement requirement)
-        {
-            var content = GetDefinition(requirement);
-            return string.IsNullOrWhiteSpace(content) ? "Click to add a definition" : content;
-        }
-
-        /// <summary>
-        /// Gets whether the given <paramref name="requirement" />'s definition is currently being edited inline.
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /></param>
-        /// <returns>true if it is being edited</returns>
-        private bool IsEditingDefinition(Requirement requirement)
-        {
-            return this.editingRequirementIid == requirement.Iid;
-        }
-
-        /// <summary>
-        /// Gets whether the inline definition edit of the given <paramref name="requirement" /> has an unsaved change,
-        /// so the editor can show the same "dirty" highlight as the simple-parameter-value editor.
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /></param>
-        /// <returns>true when the staged text differs from the saved definition</returns>
-        private bool IsDefinitionDirty(Requirement requirement)
-        {
-            return !string.Equals(this.editingDefinition ?? string.Empty, GetDefinition(requirement), StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Starts the inline edit of the given <paramref name="requirement" />'s definition.
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /></param>
-        private void StartDefinitionEdit(Requirement requirement)
-        {
-            this.editingRequirementIid = requirement.Iid;
-            this.editingDefinition = GetDefinition(requirement);
-        }
-
-        /// <summary>
-        /// Cancels the current inline definition edit without saving.
-        /// </summary>
-        private void CancelDefinitionEdit()
-        {
-            this.editingRequirementIid = null;
-            this.editingDefinition = null;
-        }
-
-        /// <summary>
-        /// Commits the current inline definition edit.
-        /// </summary>
-        /// <param name="requirement">The <see cref="Requirement" /> being edited</param>
-        /// <returns>A <see cref="Task" /></returns>
-        private async Task ConfirmDefinitionEdit(Requirement requirement)
-        {
-            var content = this.editingDefinition;
-            this.editingRequirementIid = null;
-            this.editingDefinition = null;
-            await this.ViewModel.SaveInlineDefinitionAsync(requirement, content);
-        }
-
-        /// <summary>
-        /// Cancels the inline definition edit when the Escape key is pressed.
-        /// </summary>
-        /// <param name="eventArgs">The <see cref="KeyboardEventArgs" /></param>
-        private void OnDefinitionEditorKeyDown(KeyboardEventArgs eventArgs)
-        {
-            if (eventArgs.Key == "Escape")
-            {
-                this.CancelDefinitionEdit();
-            }
         }
     }
 }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor.cs
@@ -36,6 +36,14 @@ namespace COMETwebapp.Components.RequirementsEditor
     public partial class RequirementsDocument
     {
         /// <summary>
+        /// The number of simple-parameter-value columns that still fit inline beside the definition and pills; above
+        /// this the value grid drops to its own full-width line below the row. A count heuristic — it does not measure
+        /// the actual panel width — tuned to 5 so the common case stays inline even with the table of contents open.
+        /// The grid also wraps at 5 columns per line (see .req-row-values max-width) so it never runs off the row.
+        /// </summary>
+        private const int MaxInlineValueColumns = 5;
+
+        /// <summary>
         /// Gets or sets the <see cref="IRequirementsEditorBodyViewModel" />.
         /// </summary>
         [Parameter]
@@ -113,6 +121,17 @@ namespace COMETwebapp.Components.RequirementsEditor
         private bool IsEditingDefinition(Requirement requirement)
         {
             return this.editingRequirementIid == requirement.Iid;
+        }
+
+        /// <summary>
+        /// Gets whether the inline definition edit of the given <paramref name="requirement" /> has an unsaved change,
+        /// so the editor can show the same "dirty" highlight as the simple-parameter-value editor.
+        /// </summary>
+        /// <param name="requirement">The <see cref="Requirement" /></param>
+        /// <returns>true when the staged text differs from the saved definition</returns>
+        private bool IsDefinitionDirty(Requirement requirement)
+        {
+            return !string.Equals(this.editingDefinition ?? string.Empty, GetDefinition(requirement), StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -94,7 +94,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                                 <div class="btn-group" role="group" aria-label="Requirement layout">
                                     @foreach (var mode in DisplayModes)
                                     {
-                                        <DxButton RenderStyle="@(this.ViewModel.DisplayMode == mode ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
+                                        <DxButton RenderStyle="ButtonRenderStyle.Light"
+                                                  CssClass="@(this.ViewModel.DisplayMode == mode ? "req-view-toggle-on" : string.Empty)"
                                                   Text="@GetDisplayModeLabel(mode)"
                                                   title="@GetDisplayModeTitle(mode)"
                                                   Click="@(() => this.ViewModel.DisplayMode = mode)" />
@@ -104,6 +105,10 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                             <div class="req-view-section">
                                 <span class="req-toolbar-label">Show</span>
+                                <DxCheckBox Checked="@(!this.ViewModel.TreeUsesShortName)"
+                                            CheckedChanged="@((bool value) => this.ViewModel.TreeUsesShortName = !value)"
+                                            CheckType="CheckType.Switch"
+                                            title="Label the table of contents and traceability by full name instead of short name">Full names</DxCheckBox>
                                 <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent groups</DxCheckBox>
                                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
                                 <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -34,11 +34,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
                       Click="@(() => this.ViewModel.IsTocCollapsed = !this.ViewModel.IsTocCollapsed)"
                       CssClass="req-collapse-toggle" />
 
-            <DxTextBox @bind-Text="@this.ViewModel.SearchText"
-                       BindValueMode="BindValueMode.OnDelayedInput"
-                       ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-                       NullText="Search in definitions..."
-                       CssClass="req-search" />
+            <div class="req-search">
+                <DxTextBox @bind-Text="@this.ViewModel.SearchText"
+                           BindValueMode="BindValueMode.OnDelayedInput"
+                           ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                           NullText="Search in definitions..."
+                           CssClass="req-search-input" />
+            </div>
 
             <DxTagBox Data="@this.ViewModel.AvailableOwners"
                       Values="@this.ViewModel.SelectedOwners"
@@ -65,31 +67,53 @@ Copyright (c) 2023-2026 Starion Group S.A.
                           CssClass="req-filter" />
             }
 
-            <div class="req-toolbar-group">
-                <span class="req-toolbar-label">Layout</span>
-                <div class="btn-group" role="group" aria-label="Requirement layout">
-                    @foreach (var mode in DisplayModes)
-                    {
-                        <DxButton RenderStyle="@(this.ViewModel.DisplayMode == mode ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
-                                  Text="@GetDisplayModeLabel(mode)"
-                                  title="@GetDisplayModeTitle(mode)"
-                                  Click="@(() => this.ViewModel.DisplayMode = mode)" />
-                    }
-                </div>
-            </div>
-
             <div class="req-toolbar-group req-toolbar-right">
                 <DxButton RenderStyle="ButtonRenderStyle.Primary"
                           IconCssClass="oi oi-plus"
                           Text="Specification"
                           title="Create a new specification"
                           Click="@(() => this.ViewModel.OpenCreateSpecification())" />
-                <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowSimpleParameterValues" CheckType="CheckType.Switch" title="Show the simple parameter values of each requirement as editable columns">Values</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowParametricConstraints" CheckType="CheckType.Switch" title="Show the parametric constraints of each requirement">Constraints</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowTraceability" CheckType="CheckType.Switch" title="Show the relationships to and from each requirement">Traceability</DxCheckBox>
+
+                <DxButton Id="reqViewMenuButton"
+                          RenderStyle="ButtonRenderStyle.Light"
+                          IconCssClass="oi oi-cog"
+                          Text="View"
+                          title="Layout and display options"
+                          Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
+
+                <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
+                            PositionMode="DropDownPositionMode.Bottom"
+                            PositionTarget="#reqViewMenuButton"
+                            CloseMode="DropDownCloseMode.Close"
+                            HeaderVisible="false"
+                            FooterVisible="false">
+                    <BodyTemplate>
+                        <div class="req-view-menu">
+                            <div class="req-view-section">
+                                <span class="req-toolbar-label">Layout</span>
+                                <div class="btn-group" role="group" aria-label="Requirement layout">
+                                    @foreach (var mode in DisplayModes)
+                                    {
+                                        <DxButton RenderStyle="@(this.ViewModel.DisplayMode == mode ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
+                                                  Text="@GetDisplayModeLabel(mode)"
+                                                  title="@GetDisplayModeTitle(mode)"
+                                                  Click="@(() => this.ViewModel.DisplayMode = mode)" />
+                                    }
+                                </div>
+                            </div>
+
+                            <div class="req-view-section">
+                                <span class="req-toolbar-label">Show</span>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent groups</DxCheckBox>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowSimpleParameterValues" CheckType="CheckType.Switch" title="Show the simple parameter values of each requirement as editable columns">Values</DxCheckBox>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowParametricConstraints" CheckType="CheckType.Switch" title="Show the parametric constraints of each requirement">Constraints</DxCheckBox>
+                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowTraceability" CheckType="CheckType.Switch" title="Show the relationships to and from each requirement">Traceability</DxCheckBox>
+                            </div>
+                        </div>
+                    </BodyTemplate>
+                </DxDropDown>
             </div>
         </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -46,6 +46,11 @@ namespace COMETwebapp.Components.RequirementsEditor
         ];
 
         /// <summary>
+        /// Whether the "View" layout-and-display-options dropdown is open.
+        /// </summary>
+        private bool viewMenuOpen;
+
+        /// <summary>
         /// Gets or sets the <see cref="IDomDataService" /> used to scroll a navigated-to requirement into view.
         /// </summary>
         [Inject]
@@ -70,6 +75,9 @@ namespace COMETwebapp.Components.RequirementsEditor
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.ShowHideDeprecatedThingsService.ShowDeprecatedThings)
+                .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.DraggedGroup, x => x.ViewModel.DragOverContainer)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
             this.Disposables.Add(this.WhenAnyValue(

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -1,5 +1,3 @@
-/* Fills the tab height so the tree and document panels scroll independently. Works because the shared
-   TabsPanelComponent chain (.panel-view height:100% flex → #tabs-page-content flex:1) is definite. */
 .req-editor {
     display: flex;
     flex-direction: column;
@@ -71,8 +69,6 @@
     min-width: 78px;
 }
 
-/* the table of contents keeps a fixed, readable width and the document a readable minimum; when they don't
-   both fit on a narrow panel the layout scrolls horizontally rather than squeezing the TOC to uselessness */
 .req-editor-layout {
     display: flex;
     gap: 16px;
@@ -99,12 +95,6 @@
     border: none;
 }
 
-/* only ever scroll vertically: horizontal overflow would leave a dangling scrollbar, make the sticky
-   specification header stop short of the right edge, and (with both side menus open on a tiny screen) trap
-   the document so it can't be scrolled at all. Everything inside wraps, so nothing needs horizontal scroll. */
-/* a readable minimum width; when the TOC + this minimum exceed the panel the layout gets a horizontal
-   scrollbar (above) rather than squeezing the document to one word per line. Content still wraps within this
-   width, so the document itself never needs its own horizontal scrollbar. */
 .req-document {
     flex: 1 1 auto;
     min-width: 400px;
@@ -151,8 +141,6 @@
     padding-left: 14px;
 }
 
-/* vertical guide line: full height for a middle child, but the last child stops at the connector
-   so the line does not run past the final node to the bottom of the branch */
 .req-toc ::deep ul.req-tree-branch > li::before {
     content: "";
     position: absolute;
@@ -168,7 +156,6 @@
     height: 13px;
 }
 
-/* horizontal connector from the vertical guide line to each node */
 .req-toc ::deep ul.req-tree-branch > li::after {
     content: "";
     position: absolute;
@@ -194,12 +181,10 @@
     text-overflow: ellipsis;
 }
 
-/* group rows can be dragged onto another group (to nest) or the specification (to make top-level) */
 .req-toc ::deep .req-tree-group-row {
     cursor: grab;
 }
 
-/* a valid drop target while a group is being dragged */
 .req-toc ::deep .req-tree-droptarget {
     outline: 2px dashed #4096ff;
     outline-offset: -2px;
@@ -353,17 +338,13 @@
     gap: 6px;
     padding: 9px 8px;
     border-bottom: 1px solid #f1f3f5;
-    /* keep a navigated-to requirement clear of the sticky specification header instead of landing behind it */
-    scroll-margin-top: 60px;
+     scroll-margin-top: 60px;
 }
 
 .req-document ::deep .req-row:hover {
     background: #fafbfc;
 }
 
-/* the header strip: definition (grows) | value columns | owner/category pills. On a wide row everything sits
-   on one line and the value columns line up across requirements; on a narrow panel the strip wraps so the
-   value columns and pills drop below the definition instead of squeezing it to one word per line. */
 .req-document ::deep .req-row-top {
     display: flex;
     align-items: flex-start;
@@ -401,16 +382,12 @@
     color: #1f2937;
 }
 
-/* pills block when the value columns are hidden: a compact inline group at the far right of the row */
 .req-document ::deep .req-row-pills {
     flex: 0 0 auto;
     white-space: nowrap;
     text-align: end;
 }
 
-/* when up to five value columns are shown, the pills + actions are a value-cell-sized block that flows as the
-   LAST cell of the value grid, so it fills the empty slot after the last value instead of leaving whitespace and
-   lines up in the same columns as the value cells (same 130px border-box footprint). */
 .req-document ::deep .req-pills-cell {
     flex: 0 0 130px;
     box-sizing: border-box;
@@ -428,22 +405,11 @@
     white-space: normal;
 }
 
-.req-document ::deep .req-pill-action-row {
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    gap: 6px;
-    width: 100%;
-}
-
-.req-document ::deep .req-pills {
-    display: inline-flex;
-    gap: 3px;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-}
-
-/* the category pills always share one (wrapping) row, whether the block is inline or stacked under the owner */
+/* shared pill layout used by RequirementPills (tree + document) and RequirementRowActions — kept once here,
+   in both the tree and document scopes, rather than duplicated in each component's scoped stylesheet */
+.req-toc ::deep .req-pills,
+.req-document ::deep .req-pills,
+.req-toc ::deep .req-pill-categories,
 .req-document ::deep .req-pill-categories {
     display: inline-flex;
     gap: 3px;
@@ -463,8 +429,6 @@
     padding: 24px;
 }
 
-/* pill sizing: the shared .starion-pill is a fixed 19px with no horizontal padding, so text is
-   clipped. Give our pills real padding, centring and no-wrap so short names fit cleanly. */
 .req-toc ::deep .starion-pill,
 .req-document ::deep .starion-pill {
     display: inline-flex;
@@ -480,7 +444,6 @@
     color: #1f2937;
 }
 
-/* Indent toggle: when off, flatten the group indentation so headers and requirements sit flush-left. */
 .req-document.no-indent ::deep .req-group {
     margin-left: 0;
     padding-left: 0;
@@ -489,7 +452,6 @@
 
 /* --- requirement detail sections (rendered by RequirementDetails) --- */
 
-/* constraints + traceability sit side by side to use the horizontal space; they wrap on a narrow row */
 .req-document ::deep .req-details {
     margin-top: 6px;
     display: flex;
@@ -504,8 +466,6 @@
     min-width: 0;
 }
 
-/* DOORS-like value columns: fixed-width cells on the right of every requirement row, one per visible
-   parameter type in a fixed order, so the cells line up vertically across requirements. */
 .req-document ::deep .req-row-values {
     flex: 0 1 auto;
     display: flex;
@@ -537,7 +497,6 @@
     border-style: dashed;
 }
 
-/* an editing cell grows to fit the (wider) date/combo editor instead of cramping it into the column width */
 .req-document ::deep .req-value-cell:has(.req-value-editor) {
     width: auto;
     min-width: 160px;
@@ -572,7 +531,6 @@
     background: #fff;
 }
 
-/* empty cell: an obviously-different "+ add" affordance so a missing value never looks like a set one */
 .req-document ::deep .req-value-add {
     border: none;
     background: none;
@@ -589,7 +547,6 @@
     text-decoration: underline;
 }
 
-/* actions sit on a row ABOVE the editor so the value/date stays fully readable before confirming */
 .req-document ::deep .req-value-editor {
     display: flex;
     flex-direction: column;
@@ -629,7 +586,6 @@
     color: #b42318;
 }
 
-/* shared shell for the Constraints and Traceability sections */
 .req-document ::deep .req-section {
     padding: 5px 10px 7px;
     background: #fbfcfe;
@@ -655,7 +611,6 @@
     border-top: 1px dashed #e5e9ee;
 }
 
-/* a non-leaf node: collapse toggle + operator chip + one-line summary of the whole subtree */
 .req-document ::deep .req-expr-node {
     display: flex;
     align-items: center;
@@ -699,8 +654,6 @@
     white-space: nowrap;
 }
 
-/* neutral violet: the published value is informational, not a pass/fail — green/red/amber all carry a
-   validation meaning in the IME, so they are deliberately avoided here */
 .req-document ::deep .req-expr-published {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.75rem;
@@ -718,8 +671,6 @@
     border-left: 1px solid #d8e3f4;
 }
 
-/* wrap so the bound-parameter model code and its published value drop to the next line inside the constraint
-   card on a narrow panel instead of spilling past its right edge */
 .req-document ::deep .req-expr-leaf {
     display: inline-flex;
     flex-wrap: wrap;
@@ -755,7 +706,6 @@
     padding: 0 5px;
 }
 
-/* traceability rows: wrap so the linked things and the rule pills stay inside the card on a narrow panel */
 .req-document ::deep .req-link-row {
     display: flex;
     flex-wrap: wrap;
@@ -802,9 +752,6 @@
     overflow-wrap: anywhere;
 }
 
-/* the linked requirement's definition, shown in the remaining space on ONE line (truncated) so it never grows
-   the card. flex-basis 0 means it never forces a wrap to a second line: it only grows into the room left between
-   the link and the rule pills, and also acts as the spacer that pushes the pills to the right. */
 .req-document ::deep .req-link-def {
     flex: 1 1 0;
     min-width: 0;
@@ -835,7 +782,6 @@
     white-space: nowrap;
 }
 
-/* Deprecated things (rendered only when the global "Show Deprecated Things" toggle is on). */
 .req-document ::deep .req-row-deprecated {
     opacity: 0.6;
 }
@@ -889,66 +835,4 @@
 .req-document ::deep .req-spec-title:hover .req-actions .dxbl-btn,
 .req-document ::deep .req-group-header:hover .req-actions .dxbl-btn {
     opacity: 1;
-}
-
-.req-document ::deep .req-def-display {
-    flex: 1 1 auto;
-    min-width: 0;
-    white-space: pre-wrap;
-    cursor: text;
-    border-radius: 3px;
-    padding: 1px 3px;
-    transition: background-color 0.15s ease;
-}
-
-.req-document ::deep .req-def-display:hover {
-    background-color: #eef2ff;
-    box-shadow: inset 0 0 0 1px #c7d2fe;
-}
-
-.req-document ::deep .req-def-editor {
-    display: flex;
-    flex: 1 1 auto;
-    min-width: 0;
-    align-items: flex-start;
-    gap: 4px;
-    max-width: 100%;
-}
-
-/* same "unsaved edit" highlight as the value editor (.req-value-editor-dirty) */
-.req-document ::deep .req-def-editor-dirty {
-    outline: 2px solid #b9d0f0;
-    background: #e7f1ff;
-    border-radius: 4px;
-    padding: 2px;
-}
-
-.req-document ::deep .req-def-editor-actions {
-    display: inline-flex;
-    flex-direction: column;
-    gap: 2px;
-    flex: 0 0 auto;
-}
-
-.req-document ::deep .req-def-save,
-.req-document ::deep .req-def-cancel {
-    border: none;
-    background: none;
-    padding: 0 3px;
-    cursor: pointer;
-    font-size: 0.85rem;
-    line-height: 1;
-}
-
-.req-document ::deep .req-def-save {
-    color: #12805c;
-}
-
-.req-document ::deep .req-def-cancel {
-    color: #b42318;
-}
-
-.req-document ::deep .req-def-memo {
-    flex: 1 1 auto;
-    min-width: 0;
 }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -59,6 +59,13 @@
     gap: 6px;
 }
 
+.req-view-menu ::deep .req-view-toggle-on {
+    background-color: #e7f1ff !important;
+    border-color: #b9d0f0 !important;
+    color: #3b5b8c !important;
+    font-weight: 600;
+}
+
 .req-filter {
     flex: 1 1 100px;
     min-width: 78px;
@@ -385,10 +392,13 @@
 }
 
 .req-document ::deep .req-def {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    column-gap: 4px;
     margin: 2px 0 0;
     line-height: 1.5;
     color: #1f2937;
-    white-space: pre-wrap;
 }
 
 /* pills block when the value columns are hidden: a compact inline group at the far right of the row */
@@ -589,10 +599,9 @@
     padding: 1px;
 }
 
-/* clearly show an unsaved edit (blue, not amber — amber reads as a warning) */
 .req-document ::deep .req-value-editor-dirty {
-    outline: 2px solid #4096ff;
-    background: #e6f4ff;
+    outline: 2px solid #b9d0f0;
+    background: #e7f1ff;
 }
 
 .req-document ::deep .req-value-editor-actions {
@@ -793,8 +802,21 @@
     overflow-wrap: anywhere;
 }
 
+/* the linked requirement's definition, shown in the remaining space on ONE line (truncated) so it never grows
+   the card. flex-basis 0 means it never forces a wrap to a second line: it only grows into the room left between
+   the link and the rule pills, and also acts as the spacer that pushes the pills to the right. */
+.req-document ::deep .req-link-def {
+    flex: 1 1 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #98a2b3;
+    font-size: 0.82rem;
+}
+
 .req-document ::deep .req-link-row .req-pills {
-    margin-left: auto;
+    flex: 0 0 auto;
     padding-left: 6px;
 }
 
@@ -870,6 +892,9 @@
 }
 
 .req-document ::deep .req-def-display {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: pre-wrap;
     cursor: text;
     border-radius: 3px;
     padding: 1px 3px;
@@ -881,26 +906,27 @@
     box-shadow: inset 0 0 0 1px #c7d2fe;
 }
 
-/* same compact shape as the simple-parameter-value editor: borderless ✓/✗ on a row above the memo */
 .req-document ::deep .req-def-editor {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 3px;
+    flex: 1 1 auto;
+    min-width: 0;
+    align-items: flex-start;
+    gap: 4px;
+    max-width: 100%;
 }
 
-/* same blue "unsaved edit" highlight as the value editor (.req-value-editor-dirty) */
+/* same "unsaved edit" highlight as the value editor (.req-value-editor-dirty) */
 .req-document ::deep .req-def-editor-dirty {
-    outline: 2px solid #4096ff;
-    background: #e6f4ff;
+    outline: 2px solid #b9d0f0;
+    background: #e7f1ff;
     border-radius: 4px;
     padding: 2px;
 }
 
 .req-document ::deep .req-def-editor-actions {
-    display: flex;
+    display: inline-flex;
+    flex-direction: column;
     gap: 2px;
-    justify-content: flex-end;
     flex: 0 0 auto;
 }
 
@@ -923,5 +949,6 @@
 }
 
 .req-document ::deep .req-def-memo {
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
 }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -36,9 +36,27 @@
 }
 
 .req-search {
-    flex: 1 1 130px;
-    min-width: 90px;
-    max-width: 260px;
+    flex: 1 0 220px;
+    min-width: 200px;
+    max-width: 420px;
+}
+
+.req-search ::deep .req-search-input {
+    width: 100%;
+}
+
+.req-view-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    min-width: 200px;
+}
+
+.req-view-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .req-filter {
@@ -167,6 +185,18 @@
     flex: 0 1 auto;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+/* group rows can be dragged onto another group (to nest) or the specification (to make top-level) */
+.req-toc ::deep .req-tree-group-row {
+    cursor: grab;
+}
+
+/* a valid drop target while a group is being dragged */
+.req-toc ::deep .req-tree-droptarget {
+    outline: 2px dashed #4096ff;
+    outline-offset: -2px;
+    background: #e6f4ff;
 }
 
 .req-toc ::deep .req-tree-row .req-pills {
@@ -361,23 +391,39 @@
     white-space: pre-wrap;
 }
 
+/* pills block when the value columns are hidden: a compact inline group at the far right of the row */
 .req-document ::deep .req-row-pills {
     flex: 0 0 auto;
     white-space: nowrap;
     text-align: end;
 }
 
-/* with values open the pills sit at the far right in a fixed-width column so the value columns to their left
-   stay vertically aligned across rows: the owner pill on top, the category pills as one wrapping row below */
-.req-document ::deep .req-row-pills.req-pills-stacked {
+/* when up to five value columns are shown, the pills + actions are a value-cell-sized block that flows as the
+   LAST cell of the value grid, so it fills the empty slot after the last value instead of leaving whitespace and
+   lines up in the same columns as the value cells (same 130px border-box footprint). */
+.req-document ::deep .req-pills-cell {
     flex: 0 0 130px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-end;
+}
+
+.req-document ::deep .req-row-pills.req-pills-corner {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-end;
     white-space: normal;
 }
 
-.req-document ::deep .req-row-pills.req-pills-stacked .req-pills {
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 2px;
+.req-document ::deep .req-pill-action-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    gap: 6px;
+    width: 100%;
 }
 
 .req-document ::deep .req-pills {
@@ -459,6 +505,12 @@
     padding-left: 8px;
 }
 
+.req-document ::deep .req-row-top.req-values-below .req-row-values {
+    order: 3;
+    flex: 1 1 100%;
+    padding-left: 0;
+}
+
 .req-document ::deep .req-value-cell {
     display: flex;
     flex-direction: column;
@@ -537,10 +589,10 @@
     padding: 1px;
 }
 
-/* clearly show an unsaved edit */
+/* clearly show an unsaved edit (blue, not amber — amber reads as a warning) */
 .req-document ::deep .req-value-editor-dirty {
-    outline: 2px solid #ffd666;
-    background: #fffbe6;
+    outline: 2px solid #4096ff;
+    background: #e6f4ff;
 }
 
 .req-document ::deep .req-value-editor-actions {
@@ -829,30 +881,41 @@
     box-shadow: inset 0 0 0 1px #c7d2fe;
 }
 
+/* same compact shape as the simple-parameter-value editor: borderless ✓/✗ on a row above the memo */
 .req-document ::deep .req-def-editor {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    align-items: stretch;
+    gap: 3px;
+}
+
+/* same blue "unsaved edit" highlight as the value editor (.req-value-editor-dirty) */
+.req-document ::deep .req-def-editor-dirty {
+    outline: 2px solid #4096ff;
+    background: #e6f4ff;
+    border-radius: 4px;
+    padding: 2px;
 }
 
 .req-document ::deep .req-def-editor-actions {
     display: flex;
-    gap: 4px;
+    gap: 2px;
+    justify-content: flex-end;
+    flex: 0 0 auto;
 }
 
 .req-document ::deep .req-def-save,
 .req-document ::deep .req-def-cancel {
-    border: 1px solid #d0d5dd;
-    background: #fff;
-    border-radius: 4px;
-    width: 24px;
-    height: 24px;
-    line-height: 1;
+    border: none;
+    background: none;
+    padding: 0 3px;
     cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
 }
 
 .req-document ::deep .req-def-save {
-    color: #067647;
+    color: #12805c;
 }
 
 .req-document ::deep .req-def-cancel {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -56,10 +56,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
         @foreach (var specification in this.ViewModel.AvailableSpecifications)
         {
             var isSelected = specification == this.ViewModel.SelectedSpecification;
+            var specIsDropTarget = this.ViewModel.DragOverContainer == specification && this.ViewModel.CanMoveGroup(this.ViewModel.DraggedGroup, specification);
 
             <li class="req-tree-item">
-                <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty) @(specification.IsDeprecated ? "req-tree-deprecated" : string.Empty)"
-                     @onclick="@(() => this.ViewModel.SelectedSpecification = specification)">
+                <div class="req-tree-row req-tree-spec @(isSelected ? "selected" : string.Empty) @(specification.IsDeprecated ? "req-tree-deprecated" : string.Empty) @(specIsDropTarget ? "req-tree-droptarget" : string.Empty)"
+                     @onclick="@(() => this.ViewModel.SelectedSpecification = specification)"
+                     @ondragenter="@(() => this.OnDragEnter(specification))"
+                     @ondragover:preventDefault="true"
+                     @ondrop="@(() => this.OnDropOnContainer(specification))">
                     <span class="req-tree-label">@(this.ViewModel.TreeUsesShortName ? specification.ShortName : specification.Name)</span>
                     @pills((specification.Owner, specification.Category))
                 </div>
@@ -78,9 +82,17 @@ else
         {
             var hasChildren = this.ViewModel.GetGroups(group).Any();
             var collapsed = this.ViewModel.IsTreeNodeCollapsed(group.Iid);
+            var isDropTarget = this.ViewModel.DragOverContainer == group && this.ViewModel.CanMoveGroup(this.ViewModel.DraggedGroup, group);
 
             <li class="req-tree-item">
-                <div class="req-tree-row">
+                <div class="req-tree-row req-tree-group-row @(isDropTarget ? "req-tree-droptarget" : string.Empty)"
+                     draggable="true"
+                     title="Drag onto a group to nest it, or onto the specification to make it top-level"
+                     @ondragstart="@(() => this.OnGroupDragStart(group))"
+                     @ondragend="@this.OnGroupDragEnd"
+                     @ondragenter="@(() => this.OnDragEnter(group))"
+                     @ondragover:preventDefault="true"
+                     @ondrop="@(() => this.OnDropOnContainer(group))">
                     @if (hasChildren)
                     {
                         <button type="button" class="req-tree-chevron" title="@(collapsed ? "Expand" : "Collapse")"
@@ -92,7 +104,7 @@ else
                     {
                         <span class="req-tree-chevron-placeholder"></span>
                     }
-                    <a class="req-tree-group" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</a>
+                    <a class="req-tree-group" draggable="false" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</a>
                     @pills((group.Owner, group.Category))
                 </div>
                 @if (hasChildren && !collapsed)

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -18,26 +18,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
-@using CDP4Common.SiteDirectoryData
-@using COMETwebapp.Utilities
-
-@{
-    RenderFragment<(DomainOfExpertise Owner, IEnumerable<Category> Categories)> pills = context =>
-        @<span class="req-pills">
-            @if (this.ViewModel.ShowOwner && context.Owner != null)
-            {
-                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{context.Owner.ShortName}") !important;" title="Owner: @context.Owner.Name">@context.Owner.ShortName</span>
-            }
-            @if (this.ViewModel.ShowCategory)
-            {
-                @foreach (var category in context.Categories)
-                {
-                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
-                }
-            }
-        </span>;
-}
-
 @if (this.Groups == null)
 {
     <div class="req-tree-header">
@@ -57,7 +37,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                      @ondragover:preventDefault="true"
                      @ondrop="@(() => this.OnDropOnContainer(specification))">
                     <span class="req-tree-label">@(this.ViewModel.TreeUsesShortName ? specification.ShortName : specification.Name)</span>
-                    @pills((specification.Owner, specification.Category))
+                    <RequirementPills ViewModel="@this.ViewModel" Owner="@specification.Owner" Categories="@specification.Category" />
                 </div>
                 @if (isSelected)
                 {
@@ -97,7 +77,7 @@ else
                         <span class="req-tree-chevron-placeholder"></span>
                     }
                     <a class="req-tree-group" draggable="false" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</a>
-                    @pills((group.Owner, group.Category))
+                    <RequirementPills ViewModel="@this.ViewModel" Owner="@group.Owner" Categories="@group.Category" />
                 </div>
                 @if (hasChildren && !collapsed)
                 {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -42,14 +42,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
 {
     <div class="req-tree-header">
         <span class="req-tree-header-title">Contents</span>
-        <div class="btn-group" role="group" aria-label="Table of contents label">
-            <DxButton RenderStyle="@(this.ViewModel.TreeUsesShortName ? ButtonRenderStyle.Primary : ButtonRenderStyle.Light)"
-                      Text="ID" title="Label by short name"
-                      Click="@(() => this.ViewModel.TreeUsesShortName = true)" />
-            <DxButton RenderStyle="@(this.ViewModel.TreeUsesShortName ? ButtonRenderStyle.Light : ButtonRenderStyle.Primary)"
-                      Text="Name" title="Label by name"
-                      Click="@(() => this.ViewModel.TreeUsesShortName = false)" />
-        </div>
     </div>
 
     <ul class="req-tree">

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor.cs
@@ -46,5 +46,51 @@ namespace COMETwebapp.Components.RequirementsEditor
         /// </summary>
         [Parameter]
         public IEnumerable<RequirementsGroup> Groups { get; set; }
+
+        /// <summary>
+        /// Records the <paramref name="group" /> being dragged so a subsequent drop can re-parent it.
+        /// </summary>
+        /// <param name="group">The dragged <see cref="RequirementsGroup" />.</param>
+        private void OnGroupDragStart(RequirementsGroup group)
+        {
+            this.ViewModel.DraggedGroup = group;
+        }
+
+        /// <summary>
+        /// Marks the given <paramref name="target" /> as the hovered container so it is highlighted while the drag is
+        /// over it (only the hovered target is highlighted, and only the invalid-target check gates the highlight).
+        /// </summary>
+        /// <param name="target">The <see cref="RequirementsContainer" /> the drag entered.</param>
+        private void OnDragEnter(RequirementsContainer target)
+        {
+            this.ViewModel.DragOverContainer = target;
+        }
+
+        /// <summary>
+        /// Clears the drag state when the drag ends (whether or not it resulted in a drop).
+        /// </summary>
+        private void OnGroupDragEnd()
+        {
+            this.ViewModel.DraggedGroup = null;
+            this.ViewModel.DragOverContainer = null;
+        }
+
+        /// <summary>
+        /// Drops the dragged group onto the given <paramref name="target" /> container, re-parenting it (the move is
+        /// validated and silently ignored when it is not allowed, e.g. onto itself or a descendant).
+        /// </summary>
+        /// <param name="target">The target <see cref="RequirementsContainer" /> (a specification or a group).</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task OnDropOnContainer(RequirementsContainer target)
+        {
+            var dragged = this.ViewModel.DraggedGroup;
+            this.ViewModel.DraggedGroup = null;
+            this.ViewModel.DragOverContainer = null;
+
+            if (dragged != null && this.ViewModel.CanMoveGroup(dragged, target))
+            {
+                await this.ViewModel.MoveGroupAsync(dragged, target);
+            }
+        }
     }
 }

--- a/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
+++ b/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
@@ -101,7 +101,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 @if (this.editorSelectorViewModel != null)
                 {
                     <DxFormLayoutItem Caption="Value:" ColSpanMd="12">
-                        <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" />
+                        <ParameterTypeEditorSelector ViewModel="@this.editorSelectorViewModel" BindValueMode="BindValueMode.OnInput" IsOnEditMode="true" />
                     </DxFormLayoutItem>
                 }
             </DxFormLayout>

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
@@ -206,6 +206,12 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         public IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the form can be saved. A <see cref="Requirement" /> must carry at least one
+        /// non-empty <see cref="Definition" /> (in any language); groups and specifications are always saveable.
+        /// </summary>
+        public bool CanSave => !this.IsRequirement || this.DefinedThing.Definition.Any(x => !string.IsNullOrWhiteSpace(x.Content));
+
+        /// <summary>
         /// Gets or sets the callback invoked when the user submits a valid edit.
         /// </summary>
         public EventCallback OnValidSubmit { get; set; }

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IEditRequirementThingViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IEditRequirementThingViewModel.cs
@@ -119,6 +119,12 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the form can be saved. A <see cref="Requirement" /> must have at least one
+        /// non-empty <see cref="Definition" />; groups and specifications are always saveable.
+        /// </summary>
+        bool CanSave { get; }
+
+        /// <summary>
         /// Gets or sets the callback invoked when the user submits a valid edit.
         /// </summary>
         EventCallback OnValidSubmit { get; set; }

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
@@ -231,6 +231,14 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         IReadOnlyList<BooleanExpression> GetTerms(BooleanExpression expression);
 
         /// <summary>
+        /// Gets every <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
+        /// <see cref="BinaryRelationship" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The bound parameters, empty when none are bound</returns>
+        IReadOnlyList<ParameterOrOverrideBase> GetBoundParameters(RelationalExpression expression);
+
+        /// <summary>
         /// Gets the <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
         /// <see cref="BinaryRelationship" />.
         /// </summary>
@@ -247,12 +255,36 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         string GetBoundParameterModelCode(RelationalExpression expression);
 
         /// <summary>
+        /// Gets the formatted published value of the given <paramref name="parameter" />.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /></param>
+        /// <returns>The formatted published value, or null when it cannot be shown unambiguously</returns>
+        string GetPublishedValue(ParameterOrOverrideBase parameter);
+
+        /// <summary>
         /// Gets the published value of the <see cref="ParameterOrOverrideBase" /> bound to the given
         /// <paramref name="expression" />.
         /// </summary>
         /// <param name="expression">The <see cref="RelationalExpression" /></param>
         /// <returns>The formatted published value, or null when no parameter is bound</returns>
         string GetBoundParameterPublishedValue(RelationalExpression expression);
+
+        /// <summary>
+        /// Gets the <see cref="ParameterOrOverrideBase" />s of the element tree that could be linked to the given
+        /// <paramref name="expression" />, i.e. the ones sharing its <see cref="ParameterType" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The candidate parameters, ordered by model code</returns>
+        IReadOnlyList<ParameterOrOverrideBase> GetLinkableParameters(RelationalExpression expression);
+
+        /// <summary>
+        /// Creates and removes the <see cref="BinaryRelationship" />s so that the given <paramref name="expression" />
+        /// ends up bound to exactly the <paramref name="selected" /> parameters.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <param name="selected">The <see cref="ParameterOrOverrideBase" />s the expression should be bound to</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the operation</returns>
+        Task<Result> UpdateParameterLinksAsync(RelationalExpression expression, IReadOnlyCollection<ParameterOrOverrideBase> selected);
 
         /// <summary>
         /// Gets a one-line human-readable summary of the given <paramref name="expression" /> tree.
@@ -288,6 +320,36 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// </summary>
         /// <param name="requirement">The <see cref="Requirement" /> to navigate to</param>
         void NavigateToRequirement(Requirement requirement);
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsGroup" /> currently being dragged in the table of contents to change
+        /// its nesting, or null when no drag is in progress.
+        /// </summary>
+        RequirementsGroup DraggedGroup { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsContainer" /> the dragged group is currently hovered over, or null;
+        /// used to highlight only the hovered valid drop target.
+        /// </summary>
+        RequirementsContainer DragOverContainer { get; set; }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="group" /> may be dropped onto the given <paramref name="target" />
+        /// container (a different container in the same specification that is not the group itself or a descendant).
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> being moved.</param>
+        /// <param name="target">The target <see cref="RequirementsContainer" />.</param>
+        /// <returns>true when the move is allowed</returns>
+        bool CanMoveGroup(RequirementsGroup group, RequirementsContainer target);
+
+        /// <summary>
+        /// Re-parents the given <paramref name="group" /> under the given <paramref name="target" /> container and
+        /// persists the move; does nothing when the move is not allowed.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> to move.</param>
+        /// <param name="target">The target <see cref="RequirementsContainer" />.</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the move</returns>
+        Task<Result> MoveGroupAsync(RequirementsGroup group, RequirementsContainer target);
 
         /// <summary>
         /// Gets whether the group with the given <paramref name="iid" /> is collapsed in the document panel.

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -572,7 +572,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
                 if (definition == null)
                 {
-                    definition = new Definition { Iid = Guid.NewGuid(), LanguageCode = "en-GB" };
+                    definition = new Definition { Iid = Guid.NewGuid(), LanguageCode = this.GetDefaultDefinitionLanguageCode() };
                     clone.Definition.Add(definition);
                 }
 
@@ -597,6 +597,108 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             {
                 this.IsLoading = false;
             }
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="DraggedGroup" />.
+        /// </summary>
+        private RequirementsGroup draggedGroup;
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsGroup" /> currently being dragged in the table of contents to change
+        /// its nesting, or null when no drag is in progress. Reactive so the tree re-renders to gate drop targets.
+        /// </summary>
+        public RequirementsGroup DraggedGroup
+        {
+            get => this.draggedGroup;
+            set => this.RaiseAndSetIfChanged(ref this.draggedGroup, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="DragOverContainer" />.
+        /// </summary>
+        private RequirementsContainer dragOverContainer;
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsContainer" /> the dragged group is currently hovered over, or null.
+        /// Reactive so only the hovered valid target is highlighted (like the System Representation tree).
+        /// </summary>
+        public RequirementsContainer DragOverContainer
+        {
+            get => this.dragOverContainer;
+            set => this.RaiseAndSetIfChanged(ref this.dragOverContainer, value);
+        }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="group" /> may be dropped onto the given <paramref name="target" />
+        /// container: the target must be a different container in the same specification, and must not be the group
+        /// itself or one of its descendants (which would create a cycle).
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> being moved.</param>
+        /// <param name="target">The target <see cref="RequirementsContainer" /> (a specification or a group).</param>
+        /// <returns>true when the move is allowed</returns>
+        public bool CanMoveGroup(RequirementsGroup group, RequirementsContainer target)
+        {
+            if (group == null || target == null || target == group.Container)
+            {
+                return false;
+            }
+
+            var groupSpecification = group.GetContainerOfType<RequirementsSpecification>();
+            var targetSpecification = target as RequirementsSpecification ?? target.GetContainerOfType<RequirementsSpecification>();
+
+            if (groupSpecification != targetSpecification)
+            {
+                return false;
+            }
+
+            for (var ancestor = target as RequirementsGroup; ancestor != null; ancestor = ancestor.Container as RequirementsGroup)
+            {
+                if (ancestor == group)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Re-parents the given <paramref name="group" /> under the given <paramref name="target" /> container — a
+        /// <see cref="RequirementsSpecification" /> to make it a top-level group, or another <see cref="RequirementsGroup" />
+        /// to nest it — and persists the move. Does nothing when the move is not allowed (see <see cref="CanMoveGroup" />).
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> to move.</param>
+        /// <param name="target">The target <see cref="RequirementsContainer" />.</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the move</returns>
+        public async Task<Result> MoveGroupAsync(RequirementsGroup group, RequirementsContainer target)
+        {
+            if (!this.CanMoveGroup(group, target))
+            {
+                return Result.Fail("The group cannot be moved to that location.");
+            }
+
+            // mirrors the desktop IME (RequirementsSpecificationRowViewModel.MoveGroup): only the NEW container is
+            // updated, with the moved group added to its Group list — the server re-parents it and removes it from its
+            // old container. Sending the old container or the group as separate updates trips the server's acyclic
+            // check (NullReferenceException in RequirementsGroupSideEffect) because it then sees inconsistent state.
+            var newContainerClone = (RequirementsContainer)target.Clone(false);
+            newContainerClone.Group.Add(group.Clone(false));
+
+            return await this.SessionService.CreateOrUpdateThingsWithNotification(newContainerClone, [newContainerClone],
+                BuildNotification(group, "moved", "move"));
+        }
+
+        /// <summary>
+        /// Gets the directory-wide default definition language: the first <see cref="NaturalLanguage" /> configured on the
+        /// model's <see cref="SiteDirectory" />, falling back to English when the directory defines none. Mirrors the
+        /// create/edit dialog so an inline-added definition gets the same default language.
+        /// </summary>
+        /// <returns>The default language code</returns>
+        private string GetDefaultDefinitionLanguageCode()
+        {
+            var directoryLanguage = this.SessionService.Session.RetrieveSiteDirectory().NaturalLanguage.FirstOrDefault()?.LanguageCode;
+            return string.IsNullOrWhiteSpace(directoryLanguage) ? "en" : directoryLanguage;
         }
 
         /// <summary>
@@ -743,6 +845,26 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Gets every <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
+        /// <see cref="BinaryRelationship" />, the way requirement verification links a parameter to a relational
+        /// expression.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The bound parameters, empty when none are bound</returns>
+        public IReadOnlyList<ParameterOrOverrideBase> GetBoundParameters(RelationalExpression expression)
+        {
+            if (this.CurrentThing == null)
+            {
+                return [];
+            }
+
+            return this.CurrentThing.Relationship.OfType<BinaryRelationship>()
+                .Select(x => (x.Source == expression ? x.Target : x.Target == expression ? x.Source : null) as ParameterOrOverrideBase)
+                .Where(x => x != null)
+                .ToList();
+        }
+
+        /// <summary>
         /// Gets the <see cref="ParameterOrOverrideBase" /> bound to the given <paramref name="expression" /> through a
         /// <see cref="BinaryRelationship" />, the way requirement verification links a parameter to a relational
         /// expression.
@@ -751,15 +873,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// <returns>The bound parameter, or null when none is bound</returns>
         public ParameterOrOverrideBase GetBoundParameter(RelationalExpression expression)
         {
-            var binding = this.CurrentThing?.Relationship.OfType<BinaryRelationship>()
-                .FirstOrDefault(x => (x.Source == expression && x.Target is ParameterOrOverrideBase) || (x.Target == expression && x.Source is ParameterOrOverrideBase));
-
-            if (binding == null)
-            {
-                return null;
-            }
-
-            return (ParameterOrOverrideBase)(binding.Source == expression ? binding.Target : binding.Source);
+            return this.GetBoundParameters(expression).FirstOrDefault();
         }
 
         /// <summary>
@@ -774,6 +888,21 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Gets the formatted published value of the given <paramref name="parameter" /> — the value the bound element
+        /// last published, to compare against the constraint's threshold.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /></param>
+        /// <returns>The formatted published value, or null when it cannot be shown unambiguously</returns>
+        public string GetPublishedValue(ParameterOrOverrideBase parameter)
+        {
+            var valueSets = parameter?.ValueSets.OfType<ParameterValueSetBase>().ToList() ?? [];
+
+            // only show a single, unambiguous published value; an option/state-dependent parameter has several and we
+            // would otherwise present an arbitrary one as "the" published value
+            return valueSets.Count == 1 ? ParameterValueFormatter.Format(valueSets[0].Published, parameter.Scale) : null;
+        }
+
+        /// <summary>
         /// Gets the published value of the <see cref="ParameterOrOverrideBase" /> bound to the given
         /// <paramref name="expression" /> — the value the bound element last published, to compare against the
         /// constraint's threshold.
@@ -782,12 +911,77 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// <returns>The formatted published value, or null when no parameter is bound</returns>
         public string GetBoundParameterPublishedValue(RelationalExpression expression)
         {
-            var parameter = this.GetBoundParameter(expression);
-            var valueSets = parameter?.ValueSets.OfType<ParameterValueSetBase>().ToList() ?? [];
+            return this.GetPublishedValue(this.GetBoundParameter(expression));
+        }
 
-            // only show a single, unambiguous published value; an option/state-dependent parameter has several and we
-            // would otherwise present an arbitrary one as "the" published value
-            return valueSets.Count == 1 ? ParameterValueFormatter.Format(valueSets[0].Published, parameter.Scale) : null;
+        /// <summary>
+        /// Gets the <see cref="ParameterOrOverrideBase" />s of the element tree that could be linked to the given
+        /// <paramref name="expression" />, i.e. the ones sharing its <see cref="ParameterType" />.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <returns>The candidate parameters, ordered by model code</returns>
+        public IReadOnlyList<ParameterOrOverrideBase> GetLinkableParameters(RelationalExpression expression)
+        {
+            if (this.CurrentThing == null || expression?.ParameterType == null)
+            {
+                return [];
+            }
+
+            var definitionParameters = this.CurrentThing.Element.SelectMany(x => x.Parameter);
+            var usageOverrides = this.CurrentThing.Element.SelectMany(x => x.ContainedElement).SelectMany(x => x.ParameterOverride);
+
+            // same gate as the desktop IME (ThingCreator.IsCreateBinaryRelationshipForRequirementVerificationAllowed):
+            // same parameter type, and for a quantity kind also the same scale
+            return definitionParameters.Concat<ParameterOrOverrideBase>(usageOverrides)
+                .Where(x => x.ParameterType == expression.ParameterType && (expression.ParameterType is not QuantityKind || x.Scale == expression.Scale))
+                .OrderBy(x => x.ModelCode())
+                .ToList();
+        }
+
+        /// <summary>
+        /// Creates and removes the <see cref="BinaryRelationship" />s so that the given <paramref name="expression" />
+        /// ends up bound to exactly the <paramref name="selected" /> parameters.
+        /// </summary>
+        /// <param name="expression">The <see cref="RelationalExpression" /></param>
+        /// <param name="selected">The <see cref="ParameterOrOverrideBase" />s the expression should be bound to</param>
+        /// <returns>A <see cref="Task{T}" /> with the <see cref="Result" /> of the operation</returns>
+        public async Task<Result> UpdateParameterLinksAsync(RelationalExpression expression, IReadOnlyCollection<ParameterOrOverrideBase> selected)
+        {
+            if (this.CurrentThing == null)
+            {
+                return Result.Fail("No iteration is loaded");
+            }
+
+            var currentBindings = this.CurrentThing.Relationship.OfType<BinaryRelationship>()
+                .Where(x => (x.Source == expression && x.Target is ParameterOrOverrideBase) || (x.Target == expression && x.Source is ParameterOrOverrideBase))
+                .ToList();
+
+            var boundParameters = currentBindings.ToDictionary(x => x, x => (ParameterOrOverrideBase)(x.Source == expression ? x.Target : x.Source));
+
+            var toAdd = selected.Where(x => !boundParameters.Values.Contains(x)).ToList();
+            var toRemove = currentBindings.Where(x => !selected.Contains(boundParameters[x])).ToList();
+
+            if (toAdd.Count == 0 && toRemove.Count == 0)
+            {
+                return Result.Ok();
+            }
+
+            var iterationClone = this.CurrentThing.Clone(false);
+            var created = new List<Thing> { iterationClone };
+
+            foreach (var parameter in toAdd)
+            {
+                // direction matches the desktop IME (ThingCreator.CreateBinaryRelationshipForRequirementVerification):
+                // Source is the parameter, Target is the relational expression — the IME only recognises links written this way
+                var relationship = new BinaryRelationship { Iid = Guid.NewGuid(), Source = parameter, Target = expression, Owner = this.CurrentDomain };
+                iterationClone.Relationship.Add(relationship);
+                created.Add(relationship);
+            }
+
+            var deleted = toRemove.Select(x => (Thing)x.Clone(false)).ToList();
+
+            return await this.SessionService.CreateUpdateAndDeleteThingsWithNotification(iterationClone, created, deleted,
+                new NotificationDescription { OnSuccess = "Parameter link updated", OnError = "Updating the parameter link failed" });
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -678,15 +678,33 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
                 return Result.Fail("The group cannot be moved to that location.");
             }
 
-            // mirrors the desktop IME (RequirementsSpecificationRowViewModel.MoveGroup): only the NEW container is
-            // updated, with the moved group added to its Group list — the server re-parents it and removes it from its
-            // old container. Sending the old container or the group as separate updates trips the server's acyclic
-            // check (NullReferenceException in RequirementsGroupSideEffect) because it then sees inconsistent state.
-            var newContainerClone = (RequirementsContainer)target.Clone(false);
-            newContainerClone.Group.Add(group.Clone(false));
+            try
+            {
+                // toggling IsLoading is what makes the body (tree AND document) re-render with the new nesting once the
+                // write returns — every other write in this VM follows the same IsLoading + ReloadPreservingSelection pattern
+                this.IsLoading = true;
 
-            return await this.SessionService.CreateOrUpdateThingsWithNotification(newContainerClone, [newContainerClone],
-                BuildNotification(group, "moved", "move"));
+                // mirrors the desktop IME (RequirementsSpecificationRowViewModel.MoveGroup): only the NEW container is
+                // updated, with the moved group added to its Group list — the server re-parents it and removes it from
+                // its old container. Sending the old container or the group as separate updates trips the server's
+                // acyclic check (NullReferenceException in RequirementsGroupSideEffect) because it sees inconsistent state.
+                var newContainerClone = (RequirementsContainer)target.Clone(false);
+                newContainerClone.Group.Add(group.Clone(false));
+
+                var result = await this.SessionService.CreateOrUpdateThingsWithNotification(newContainerClone, [newContainerClone],
+                    BuildNotification(group, "moved", "move"));
+
+                if (result.IsSuccess)
+                {
+                    await this.ReloadPreservingSelection();
+                }
+
+                return result;
+            }
+            finally
+            {
+                this.IsLoading = false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
## Link a parametric constraint to an element parameter (#803) and drag-n-drop of requirements groups in ToC #807 

Adds the ability to link a parametric constraint's relational expression to an element parameter), plus a round of Requirements Editor UX improvements and table-of-contents drag-and-drop.

### Feature (#803)
- On each relational-expression leaf, a 🔗 link button opens a picker of element parameters/overrides sharing the expression's parameter type (and scale for quantity kinds); multi-select. Links are `BinaryRelationship`s.
- Direction/owner/no-category match the desktop IME (`Source = parameter, Target = relationalExpression`) so links interoperate both ways.

### Table-of-contents drag-and-drop (#807)
- Drag a requirements group onto another group to nest it, or onto its specification to make it top-level. Same-spec only, cycle-safe, hovered valid target highlighted (mirrors the System Representation tree). Write mirrors the IME `MoveGroup` to avoid the server acyclic-check failure.

### Requirements Editor
- **Toolbar:** view/layout/label toggles consolidated into a "View" dropdown; wider search box.
- **Editing:** a requirement now requires a definition to save; inline "add definition" sets the model's default language; inline definition editing works in all three layouts (ID / Name / ID+Name) as a compact, full-width-until-pills box; unsaved-edit highlight uses the soft pastel selection blue.
- **Values:** compound/array parameter values are editable inline; value grid re-worked (pills fill the trailing slot, or move to the top-right corner past 5 columns).
- **Traceability:** linked-requirement label follows the ID/Full-names toggle; each linked requirement's definition shows truncated in the trailing whitespace without growing the card.
- Removed the delete action for specifications and requirements (deprecate/restore kept).


<img width="1595" height="938" alt="image" src="https://github.com/user-attachments/assets/3ecc52ad-2332-45a4-97e4-2608676059b2" />


