### PR TITLE
Fix #806 made sidebar smaller

### DIFF
--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -401,8 +401,8 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
         }
 
         /// <summary>
-        /// Verifies the markup hooks that keep the collapsed side bar narrow (issue GH806): the footer logo is dropped on
-        /// collapse and the "Model"/"General" section headers carry the class that centers them in the narrow view.
+        /// Verifies the markup hooks that keep the collapsed side bar narrow (issue GH806): the footer logo and both
+        /// section-header labels are dropped on collapse, and the "General" header doubles as a horizontal divider.
         /// </summary>
         [Test]
         public void VerifyCollapsedSideBarIconOnlyLayout()
@@ -414,11 +414,14 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
 
             var applicationsSideBar = renderer.FindComponent<ApplicationsSideBar>();
             var sectionHeaders = applicationsSideBar.FindAll(".side-bar-section-header");
+            var dividers = applicationsSideBar.FindAll(".side-bar-section-divider");
 
             Assert.Multiple(() =>
             {
                 Assert.That(logo.ClassList, Does.Contain("not-displayed-on-collapse"));
                 Assert.That(sectionHeaders, Has.Count.EqualTo(2));
+                Assert.That(dividers, Has.Count.EqualTo(1));
+                Assert.That(sectionHeaders.All(header => header.QuerySelector(".not-displayed-on-collapse") is not null), Is.True);
             });
         }
 

--- a/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
+++ b/COMETwebapp.Tests/Shared/SideBarEntry/SideBarTestFixture.cs
@@ -400,6 +400,28 @@ namespace COMETwebapp.Tests.Shared.SideBarEntry
             renderer.WaitForAssertion(() => Assert.That(sideBar.IsCollapsed, Is.False, "Re-setting the same viewport state must keep the user's own choice."));
         }
 
+        /// <summary>
+        /// Verifies the markup hooks that keep the collapsed side bar narrow (issue GH806): the footer logo is dropped on
+        /// collapse and the "Model"/"General" section headers carry the class that centers them in the narrow view.
+        /// </summary>
+        [Test]
+        public void VerifyCollapsedSideBarIconOnlyLayout()
+        {
+            var renderer = this.context.Render<SideBar>();
+
+            var footer = renderer.FindComponent<SideBarFooter>();
+            var logo = footer.Find("img");
+
+            var applicationsSideBar = renderer.FindComponent<ApplicationsSideBar>();
+            var sectionHeaders = applicationsSideBar.FindAll(".side-bar-section-header");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(logo.ClassList, Does.Contain("not-displayed-on-collapse"));
+                Assert.That(sectionHeaders, Has.Count.EqualTo(2));
+            });
+        }
+
         [Test]
         public void VerifySideBarFooterIsInFlow()
         {

--- a/COMETwebapp/Shared/SideBar.razor.css
+++ b/COMETwebapp/Shared/SideBar.razor.css
@@ -10,3 +10,8 @@
 .main-side-bar ::deep > * {
     flex-shrink: 0;
 }
+
+.main-side-bar.collapsed {
+    padding-left: 4px;
+    padding-right: 4px;
+}

--- a/COMETwebapp/Shared/SideBar.razor.css
+++ b/COMETwebapp/Shared/SideBar.razor.css
@@ -1,10 +1,11 @@
 .main-side-bar {
     height: 100vh;
     background-color: var(--colors-primary-25);
-    padding: 10px 20px 10px 20px;
+    padding: 4px 20px 4px 20px;
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    scrollbar-width: thin;
 }
 
 .main-side-bar ::deep > * {
@@ -12,6 +13,9 @@
 }
 
 .main-side-bar.collapsed {
-    padding-left: 4px;
-    padding-right: 4px;
+    width: 36px;
+    padding-left: 2px;
+    padding-right: 2px;
+    align-items: center;
+    overflow-x: hidden;
 }

--- a/COMETwebapp/Shared/SideBarEntry/ApplicationsSideBar.razor
+++ b/COMETwebapp/Shared/SideBarEntry/ApplicationsSideBar.razor
@@ -21,7 +21,7 @@
 @using COMETwebapp.Utilities
 @inherits COMET.Web.Common.Shared.TopMenuEntry.AuthorizedMenuEntry
 
-<div class="pt-2 pb-2 ps-3 font-weight-bold" style="color: var(--colors-primary-900);">
+<div class="pt-2 pb-2 ps-3 font-weight-bold side-bar-section-header" style="color: var(--colors-primary-900);">
     Model
 </div>
 
@@ -34,7 +34,7 @@
                  Enabled="@(this.IsApplicationEnabled(applicationEntry))"/>
 }
 
-<div class="pt-4 pb-2 ps-3 font-weight-bold" style="color: var(--colors-primary-900);">
+<div class="pt-4 pb-2 ps-3 font-weight-bold side-bar-section-header" style="color: var(--colors-primary-900);">
     General
 </div>
 

--- a/COMETwebapp/Shared/SideBarEntry/ApplicationsSideBar.razor
+++ b/COMETwebapp/Shared/SideBarEntry/ApplicationsSideBar.razor
@@ -22,7 +22,7 @@
 @inherits COMET.Web.Common.Shared.TopMenuEntry.AuthorizedMenuEntry
 
 <div class="pt-2 pb-2 ps-3 font-weight-bold side-bar-section-header" style="color: var(--colors-primary-900);">
-    Model
+    <span class="not-displayed-on-collapse">Model</span>
 </div>
 
 @foreach (var applicationEntry in this.GetModelApplications())
@@ -34,8 +34,8 @@
                  Enabled="@(this.IsApplicationEnabled(applicationEntry))"/>
 }
 
-<div class="pt-4 pb-2 ps-3 font-weight-bold side-bar-section-header" style="color: var(--colors-primary-900);">
-    General
+<div class="pt-4 pb-2 ps-3 font-weight-bold side-bar-section-header side-bar-section-divider" style="color: var(--colors-primary-900);">
+    <span class="not-displayed-on-collapse">General</span>
 </div>
 
 @foreach (var applicationEntry in this.GetGeneralApplications())

--- a/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor
+++ b/COMETwebapp/Shared/SideBarEntry/SideBarFooter.razor
@@ -22,7 +22,7 @@
 
 <div class="side-bar-footer">
 	<a class="homelink" href="/">
-		<img src=@("_content/CDP4.WEB.Common/images/COMET-Symbol.png") class="p-1" style="width: 75px;" title="COMET Community Edition" alt="COMET Community Edition" />
+		<img src=@("_content/CDP4.WEB.Common/images/COMET-Symbol.png") class="p-1 not-displayed-on-collapse" style="width: 75px;" title="COMET Community Edition" alt="COMET Community Edition" />
 		<span class="font-weight-bold not-displayed-on-collapse" style="font-size: 0.8rem;">COMET Community Edition</span>
 	</a>
 </div>

--- a/COMETwebapp/Shared/SideBarEntry/SideBarItem.razor.css
+++ b/COMETwebapp/Shared/SideBarEntry/SideBarItem.razor.css
@@ -13,7 +13,7 @@
     transition: width 0.5s;
     white-space: nowrap;
     overflow: hidden;
-    height: 44px;
+    height: 36px;
     font-weight: 500;
 }
 

--- a/COMETwebapp/wwwroot/css/app.css
+++ b/COMETwebapp/wwwroot/css/app.css
@@ -239,16 +239,26 @@ div[id^="dropdown-customization-target-container-"] { display: flex; }
 }
 
 .collapsed .application-item-container {
-    width: 40px !important;
+    width: 32px !important;
     padding: 4px;
-    margin: 0 4px;
+    margin: 2px 0;
     justify-content: center;
 }
 
+.collapsed #side-bar-collapse-button {
+    padding: 4px !important;
+    min-width: 0 !important;
+}
+
 .collapsed .side-bar-section-header {
-    text-align: center;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    padding: 0 !important;
+    min-height: 0;
+}
+
+.collapsed .side-bar-section-divider {
+    align-self: stretch;
+    border-top: 1px solid var(--colors-gray-300);
+    margin: 6px 4px;
 }
 
 sub {

--- a/COMETwebapp/wwwroot/css/app.css
+++ b/COMETwebapp/wwwroot/css/app.css
@@ -79,8 +79,6 @@ html, body, #app {
 
 .m-right-3px { margin-right: 3px; }
 
-::deep .dx-blazor-widget .dx-chart { justify-content: center }
-
 .dxbs-fl .dxbs-fl-cpt { font-weight: normal; }
 
 .width-200 { width: 200px; }
@@ -165,8 +163,6 @@ html, body, #app {
 
 .width-30 { width: 30%; }
 
-.width-12.5 { width: 12.5%; }
-
 .centered {
     display: block !important;
     margin: 0 auto !important;
@@ -243,8 +239,16 @@ div[id^="dropdown-customization-target-container-"] { display: flex; }
 }
 
 .collapsed .application-item-container {
-    width: 70px !important;
-    padding: 22px;
+    width: 40px !important;
+    padding: 4px;
+    margin: 0 4px;
+    justify-content: center;
+}
+
+.collapsed .side-bar-section-header {
+    text-align: center;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
 }
 
 sub {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #806 Sidebar too wide in collapsed state

Narrows the collapsed sidebar to icon-only with small padding: collapsed items shrink and center their icon, the COMET logo is dropped on collapse, the nav padding is trimmed, and the "Model"/"General" section headers are centered in the narrow view.

<img width="175" height="940" alt="image" src="https://github.com/user-attachments/assets/dc092244-8a7f-492b-8432-2cd4912a767b" />
<img width="128" height="585" alt="image" src="https://github.com/user-attachments/assets/8d8cd658-0a07-4ed5-89fa-c0aeb948046e" />


