### PR TITLE
fix #805 System representation clean up, shared searchbar and blocked circular references

### DIFF
--- a/COMET.Web.Common.Tests/Components/SearchBarTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/SearchBarTestFixture.cs
@@ -1,0 +1,80 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SearchBarTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components
+{
+    using Bunit;
+
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.Test.Helpers;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SearchBarTestFixture
+    {
+        private BunitContext context;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifySearchBar()
+        {
+            var captured = string.Empty;
+
+            var renderer = this.context.Render<SearchBar>(parameters => parameters
+                .Add(p => p.Placeholder, "Find things...")
+                .Add(p => p.CssClass, "extra-class")
+                .Add(p => p.Text, "initial")
+                .Add(p => p.TextChanged, EventCallback.Factory.Create<string>(this, value => captured = value)));
+
+            var textBox = renderer.FindComponent<DxTextBox>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(textBox.Instance.NullText, Is.EqualTo("Find things..."));
+                Assert.That(textBox.Instance.CssClass, Does.Contain("inline-search-icon"));
+                Assert.That(textBox.Instance.CssClass, Does.Contain("extra-class"));
+                Assert.That(textBox.Instance.Text, Is.EqualTo("initial"));
+            });
+
+            await renderer.InvokeAsync(() => textBox.Instance.TextChanged.InvokeAsync("hello"));
+
+            Assert.That(captured, Is.EqualTo("hello"));
+        }
+    }
+}

--- a/COMET.Web.Common/Components/CardView/CardView.razor
+++ b/COMET.Web.Common/Components/CardView/CardView.razor
@@ -22,12 +22,11 @@
 @typeparam T
 @inherits DisposableComponent
 
-<p>
+<div>
     <table>
         <tr>
             <td id="search-textbox" style="visibility:@(this.AllowSearch ? "block": "hidden");">
-                <DxTextBox CssClass="inline-search-icon" SizeMode="SizeMode.Medium" BindValueMode="BindValueMode.OnDelayedInput" InputDelay="500" TextChanged="this.OnSearchTextChanged" NullText="Search..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto">
-                </DxTextBox>
+                <SearchBar TextChanged="this.OnSearchTextChanged"/>
             </td>
             <td id="sort-dropdown" style="visibility:@(this.AllowSort ? "block": "hidden");">
                 <DxComboBox TData="string" TValue="string" CssClass="inline-sort-icon" FilteringMode="DataGridFilteringMode.Contains" SizeMode="SizeMode.Medium" Data="@this.SortFields" SelectedItemChanged="@( x => this.OnSelectedSortItemChanged(x))"
@@ -36,7 +35,7 @@
             </td>
         </tr>
     </table>
-</p>
+</div>
 <div class="container @this.ScrollableAreaCssClass" style="overflow:auto;max-width: inherit !important;">
     <div class="row">
         <Virtualize ItemSize="@this.ItemSize" ItemsProvider="this.LoadItemsAsync" @ref="this.virtualize">

--- a/COMET.Web.Common/Components/SearchBar.razor
+++ b/COMET.Web.Common/Components/SearchBar.razor
@@ -1,0 +1,31 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components
+
+<div class="search-bar">
+    <DxTextBox CssClass="@this.EffectiveCssClass"
+               SizeMode="SizeMode.Medium"
+               Text="@this.Text"
+               TextChanged="@this.OnTextChangedAsync"
+               BindValueMode="@this.BindValueMode"
+               InputDelay="@this.InputDelay"
+               NullText="@this.Placeholder"
+               ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"/>
+</div>

--- a/COMET.Web.Common/Components/SearchBar.razor
+++ b/COMET.Web.Common/Components/SearchBar.razor
@@ -20,12 +20,13 @@
 @namespace COMET.Web.Common.Components
 
 <div class="search-bar">
-    <DxTextBox CssClass="@this.EffectiveCssClass"
-               SizeMode="SizeMode.Medium"
-               Text="@this.Text"
-               TextChanged="@this.OnTextChangedAsync"
-               BindValueMode="@this.BindValueMode"
-               InputDelay="@this.InputDelay"
-               NullText="@this.Placeholder"
-               ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"/>
+    <DxTextBox 
+        CssClass="@this.EffectiveCssClass" 
+        SizeMode="SizeMode.Medium" 
+        Text="@this.Text" 
+        TextChanged="@this.OnTextChangedAsync"
+        BindValueMode="@this.BindValueMode" 
+        InputDelay="@this.InputDelay" 
+        NullText="@this.Placeholder" 
+        ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"/>
 </div>

--- a/COMET.Web.Common/Components/SearchBar.razor.cs
+++ b/COMET.Web.Common/Components/SearchBar.razor.cs
@@ -1,0 +1,91 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SearchBar.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components
+{
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// A reusable search text box with a leading magnifying-glass icon. Gives every search field across the
+    /// application the same appearance and behaviour; supports two-way binding through <c>@bind-Text</c>.
+    /// </summary>
+    public partial class SearchBar
+    {
+        /// <summary>
+        /// The current search text. Supports two-way binding via <c>@bind-Text</c>.
+        /// </summary>
+        [Parameter]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Invoked when <see cref="Text" /> changes, enabling <c>@bind-Text</c>.
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> TextChanged { get; set; }
+
+        /// <summary>
+        /// The placeholder shown when the box is empty.
+        /// </summary>
+        [Parameter]
+        public string Placeholder { get; set; } = "Search...";
+
+        /// <summary>
+        /// When the bound value is pushed back: on every keystroke or after a typing pause. Defaults to
+        /// <see cref="DevExpress.Blazor.BindValueMode.OnDelayedInput" />.
+        /// </summary>
+        [Parameter]
+        public BindValueMode BindValueMode { get; set; } = BindValueMode.OnDelayedInput;
+
+        /// <summary>
+        /// The debounce, in milliseconds, applied when <see cref="BindValueMode" /> is
+        /// <see cref="DevExpress.Blazor.BindValueMode.OnDelayedInput" />.
+        /// </summary>
+        [Parameter]
+        public int InputDelay { get; set; } = 500;
+
+        /// <summary>
+        /// Additional CSS classes appended to the search box.
+        /// </summary>
+        [Parameter]
+        public string CssClass { get; set; }
+
+        /// <summary>
+        /// Gets the CSS class applied to the underlying text box: the shared inline-search-icon styling plus
+        /// any caller-supplied <see cref="CssClass" />.
+        /// </summary>
+        private string EffectiveCssClass => string.IsNullOrWhiteSpace(this.CssClass) ? "inline-search-icon" : $"inline-search-icon {this.CssClass}";
+
+        /// <summary>
+        /// Propagates a text change from the underlying text box to the bound value.
+        /// </summary>
+        /// <param name="value">The new search text.</param>
+        /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+        private async Task OnTextChangedAsync(string value)
+        {
+            this.Text = value;
+            await this.TextChanged.InvokeAsync(value);
+        }
+    }
+}

--- a/COMET.Web.Common/Components/SearchBar.razor.css
+++ b/COMET.Web.Common/Components/SearchBar.razor.css
@@ -1,0 +1,7 @@
+.search-bar {
+    width: 100%;
+}
+
+.search-bar ::deep .inline-search-icon {
+    width: 100%;
+}

--- a/COMETwebapp.Tests/Components/Common/ParameterGroupSectionTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Common/ParameterGroupSectionTestFixture.cs
@@ -210,5 +210,34 @@ namespace COMETwebapp.Tests.Components.Common
                 Assert.That(markup, Does.Contain("Temperature"), "Matching parameter must still render.");
             });
         }
+
+        [Test]
+        public void VerifySearchFilterMatchesOwner()
+        {
+            var owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            var group = new ParameterGroup { Iid = Guid.NewGuid(), Name = "Thermal" };
+
+            var parameter = BuildParameter(owner, "Temperature", "T");
+            parameter.Group = group;
+
+            var row = new ElementDefinitionDetailsRowViewModel(parameter, owner);
+
+            // The term matches neither the parameter type name ("Temperature") nor its short name ("T"),
+            // only the owner short name ("SYS") — the row must still be kept.
+            var rendered = this.context.Render<ParameterGroupSection>(parameters => parameters
+                .Add(p => p.Group, group)
+                .Add(p => p.AllRows, new List<ElementDefinitionDetailsRowViewModel> { row })
+                .Add(p => p.AllGroups, new List<ParameterGroup> { group })
+                .Add(p => p.SearchTerm, "sys")
+                .Add(p => p.Level, 0));
+
+            var markup = rendered.Markup;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(markup, Does.Contain("group-card"), "Group must render when the search term matches the parameter owner.");
+                Assert.That(markup, Does.Contain("Temperature"), "The owner-matched parameter must still render.");
+            });
+        }
     }
 }

--- a/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
@@ -36,12 +36,14 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
 
     using CDP4Web.Enumerations;
 
+    using COMET.Web.Common.Components;
     using COMET.Web.Common.Components.Selectors;
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
 
+    using COMETwebapp.Components.Common;
     using COMETwebapp.Components.SystemRepresentation;
     using COMETwebapp.Utilities;
     using COMETwebapp.ViewModels.Components.Common;
@@ -206,6 +208,12 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
                 }
             };
 
+            elementDefinition.Category.Add(new Category(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                Name = "Structure",
+                ShortName = "STR"
+            });
+
             this.iteration.Element.Add(elementDefinition);
             this.iteration.TopElement = this.iteration.Element[0];
 
@@ -297,6 +305,56 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
                 Assert.That(this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows.First().ActualValue, Is.Not.Null);
                 Assert.That(this.viewModel.DetailsPanelViewModel.ElementDefinitionDetailsViewModel.Rows.First().SwitchValue, Is.Not.Null);
             });
+        }
+
+        [Test]
+        public async Task VerifyDetailsActionBarAndTreeNodePillsRender()
+        {
+            var renderer = this.context.Render<SystemRepresentationBody>(parameters => parameters.Add(p => p.CurrentThing, this.iteration));
+
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            this.viewModel.DetailsPanelViewModel.CurrentDomain = this.domain;
+
+            // Selecting an option builds and draws the product tree, rendering SystemNode's owner and category pills.
+            await renderer.InvokeAsync(() => this.viewModel.OptionSelector.SelectedOption = this.iteration.DefaultOption);
+
+            var panel = renderer.FindComponent<ElementDetailsPanel>();
+
+            // Selecting an ElementDefinition renders the details action bar (search box + the three add buttons).
+            await renderer.InvokeAsync(() => this.viewModel.DetailsPanelViewModel.SelectElement(this.iteration.Element[0]));
+
+            // In the app the panel re-renders from its SelectedElement subscription; force it here so the
+            // SelectedElementDefinition-gated action bar is reflected in the markup.
+            panel.Render();
+
+            renderer.WaitForAssertion(() =>
+            {
+                Assert.That(this.viewModel.DetailsPanelViewModel.SelectedElementDefinition, Is.Not.Null, "Selecting an ElementDefinition must set SelectedElementDefinition.");
+                Assert.That(renderer.Markup, Does.Contain("Parameter Group"), "The renamed add-parameter-group button must render.");
+                Assert.That(renderer.Markup, Does.Contain("Element Definition"), "The renamed add-element-definition button must render.");
+                Assert.That(renderer.Markup, Does.Contain("STR"), "The tree node's category pill must render.");
+            });
+
+            // Drive the details-panel search box to cover the SearchTerm binding and the owner-aware parameter filter.
+            var detailsSearch = renderer.FindComponents<SearchBar>()
+                .First(searchBar => searchBar.Instance.Placeholder != null && searchBar.Instance.Placeholder.Contains("parameters"));
+
+            await renderer.InvokeAsync(() => detailsSearch.Instance.TextChanged.InvokeAsync("SYS"));
+
+            Assert.That(detailsSearch.Instance, Is.Not.Null);
+
+            // Simulate a drag hovering over the root node so its drop-impact badge renders.
+            var treeViewModel = this.viewModel.ProductTreeViewModel;
+            var rootNode = treeViewModel.RootViewModel;
+            var childNode = rootNode.GetChildren().First();
+            treeViewModel.DraggedNode = childNode;
+            treeViewModel.DragOverNode = rootNode;
+
+            var rootSystemNode = renderer.FindComponents<SystemNode>().First(node => ReferenceEquals(node.Instance.ViewModel, rootNode));
+            rootSystemNode.Render();
+
+            renderer.WaitForAssertion(() => Assert.That(renderer.Markup, Does.Contain("drop-impact-badge"), "The drop-impact badge must render on a valid drop target during a drag."));
         }
 
         [Test]

--- a/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
@@ -336,6 +336,9 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
                 Assert.That(renderer.Markup, Does.Contain("STR"), "The tree node's category pill must render.");
             });
 
+            // Toggle the tree's View display-options dropdown to cover its click handler.
+            renderer.Find("#systemTreeViewMenuButton").Click();
+
             // Drive the details-panel search box to cover the SearchTerm binding and the owner-aware parameter filter.
             var detailsSearch = renderer.FindComponents<SearchBar>()
                 .First(searchBar => searchBar.Instance.Placeholder != null && searchBar.Instance.Placeholder.Contains("parameters"));

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
@@ -105,6 +105,23 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 
             Assert.That(SystemRepresentationTreeViewModel.CanDrop(freshRootNode, rootUsageNode), Is.False,
                 "Dropping an element definition onto a separate usage of the same definition must be rejected to avoid a self-containment cycle.");
+
+            // A node whose Thing is not an ElementBase → false, on either side.
+            var nonElementNode = new SystemNodeViewModel(rootDefinition);
+            nonElementNode.SetThing(new Option { Iid = Guid.NewGuid(), Name = "Option", ShortName = "OPT" });
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(nonElementNode, rootNode), Is.False,
+                "A dragged node whose Thing is not an ElementBase must be rejected.");
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(rootNode, nonElementNode), Is.False,
+                "A target node whose Thing is not an ElementBase must be rejected.");
+
+            // A target usage with no ElementDefinition resolves to a null definition → false.
+            var danglingUsage = new ElementUsage { Iid = Guid.NewGuid(), Name = "Dangling", ShortName = "DU", Owner = domain };
+            var danglingNode = new SystemNodeViewModel(danglingUsage);
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(unrelatedNode, danglingNode), Is.False,
+                "Dropping onto a usage node with no ElementDefinition must be rejected.");
         }
 
         /// <summary>

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
@@ -98,6 +98,13 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
             // Child node dropped onto the root (inverted — valid, no cycle) → true
             Assert.That(SystemRepresentationTreeViewModel.CanDrop(childNode, rootNode), Is.True,
                 "Dropping a child node back onto the root is a valid operation.");
+            
+            var rootUsage = new ElementUsage { Iid = Guid.NewGuid(), Name = "RootUsage", ShortName = "RU", Owner = domain, ElementDefinition = rootDefinition };
+            var rootUsageNode = new SystemNodeViewModel(rootUsage);
+            var freshRootNode = new SystemNodeViewModel(rootDefinition);
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(freshRootNode, rootUsageNode), Is.False,
+                "Dropping an element definition onto a separate usage of the same definition must be rejected to avoid a self-containment cycle.");
         }
 
         /// <summary>

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor
@@ -22,17 +22,21 @@
 @using COMETwebapp.Components.ModelEditor
 @inherits DisposableComponent
 
-<div id="panel-action-bar" class="mb-2 d-flex flex-wrap justify-content-end" style="gap:8px;">
+<div id="panel-action-bar" class="mb-2 d-flex flex-wrap align-items-center justify-content-end" style="gap:8px;">
     @if (this.ViewModel.SelectedElementDefinition is not null)
     {
-        <DxButton Id="addParameter" Text="Add Parameter" IconCssClass="oi oi-plus" Click="@(this.ViewModel.OpenAddParameterPopup)"/>
-        <DxButton Id="addParameterGroup" Text="Add Parameter Group" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateParameterGroupPopup"/>
+        <div style="flex:1 1 200px; min-width:0;">
+            <SearchBar @bind-Text="@this.SearchTerm" Placeholder="Search parameters or owner…"/>
+        </div>
+        <DxButton Id="addParameter" Text="Parameter" IconCssClass="oi oi-plus" Click="@(this.ViewModel.OpenAddParameterPopup)"/>
+        <DxButton Id="addParameterGroup" Text="Parameter Group" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateParameterGroupPopup"/>
     }
 
-    <DxButton Id="addElementDefinition" Text="Add Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
+    <DxButton Id="addElementDefinition" Text="Element Definition" IconCssClass="oi oi-plus" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
 </div>
 
 <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"
+                    SearchTerm="@this.SearchTerm"
                     OnEditParameter="@(parameter => this.ViewModel.OpenEditParameterPopup(parameter))"
                     OnDeleteParameter="@(parameter => this.ViewModel.OpenDeleteParameterPopup(parameter))"
                     OnCreateSubscription="@(parameter => this.ViewModel.OpenCreateSubscriptionPopup(parameter))"

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
@@ -45,7 +45,7 @@ namespace COMETwebapp.Components.Common
 
         /// <summary>
         /// Gets or sets the current search term used to filter the parameter cards rendered by the
-        /// <see cref="DetailsPanelEditor" />. Held here so the search box can share the action-bar row.
+        /// <see cref="COMETwebapp.Components.ModelEditor.DetailsPanelEditor" />. Held here so the search box can share the action-bar row.
         /// </summary>
         private string SearchTerm { get; set; }
 

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
@@ -44,6 +44,12 @@ namespace COMETwebapp.Components.Common
         public IElementDetailsPanelViewModel ViewModel { get; set; }
 
         /// <summary>
+        /// Gets or sets the current search term used to filter the parameter cards rendered by the
+        /// <see cref="DetailsPanelEditor" />. Held here so the search box can share the action-bar row.
+        /// </summary>
+        private string SearchTerm { get; set; }
+
+        /// <summary>
         /// Method invoked when the component is ready to start, having received its initial parameters
         /// from its parent in the render tree. Subscribes to the three mode flags that control popup
         /// visibility so the component re-renders when they change.

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.css
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.css
@@ -1,4 +1,3 @@
-/* ── Sticky action bar (Add Parameter / Add Parameter Group / Add Element Definition buttons) ── */
 #panel-action-bar {
     position: sticky;
     top: 0;

--- a/COMETwebapp/Components/Common/ParameterGroupSection.razor.cs
+++ b/COMETwebapp/Components/Common/ParameterGroupSection.razor.cs
@@ -292,7 +292,8 @@ namespace COMETwebapp.Components.Common
         {
             return !this.IsSearchActive
                    || row.ParameterTypeName.Contains(this.SearchTerm, StringComparison.OrdinalIgnoreCase)
-                   || row.ShortName.Contains(this.SearchTerm, StringComparison.OrdinalIgnoreCase);
+                   || row.ShortName.Contains(this.SearchTerm, StringComparison.OrdinalIgnoreCase)
+                   || (row.Owner?.Contains(this.SearchTerm, StringComparison.OrdinalIgnoreCase) ?? false);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -103,15 +103,6 @@
         }
     </div>
 
-    @* ── Search toolbar ── *@
-    <div class="param-group-search-bar mb-2">
-        <span class="oi oi-magnifying-glass param-group-search-icon" aria-hidden="true"></span>
-        <DxTextBox @bind-Text="@this.SearchTerm"
-                   BindValueMode="BindValueMode.OnInput"
-                   NullText="Search parameters…"
-                   CssClass="param-group-search-input"/>
-    </div>
-
     @* ── Collapsible grouped parameter sections ── *@
     <div class="param-groups-container" @ref="this.groupsContainer">
         @foreach (var group in this.TopLevelGroups)

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
@@ -39,8 +39,8 @@ namespace COMETwebapp.Components.ModelEditor
     ///     (which recursively renders nested sub-groups) followed by a trailing "Ungrouped" section.
     ///     Parameters can be dragged from a card and dropped onto a section header to reassign group
     ///     membership. Parameter groups can be dragged by their header and dropped onto another section to
-    ///     nest them, or onto the Ungrouped section to move them to the top level. A search box at the top
-    ///     filters cards by parameter type name or short name.
+    ///     nest them, or onto the Ungrouped section to move them to the top level. The <see cref="SearchTerm" />
+    ///     supplied by the parent filters cards by parameter type name, short name or owner.
     /// </summary>
     public partial class DetailsPanelEditor : IAsyncDisposable
     {
@@ -179,23 +179,12 @@ namespace COMETwebapp.Components.ModelEditor
         private IJSRuntime JsRuntime { get; set; }
 
         /// <summary>
-        ///     Backing field for <see cref="SearchTerm" />.
+        ///     Gets or sets the current search term used to filter parameter cards. Supplied by the parent
+        ///     (<see cref="Components.Common.ElementDetailsPanel" />), which renders the search box in its
+        ///     action-bar row.
         /// </summary>
-        private string searchTerm;
-
-        /// <summary>
-        ///     Gets or sets the current search term used to filter parameter cards. Setting this property
-        ///     triggers a component re-render via <see cref="Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged" />.
-        /// </summary>
-        private string SearchTerm
-        {
-            get => this.searchTerm;
-            set
-            {
-                this.searchTerm = value;
-                this.StateHasChanged();
-            }
-        }
+        [Parameter]
+        public string SearchTerm { get; set; }
 
         /// <summary>
         ///     The row whose card is currently being dragged, or <c>null</c> when no drag is in progress.

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.css
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.css
@@ -7,23 +7,3 @@
     gap: 12px;
 }
 
-/* ── Search toolbar ── */
-.param-group-search-bar {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-    background: #f8f9fa;
-    border: 1px solid #dee2e6;
-    border-radius: 6px;
-}
-
-.param-group-search-icon {
-    color: #6c757d;
-    flex-shrink: 0;
-}
-
-.param-group-search-input {
-    flex: 1;
-    min-width: 0;
-}

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
@@ -39,8 +39,7 @@ else
 }
 </div>
 <div id="search-textbox" style="visibility:@(this.AllowSearch ? "visible" : "hidden");">
-    <DxTextBox CssClass="inline-search-icon" SizeMode="SizeMode.Medium" BindValueMode="BindValueMode.OnDelayedInput" InputDelay="500" @bind-Text="this.SearchTerm" NullText="Search..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto">
-    </DxTextBox>
+    <SearchBar @bind-Text="this.SearchTerm"/>
 </div>
 <div class="drop-area-color @(this.dragOverNode == this.TreeView && this.AllowNodeDrop && this.AllowDrop ? "treeview-drag-over" : "")"
      dropzone="@(this.AllowDrop ? "move" : "")"

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -35,11 +35,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                       CssClass="req-collapse-toggle" />
 
             <div class="req-search">
-                <DxTextBox @bind-Text="@this.ViewModel.SearchText"
-                           BindValueMode="BindValueMode.OnDelayedInput"
-                           ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-                           NullText="Search in definitions..."
-                           CssClass="req-search-input" />
+                <SearchBar @bind-Text="@this.ViewModel.SearchText" Placeholder="Search in definitions..."/>
             </div>
 
             <DxTagBox Data="@this.ViewModel.AvailableOwners"

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -39,10 +39,6 @@
     max-width: 420px;
 }
 
-.req-search ::deep .req-search-input {
-    width: 100%;
-}
-
 .req-view-menu {
     display: flex;
     flex-direction: column;

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
@@ -90,25 +90,27 @@ along with this program. If not, see http://www.gnu.org/licenses/.
                 <div class="node-label-tags">
                     <p class="node-text">@label</p>
 
-                    @if (elementBase is not null)
-                    {
-                        @if (this.TreeViewModel?.ShowOwner != false && elementBase.Owner != null)
+                    <span class="node-pills">
+                        @if (elementBase is not null)
                         {
-                            <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{elementBase.Owner.ShortName}") !important;" title="Owning Domain Of Expertise: @elementBase.Owner.ShortName">@elementBase.Owner.ShortName</button>
-                        }
-
-                        @if (this.TreeViewModel?.ShowCategories != false)
-                        {
-                            @foreach (var category in elementBase.GetDisplayCategories())
+                            @if (this.TreeViewModel?.ShowOwner != false && elementBase.Owner != null)
                             {
-                                <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.ShortName">@category.ShortName</button>
+                                <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{elementBase.Owner.ShortName}") !important;" title="Owning Domain Of Expertise: @elementBase.Owner.ShortName">@elementBase.Owner.ShortName</button>
+                            }
+
+                            @if (this.TreeViewModel?.ShowCategories != false)
+                            {
+                                @foreach (var category in elementBase.GetDisplayCategories())
+                                {
+                                    <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.ShortName">@category.ShortName</button>
+                                }
                             }
                         }
-                    }
-                    @if (this.IsValidDropTarget)
-                    {
-                        <span class="drop-impact-badge" title="This usage and everything it brings">+@this.DraggedItemImpactCount</span>
-                    }
+                        @if (this.IsValidDropTarget)
+                        {
+                            <span class="drop-impact-badge" title="This usage and everything it brings">+@this.DraggedItemImpactCount</span>
+                        }
+                    </span>
                 </div>
             </div>
         </div>

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
@@ -102,7 +102,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
                             {
                                 @foreach (var category in elementBase.GetDisplayCategories())
                                 {
-                                    <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.ShortName">@category.ShortName</button>
+                                    <button @key="category.Iid" class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.ShortName">@category.ShortName</button>
                                 }
                             }
                         }

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
@@ -4,6 +4,8 @@
     justify-content: flex-start;
     align-items: flex-start;
     flex-wrap: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
     padding: 3px 4px;
     padding-left: 0;
     border-radius: 8px;
@@ -46,15 +48,30 @@
 
 .node-text {
     margin: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .node-label-tags {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
-    gap: 4px;
+    justify-content: space-between;
+    gap: 8px;
     flex: 1 1 auto;
     min-width: 0;
+}
+
+.node-pills {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    margin-left: auto;
+    flex-shrink: 0;
 }
 
 .expandIcon {

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
@@ -31,8 +31,7 @@
 }
 
 #rightColumn ::deep #panel-action-bar,
-#rightColumn ::deep .cardview-detailspanel-summary,
-#rightColumn ::deep .param-group-search-bar {
+#rightColumn ::deep .cardview-detailspanel-summary {
     flex: 0 0 auto;
 }
 
@@ -45,6 +44,10 @@
 #option-filter {
     flex: 0 0 auto;
     margin-bottom: 8px;
+}
+
+#option-filter ::deep h6 {
+    display: none;
 }
 
 #col-resizer {

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor
@@ -20,17 +20,32 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 @inherits DisposableComponent
 
 <div id="product-tree-container">
-    <h4 id="product-tree-title">Product Tree</h4>
-
     <div id="product-tree-top-section">
-        <div class="product-tree-display-options">
-            <DxCheckBox @bind-Checked="@this.ViewModel.ShowName">Name</DxCheckBox>
-            <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner">Owner</DxCheckBox>
-            <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories">Categories</DxCheckBox>
-        </div>
         <div id="product-tree-search-bar">
-            <DxTextBox NullText="Search..." @bind-Text="@this.ViewModel.SearchText" BindValueMode="BindValueMode.OnInput" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"></DxTextBox>
+            <SearchBar @bind-Text="@this.ViewModel.SearchText"/>
         </div>
+
+        <DxButton Id="systemTreeViewMenuButton"
+                  RenderStyle="ButtonRenderStyle.Light"
+                  IconCssClass="oi oi-cog"
+                  Text="View"
+                  title="Display options"
+                  Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
+
+        <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
+                    PositionMode="DropDownPositionMode.Bottom"
+                    PositionTarget="#systemTreeViewMenuButton"
+                    CloseMode="DropDownCloseMode.Close"
+                    HeaderVisible="false"
+                    FooterVisible="false">
+            <BodyTemplate>
+                <div class="product-tree-view-menu">
+                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
+                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
+                </div>
+            </BodyTemplate>
+        </DxDropDown>
     </div>
 
     <div id="product-tree-nodes-section">

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
@@ -41,6 +41,11 @@ namespace COMETwebapp.Components.SystemRepresentation
         public SystemRepresentationTreeViewModel ViewModel { get; set; }
 
         /// <summary>
+        /// Whether the "View" display-options dropdown is open.
+        /// </summary>
+        private bool viewMenuOpen;
+
+        /// <summary>
         /// Method invoked when the component is ready to start, having received its
         /// initial parameters from its parent in the render tree.
         /// </summary>

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.css
@@ -1,11 +1,3 @@
-#product-tree-title {
-    background: #eaecee;
-    padding: 10px 12px;
-    border-radius: 8px 8px 0 0;
-    flex: 0 0 auto;
-    margin: 0;
-}
-
 #product-tree-container {
     margin: 0;
     padding: 0;
@@ -17,22 +9,24 @@
 
 #product-tree-top-section {
     display: flex;
-    flex-direction: column;
-    margin: 12px;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 8px 0;
     flex: 0 0 auto;
 }
 
-.product-tree-display-options {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 8px;
-    font-size: 0.875rem;
-    margin-bottom: 8px;
+#product-tree-search-bar {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
-#product-tree-search-bar {
-    margin-top: 8px;
+.product-tree-view-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    min-width: 180px;
 }
 
 #product-tree-nodes-section {

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
@@ -169,7 +169,7 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
                 return false;
             }
 
-            var toDefinition = to.Thing as ElementDefinition ?? (to.Thing as ElementUsage)?.ElementDefinition;
+            var toDefinition = GetElementDefinition(to);
 
             if (toDefinition is null)
             {
@@ -177,8 +177,21 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
             }
 
             return from.GetFlatListOfDescendants(true)
-                .Select(node => node.Thing as ElementDefinition ?? (node.Thing as ElementUsage)?.ElementDefinition)
+                .Select(GetElementDefinition)
                 .All(definition => definition != toDefinition);
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="ElementDefinition" /> represented by <paramref name="node" />: its
+        /// <see cref="COMETwebapp.ViewModels.Components.Shared.BaseNodeViewModel{T}.Thing" /> when that is an
+        /// <see cref="ElementDefinition" />, the referenced <see cref="ElementUsage.ElementDefinition" /> when it
+        /// is an <see cref="ElementUsage" />, or <see langword="null" /> otherwise.
+        /// </summary>
+        /// <param name="node">The node whose <see cref="ElementDefinition" /> to resolve.</param>
+        /// <returns>The resolved <see cref="ElementDefinition" />, or <see langword="null" />.</returns>
+        private static ElementDefinition GetElementDefinition(SystemNodeViewModel node)
+        {
+            return node.Thing as ElementDefinition ?? (node.Thing as ElementUsage)?.ElementDefinition;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
@@ -146,9 +146,13 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         /// <summary>
         /// Determines whether <paramref name="from" /> may be dropped onto <paramref name="to" />.
         /// The drop is rejected when either argument is <see langword="null" />, the two nodes are
-        /// the same instance, <paramref name="to" /> is a descendant of <paramref name="from" />
-        /// (which would create a cycle), or either node's <see cref="COMETwebapp.ViewModels.Components.Shared.BaseNodeViewModel{T}.Thing" />
-        /// is not an <see cref="ElementBase" />.
+        /// the same instance, either node's <see cref="COMETwebapp.ViewModels.Components.Shared.BaseNodeViewModel{T}.Thing" />
+        /// is not an <see cref="ElementBase" />, or it would introduce a containment cycle. A drop creates a new
+        /// <see cref="ElementUsage" /> of <paramref name="from" />'s <see cref="ElementDefinition" /> inside
+        /// <paramref name="to" />'s <see cref="ElementDefinition" />, so the comparison is made by
+        /// <see cref="ElementDefinition" /> (not by tree-node instance): the drop is refused when the target's
+        /// definition is the dragged definition itself or is already (transitively) contained by it. This also
+        /// catches dropping a definition onto a separate node that represents that same definition.
         /// </summary>
         /// <param name="from">The node being dragged.</param>
         /// <param name="to">The node being dropped onto.</param>
@@ -160,12 +164,21 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
                 return false;
             }
 
-            if (from.GetFlatListOfDescendants(true).Contains(to))
+            if (from.Thing is not ElementBase || to.Thing is not ElementBase)
             {
                 return false;
             }
 
-            return from.Thing is ElementBase && to.Thing is ElementBase;
+            var toDefinition = to.Thing as ElementDefinition ?? (to.Thing as ElementUsage)?.ElementDefinition;
+
+            if (toDefinition is null)
+            {
+                return false;
+            }
+
+            return from.GetFlatListOfDescendants(true)
+                .Select(node => node.Thing as ElementDefinition ?? (node.Thing as ElementUsage)?.ElementDefinition)
+                .All(definition => definition != toDefinition);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
## Fix #805 — System Representation cleanup + shared SearchBar

Removes the redundant "Product Tree" label (#805) and reworks the System Representation page to match the Requirements Editor's compact style, cutting the number of visible buttons and toggles. Also hardens product-tree drag-and-drop against circular references, and unifies every search field in the app behind one reusable component.

### System Representation
- Removed the redundant **"Product Tree"** heading and the **"Filter on Option:"** label (hidden on this page only; the shared `OptionSelector` is untouched).
- Display toggles (Name/Owner/Categories) moved behind a compact **"View" cog dropdown** (Requirements Editor pattern); the "Name" toggle is now **"Full name"**.
- Product-tree **pills now right-align**, and the search/View row is full-width and aligned with the option dropdown, with reduced padding.
- **Circular references blocked:** `CanDrop` now compares by `ElementDefinition` rather than tree-node instance, so dropping a definition onto a separate node representing the same definition (which created a self-containment cycle the server then rejected) is prevented in the UI.

### Details panel (shared by System Representation + Model Editor)
- Dropped the word "Add" from the three buttons → **Parameter / Parameter Group / Element Definition** (the `+` icon still signals add).
- Parameter **search box moved onto the same row as those buttons**, and it now also matches the parameter **owner**.

### Reusable SearchBar (new)
- New shared **`SearchBar`** component in `COMET.Web.Common` wrapping a `DxTextBox` with the `inline-search-icon` look and standard defaults; two-way bindable via `@bind-Text`, full-width in its container.
- Every search field now uses it: System Representation tree, the shared details-panel parameter search, the Requirements Editor, the Model Editor tree, and `CardView`. No raw `inline-search-icon` text boxes remain; dead per-page search CSS removed.

<img width="1916" height="950" alt="image" src="https://github.com/user-attachments/assets/ee90f9c8-3c1e-4856-9bb0-5ea806f9ec3e" />


