### PR TITLE
Fix #809 keep the collapsed details panel flush right and made column resizer possible to go wider

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           dotnet tool install --global dotnet-sonarscanner
           dotnet tool install --global dotnet-coverage
-          dotnet sonarscanner begin /k:"STARIONGROUP_COMET-WEB-Community-Edition" /o:"stariongroup" /d:sonar.token="$SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          dotnet sonarscanner begin /k:"STARIONGROUP_COMET-WEB-Community-Edition" /o:"stariongroup" /d:sonar.token="$SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.coverage.exclusions="**/wwwroot/**"
 
       - name: Build
         run: dotnet build --no-restore --no-incremental /p:ContinuousIntegrationBuild=true

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -61,6 +61,11 @@ namespace COMETwebapp.Tests.Components.ModelEditor
         private const string CollapsedPanelClass = "model-editor-panel-collapsed";
 
         /// <summary>
+        /// The css class that makes a panel grow to fill the space freed by a collapsed neighbour.
+        /// </summary>
+        private const string GrowPanelClass = "model-editor-panel-grow";
+
+        /// <summary>
         /// The bunit <see cref="BunitContext" /> used to render the component under test.
         /// </summary>
         private BunitContext context;
@@ -357,6 +362,33 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 Assert.That(renderedComponent.Find("#detailsPanel").ClassList, Does.Not.Contain(CollapsedPanelClass));
                 Assert.That(() => renderedComponent.Find("#expandDetailsPanel"), Throws.TypeOf<ElementNotFoundException>());
             });
+        }
+
+        /// <summary>
+        /// Verifies that a collapsed details panel makes the target tree grow to fill the freed space, so the collapsed
+        /// strip sticks to the right edge of the screen instead of leaving a gap next to the middle panel (issue GH809).
+        /// The grow class also overrides any fixed inline width the column resizer previously wrote on the panel.
+        /// </summary>
+        [Test]
+        public void VerifyCollapsedDetailsPanelGrowsTheTargetTree()
+        {
+            var renderedComponent = this.RenderModelEditor();
+
+            Assert.That(renderedComponent.Find("#targetPanel").ClassList, Does.Not.Contain(GrowPanelClass));
+
+            renderedComponent.Find("#collapseDetailsPanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+            {
+                Assert.That(renderedComponent.Instance.IsDetailsPanelCollapsed, Is.True);
+                Assert.That(renderedComponent.Find("#targetPanel").ClassList, Does.Contain(GrowPanelClass),
+                    "A collapsed details panel must let the target tree grow, so the collapsed strip stays flush with the screen edge.");
+            });
+
+            renderedComponent.Find("#expandDetailsPanel").Click();
+
+            renderedComponent.WaitForAssertion(() =>
+                Assert.That(renderedComponent.Find("#targetPanel").ClassList, Does.Not.Contain(GrowPanelClass)));
         }
 
         /// <summary>

--- a/COMETwebapp.Tests/Javascript/columnResizer.test.js
+++ b/COMETwebapp.Tests/Javascript/columnResizer.test.js
@@ -1,0 +1,150 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="columnResizer.test.js" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+// Unit tests for the pure width-clamp logic of columnResizer.js. Uses only Node's built-in test runner - no packages.
+// Run from the repository root:  node --test COMETwebapp.Tests/Javascript/columnResizer.test.js
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const cometResizer = require(path.join(__dirname, '..', '..', 'COMETwebapp', 'wwwroot', 'js', 'columnResizer.js'));
+
+// --- minimal fake DOM ------------------------------------------------------------------------------------------------
+// Only the members computeMaxWidth actually reads are modelled, so no jsdom (or any dependency) is needed.
+
+function makeChild(spec) {
+    return {
+        style: { maxWidth: spec.maxWidth || '' },
+        _style: {
+            flexGrow: String(spec.flexGrow || 0),
+            minWidth: (spec.minWidth || 0) + 'px',
+            paddingLeft: (spec.padLeft || 0) + 'px',
+            paddingRight: (spec.padRight || 0) + 'px',
+            borderLeftWidth: (spec.borderLeft || 0) + 'px',
+            borderRightWidth: (spec.borderRight || 0) + 'px'
+        },
+        _width: spec.width || 0,
+        _visible: spec.visible !== false,
+        getClientRects() { return this._visible ? [{}] : []; },
+        getBoundingClientRect() { return { width: this._width, left: 0 }; },
+        nextElementSibling: null
+    };
+}
+
+function makeRow(spec, children) {
+    for (let i = 0; i < children.length - 1; i++) {
+        children[i].nextElementSibling = children[i + 1];
+    }
+
+    return {
+        firstElementChild: children[0] || null,
+        clientWidth: spec.clientWidth,
+        _style: {
+            columnGap: (spec.gap || 0) + 'px',
+            paddingLeft: (spec.padLeft || 0) + 'px',
+            paddingRight: (spec.padRight || 0) + 'px'
+        }
+    };
+}
+
+const getStyle = node => node._style;
+
+function maxWidth(row, leftEl, maxPx) {
+    return cometResizer.computeMaxWidth(row, leftEl, maxPx, getStyle);
+}
+
+// --- tests -----------------------------------------------------------------------------------------------------------
+
+test('reserves every sibling, the column-gap and the padding so the row fits exactly (no overflow)', () => {
+    const source = makeChild({ flexGrow: 1, minWidth: 0, padLeft: 15, padRight: 15, borderLeft: 1, borderRight: 1 });
+    const sourceResizer = makeChild({ flexGrow: 0, width: 6 });
+    const target = makeChild({ flexGrow: 1, minWidth: 0, padLeft: 15, padRight: 15, borderLeft: 1, borderRight: 1 });
+    const targetResizer = makeChild({ flexGrow: 0, width: 6 });
+    const details = makeChild({ flexGrow: 1, minWidth: 350 });
+    const row = makeRow({ clientWidth: 1200, gap: 10 }, [source, sourceResizer, target, targetResizer, details]);
+
+    const max = maxWidth(row, target);
+
+    // reserve = source(32 padding+border) + sourceResizer(6) + targetResizer(6) + details(350) = 394; gaps = 4 * 10.
+    assert.equal(max, 766);
+    assert.equal(max + 394 + 4 * 10, row.clientWidth, 'the widened panel plus reservations must fill the row exactly');
+});
+
+test('discounts the column-gap (ignoring it overflowed the row by the total gap width)', () => {
+    const build = gap => {
+        const source = makeChild({ flexGrow: 1, minWidth: 0 });
+        const target = makeChild({ flexGrow: 1, minWidth: 0 });
+        const details = makeChild({ flexGrow: 1, minWidth: 350 });
+        return { row: makeRow({ clientWidth: 1000, gap }, [source, target, details]), target };
+    };
+
+    const withGap = build(10);
+    const noGap = build(0);
+
+    // three children => two gaps between them.
+    assert.equal(maxWidth(noGap.row, noGap.target) - maxWidth(withGap.row, withGap.target), 2 * 10);
+});
+
+test('a min-width:0 flex panel still reserves its own padding and border (box-sizing floor)', () => {
+    const target = makeChild({ flexGrow: 1, minWidth: 0 });
+    const sibling = makeChild({ flexGrow: 1, minWidth: 0, padLeft: 20, padRight: 20, borderLeft: 1, borderRight: 1 });
+    const row = makeRow({ clientWidth: 1000 }, [target, sibling]);
+
+    assert.equal(maxWidth(row, target), 1000 - 42, 'padding+border is reserved even though min-width is 0');
+});
+
+test('a panel already pinned to a fixed width reserves its current width, not its min-width', () => {
+    const target = makeChild({ flexGrow: 1, minWidth: 0 });
+    const pinned = makeChild({ flexGrow: 0, minWidth: 0, width: 500, maxWidth: '500px' });
+    const row = makeRow({ clientWidth: 1000 }, [target, pinned]);
+
+    assert.equal(maxWidth(row, target), 500);
+});
+
+test('a collapsed (display:none) sibling is skipped entirely - no reserve and no gap', () => {
+    const target = makeChild({ flexGrow: 1, minWidth: 0 });
+    const hidden = makeChild({ flexGrow: 1, minWidth: 350, visible: false });
+    const row = makeRow({ clientWidth: 1000, gap: 10 }, [target, hidden]);
+
+    assert.equal(maxWidth(row, target), 1000);
+});
+
+test('honours an explicit maxPx ceiling only when it is the smaller limit', () => {
+    const target = makeChild({ flexGrow: 1, minWidth: 0 });
+    const sibling = makeChild({ flexGrow: 1, minWidth: 100 });
+    const row = makeRow({ clientWidth: 1000 }, [target, sibling]);
+
+    assert.equal(maxWidth(row, target, 500), 500, 'the room would allow 900, the ceiling caps it at 500');
+    assert.equal(maxWidth(row, target, 5000), 900, 'a ceiling above the available room lets the room govern');
+});
+
+test('with no maxPx (omitted or 0) the only limit is the room left in the row', () => {
+    const target = makeChild({ flexGrow: 1, minWidth: 0 });
+    const sibling = makeChild({ flexGrow: 1, minWidth: 100 });
+    const row = makeRow({ clientWidth: 1000 }, [target, sibling]);
+
+    assert.equal(maxWidth(row, target, 0), 900);
+    assert.equal(maxWidth(row, target), 900);
+});

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -96,7 +96,7 @@
                 </div>
             }
             <div id="source-resizer" class="model-editor-resizer @(this.IsSourcePanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)" title="Drag to resize"></div>
-            <div id="targetPanel" class="model-editor-panel">
+              <div id="targetPanel" class="model-editor-panel @(this.IsDetailsPanelCollapsed ? "model-editor-panel-grow" : string.Empty)">
                 <ElementDefinitionTree
                     @ref="this.TargetTree"
                     ScrollableAreaCssClass="treeview-scrollarea"
@@ -124,7 +124,7 @@
                 </ElementDefinitionTree>
             </div>
             <div id="target-resizer" class="model-editor-resizer @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)" title="Drag to resize"></div>
-            <div id="detailsPanel" class="model-editor-panel model-editor-panel-borderless @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
+            <div id="detailsPanel" class="model-editor-panel model-editor-panel-borderless model-editor-details-panel @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
                 <div class="model-editor-panel-header model-editor-panel-header-end">
                     <DxButton Id="collapseDetailsPanel"
                               IconCssClass="oi oi-chevron-right"

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -52,13 +52,6 @@ namespace COMETwebapp.Components.ModelEditor
         private const int MinimumPanelWidth = 260;
 
         /// <summary>
-        /// The maximum width, in pixels, that a panel can be dragged up to. It is set high on purpose: the resizer itself
-        /// clamps the drag to the width available in the flex row, so the panels can be widened to (nearly) the full
-        /// screen without this constant capping them short (see issue #809).
-        /// </summary>
-        private const int MaximumPanelWidth = 100000;
-
-        /// <summary>
         /// Holds a reference to the data of the node where another node is dragged over
         /// </summary>
         private (ElementDefinitionTree, object) DragOverObject;
@@ -164,7 +157,7 @@ namespace COMETwebapp.Components.ModelEditor
         {
             try
             {
-                await this.JsRuntime.InvokeVoidAsync("cometResizer.init", resizerId, panelId, MinimumPanelWidth, MaximumPanelWidth);
+                await this.JsRuntime.InvokeVoidAsync("cometResizer.init", resizerId, panelId, MinimumPanelWidth);
             }
             catch (Exception)
             {

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -52,9 +52,11 @@ namespace COMETwebapp.Components.ModelEditor
         private const int MinimumPanelWidth = 260;
 
         /// <summary>
-        /// The maximum width, in pixels, that a panel can be dragged up to
+        /// The maximum width, in pixels, that a panel can be dragged up to. It is set high on purpose: the resizer itself
+        /// clamps the drag to the width available in the flex row, so the panels can be widened to (nearly) the full
+        /// screen without this constant capping them short (see issue #809).
         /// </summary>
-        private const int MaximumPanelWidth = 900;
+        private const int MaximumPanelWidth = 100000;
 
         /// <summary>
         /// Holds a reference to the data of the node where another node is dragged over

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
@@ -32,11 +32,9 @@
     vertical-align: middle;
 }
 
-/* The source tree, the target tree and the details panel are equal-share flex columns, so that
-   minimizing one of them hands its space to the ones that stay open (see issue #742). */
 .model-editor-panel {
     flex: 1 1 0;
-    min-width: 260px;
+    min-width: 0;
     min-height: 0;
     height: 100%;
     display: flex;
@@ -51,8 +49,15 @@
     padding: 0;
 }
 
-/* A minimized panel stays mounted (its ViewModel owns subscriptions that nothing would dispose on
-   unmount) and is only hidden, so its space goes to the panels that are still open. */
+.model-editor-details-panel {
+    min-width: 350px;
+}
+
+.model-editor-panel-grow {
+    flex: 1 1 0 !important;
+    max-width: none !important;
+}
+
 .model-editor-panel-collapsed {
     display: none;
 }

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
@@ -57,7 +57,7 @@ namespace COMETwebapp.Components.SystemRepresentation
             {
                 try
                 {
-                     await this.JsRuntime.InvokeVoidAsync("cometResizer.init", "col-resizer", "leftColumn", 260, 100000);
+                      await this.JsRuntime.InvokeVoidAsync("cometResizer.init", "col-resizer", "leftColumn", 260);
                 }
                 catch (Exception)
                 {

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.cs
@@ -57,7 +57,7 @@ namespace COMETwebapp.Components.SystemRepresentation
             {
                 try
                 {
-                    await this.JsRuntime.InvokeVoidAsync("cometResizer.init", "col-resizer", "leftColumn", 260, 640);
+                     await this.JsRuntime.InvokeVoidAsync("cometResizer.init", "col-resizer", "leftColumn", 260, 100000);
                 }
                 catch (Exception)
                 {

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
@@ -18,13 +18,9 @@
     overflow: hidden;
 }
 
-/* The right column is a fixed-height flex column: the action bar, element summary card and parameter
-   search bar stay put, and only the group/parameter area scrolls (mirrors the product tree, where only
-   the node list scrolls). ElementDetailsPanel / DetailsPanelEditor render inline (no wrapper element), so
-   their outputs are flat flex children of #rightColumn and can be targeted with ::deep. */
 #rightColumn {
     flex: 1 1 auto;
-    min-width: 380px;
+    min-width: 350px;
     position: sticky;
     top: 8px;
     align-self: flex-start;

--- a/COMETwebapp/wwwroot/js/columnResizer.js
+++ b/COMETwebapp/wwwroot/js/columnResizer.js
@@ -46,9 +46,40 @@ window.cometResizer = {
         resizerEl.addEventListener('mousedown', function (e) {
             e.preventDefault();
             document.body.style.userSelect = 'none';
+            
+            var row = leftEl.parentElement;
+            var rowStyle = window.getComputedStyle(row);
+            var reserve = 0;
+            var visibleCount = 0;
+
+            for (var child = row.firstElementChild; child; child = child.nextElementSibling) {
+                if (child.getClientRects().length === 0) {
+                    continue;                      
+                }
+
+                if (child !== leftEl) {
+                    var childStyle = window.getComputedStyle(child);
+                    var canShrink = parseFloat(childStyle.flexGrow) > 0 && child.style.maxWidth === '';
+
+                    if (canShrink) {
+                        var incompressible = (parseFloat(childStyle.paddingLeft) || 0) + (parseFloat(childStyle.paddingRight) || 0)
+                            + (parseFloat(childStyle.borderLeftWidth) || 0) + (parseFloat(childStyle.borderRightWidth) || 0);
+                        reserve += Math.max(parseFloat(childStyle.minWidth) || 0, incompressible);
+                    } else {
+                        reserve += child.getBoundingClientRect().width;
+                    }
+                }
+
+                visibleCount++;
+            }
+
+            var gap = parseFloat(rowStyle.columnGap) || 0;
+            var padding = (parseFloat(rowStyle.paddingLeft) || 0) + (parseFloat(rowStyle.paddingRight) || 0);
+            var available = row.clientWidth - padding - gap * Math.max(0, visibleCount - 1);
+            var effectiveMax = Math.min(maxPx, available - reserve);
 
             function onMouseMove(moveEvent) {
-                var w = Math.min(maxPx, Math.max(minPx, moveEvent.clientX - leftEl.getBoundingClientRect().left));
+                var w = Math.min(effectiveMax, Math.max(minPx, moveEvent.clientX - leftEl.getBoundingClientRect().left));
                 leftEl.style.flex = '0 0 ' + w + 'px';
                 leftEl.style.maxWidth = w + 'px';
             }

--- a/COMETwebapp/wwwroot/js/columnResizer.js
+++ b/COMETwebapp/wwwroot/js/columnResizer.js
@@ -20,51 +20,44 @@
 //  </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-window.cometResizer = {
-    /**
-     * Initialises a drag-to-resize handle between two flex columns.
-     * @param {string} resizerId - The id of the resizer element.
-     * @param {string} leftId    - The id of the left (resizable) column element.
-     * @param {number} minPx     - Minimum width in pixels.
-     * @param {number} maxPx     - Maximum width in pixels.
-     */
-    init: function (resizerId, leftId, minPx, maxPx) {
-        var resizerEl = document.getElementById(resizerId);
-        var leftEl = document.getElementById(leftId);
+(function () {
+    'use strict';
 
-        if (!resizerEl || !leftEl) {
-            return;
-        }
+    const cometResizer = {
+        /**
+         * Computes the maximum width, in pixels, that the resized column may take without pushing the flex row past its
+         * content box (which would add a horizontal scrollbar). Every other visible child is reserved at the smallest
+         * footprint it can occupy: a flexible panel yields down to its min-width but never below its own padding + border;
+         * a resizer, a collapsed-panel strip or a panel already pinned to a fixed width keeps its current width. The
+         * row's column-gap and horizontal padding are discounted as well. When maxPx is falsy the only limit is the room
+         * left in the row. Kept free of event wiring and DOM globals (the style accessor is injectable) so it is unit
+         * testable with node:test - see COMETwebapp.Tests/Javascript/columnResizer.test.js.
+         * @param {Element} row        - The flex row that holds the columns.
+         * @param {Element} leftEl     - The column being resized.
+         * @param {number} [maxPx]     - Optional upper ceiling in pixels; when falsy only the row's room limits the drag.
+         * @param {function} [getStyle] - Computed-style accessor; defaults to window.getComputedStyle.
+         * @returns {number} The maximum width, in pixels, for leftEl.
+         */
+        computeMaxWidth: function (row, leftEl, maxPx, getStyle) {
+            getStyle = getStyle || function (element) { return window.getComputedStyle(element); };
 
-        // Guard against double-init
-        if (resizerEl._cometResizerInitialised) {
-            return;
-        }
+            const rowStyle = getStyle(row);
+            let reserve = 0;
+            let visibleCount = 0;
 
-        resizerEl._cometResizerInitialised = true;
-
-        resizerEl.addEventListener('mousedown', function (e) {
-            e.preventDefault();
-            document.body.style.userSelect = 'none';
-            
-            var row = leftEl.parentElement;
-            var rowStyle = window.getComputedStyle(row);
-            var reserve = 0;
-            var visibleCount = 0;
-
-            for (var child = row.firstElementChild; child; child = child.nextElementSibling) {
+            for (let child = row.firstElementChild; child; child = child.nextElementSibling) {
                 if (child.getClientRects().length === 0) {
                     continue;                      
                 }
 
                 if (child !== leftEl) {
-                    var childStyle = window.getComputedStyle(child);
-                    var canShrink = parseFloat(childStyle.flexGrow) > 0 && child.style.maxWidth === '';
+                    const childStyle = getStyle(child);
+                    const canShrink = Number.parseFloat(childStyle.flexGrow) > 0 && child.style.maxWidth === '';
 
                     if (canShrink) {
-                        var incompressible = (parseFloat(childStyle.paddingLeft) || 0) + (parseFloat(childStyle.paddingRight) || 0)
-                            + (parseFloat(childStyle.borderLeftWidth) || 0) + (parseFloat(childStyle.borderRightWidth) || 0);
-                        reserve += Math.max(parseFloat(childStyle.minWidth) || 0, incompressible);
+                        const incompressible = (Number.parseFloat(childStyle.paddingLeft) || 0) + (Number.parseFloat(childStyle.paddingRight) || 0)
+                            + (Number.parseFloat(childStyle.borderLeftWidth) || 0) + (Number.parseFloat(childStyle.borderRightWidth) || 0);
+                        reserve += Math.max(Number.parseFloat(childStyle.minWidth) || 0, incompressible);
                     } else {
                         reserve += child.getBoundingClientRect().width;
                     }
@@ -73,25 +66,65 @@ window.cometResizer = {
                 visibleCount++;
             }
 
-            var gap = parseFloat(rowStyle.columnGap) || 0;
-            var padding = (parseFloat(rowStyle.paddingLeft) || 0) + (parseFloat(rowStyle.paddingRight) || 0);
-            var available = row.clientWidth - padding - gap * Math.max(0, visibleCount - 1);
-            var effectiveMax = Math.min(maxPx, available - reserve);
+            const gap = Number.parseFloat(rowStyle.columnGap) || 0;
+            const padding = (Number.parseFloat(rowStyle.paddingLeft) || 0) + (Number.parseFloat(rowStyle.paddingRight) || 0);
+            const available = row.clientWidth - padding - gap * Math.max(0, visibleCount - 1);
 
-            function onMouseMove(moveEvent) {
-                var w = Math.min(effectiveMax, Math.max(minPx, moveEvent.clientX - leftEl.getBoundingClientRect().left));
-                leftEl.style.flex = '0 0 ' + w + 'px';
-                leftEl.style.maxWidth = w + 'px';
+            return maxPx ? Math.min(maxPx, available - reserve) : available - reserve;
+        },
+
+        /**
+         * Initialises a drag-to-resize handle between two flex columns.
+         * @param {string} resizerId - The id of the resizer element.
+         * @param {string} leftId    - The id of the left (resizable) column element.
+         * @param {number} minPx     - Minimum width in pixels.
+         * @param {number} [maxPx]   - Optional maximum width in pixels. When omitted (or 0), the only limit is the room
+         *                             left in the flex row, so the panel can be widened up to (nearly) the full row.
+         */
+        init: function (resizerId, leftId, minPx, maxPx) {
+            const resizerEl = document.getElementById(resizerId);
+            const leftEl = document.getElementById(leftId);
+
+            if (!resizerEl || !leftEl) {
+                return;
             }
 
-            function onMouseUp() {
-                document.removeEventListener('mousemove', onMouseMove);
-                document.removeEventListener('mouseup', onMouseUp);
-                document.body.style.userSelect = '';
+            // Guard against double-init
+            if (resizerEl._cometResizerInitialised) {
+                return;
             }
 
-            document.addEventListener('mousemove', onMouseMove);
-            document.addEventListener('mouseup', onMouseUp);
-        });
+            resizerEl._cometResizerInitialised = true;
+
+            resizerEl.addEventListener('mousedown', function (e) {
+                e.preventDefault();
+                document.body.style.userSelect = 'none';
+
+                const effectiveMax = cometResizer.computeMaxWidth(leftEl.parentElement, leftEl, maxPx);
+
+                function onMouseMove(moveEvent) {
+                    const w = Math.min(effectiveMax, Math.max(minPx, moveEvent.clientX - leftEl.getBoundingClientRect().left));
+                    leftEl.style.flex = '0 0 ' + w + 'px';
+                    leftEl.style.maxWidth = w + 'px';
+                }
+
+                function onMouseUp() {
+                    document.removeEventListener('mousemove', onMouseMove);
+                    document.removeEventListener('mouseup', onMouseUp);
+                    document.body.style.userSelect = '';
+                }
+
+                document.addEventListener('mousemove', onMouseMove);
+                document.addEventListener('mouseup', onMouseUp);
+            });
+        }
+    };
+
+    if (typeof window !== 'undefined') {
+        window.cometResizer = cometResizer;
     }
-};
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = cometResizer;     
+    }
+})();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #809 

- Collapsed details panel sticks to the right edge. When the details panel is collapsed after dragging the column resizers, the target tree now grows to fill the freed space, so the expand strip stays flush with the screen edge instead of leaving a gap next to the middle panel.
- Resize to (near) full width without a horizontal scrollbar. The resizer max is no longer a fixed 900px cap; the drag is clamped to the room actually left in the row once every other element is at its minimum footprint (min-width or padding/border, plus column-gap and row padding), so widening one panel reclaims space from the others like collapsing does, and never spills the row into a scrollbar.
- Details panels floored at one parameter-group wide (Model Editor + System Representation), so the card content can't be squeezed narrower than it can reflow. System Representation's tree column can now be dragged much wider than the old 640px cap.

