### PR TITLE
Fix #824 App crashed: Completed the Disposables ownership chain so every subscription is released when its owner is disposed

### DIFF
--- a/COMETwebapp.Tests/Components/Viewer/PropertiesPanel/PropertiesComponentTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Viewer/PropertiesPanel/PropertiesComponentTestFixture.cs
@@ -106,6 +106,28 @@ namespace COMETwebapp.Tests.Components.Viewer.PropertiesPanel
             });
         }
 
+        /// <summary>
+        /// Verifies that disposing the view model unsubscribes from the <see cref="ISelectionMediator" /> events, so a
+        /// long-lived (circuit-scoped) mediator no longer keeps the disposed view model alive nor fires its callbacks.
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesFromSelectionMediator()
+        {
+            var mediator = new Mock<ISelectionMediator>();
+            var babylon = new Mock<IBabylonInterop>();
+            var session = new Mock<ISessionService>();
+
+            var vm = new PropertiesComponentViewModel(babylon.Object, session.Object, mediator.Object, this.messageBus)
+            {
+                IsVisible = false
+            };
+
+            vm.Dispose();
+            mediator.Raise(x => x.OnModelSelectionChanged += null, new SceneObject(new Cube(1, 1, 1)));
+
+            Assert.That(vm.IsVisible, Is.False);
+        }
+
         [Test]
         public void VerifyElementValueChanges()
         {

--- a/COMETwebapp.Tests/ViewModels/Components/Common/ElementDetailsPanelViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/ElementDetailsPanelViewModelTestFixture.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
     using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.SessionManagement;
@@ -220,6 +221,26 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
         {
             this.messageBus.ClearSubscriptions();
             this.viewModel.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that disposing the panel cascades disposal to its child edit view models, so the
+        /// <see cref="IDomainOfExpertiseSelectorViewModel" /> subscriptions they hold on the circuit-scoped
+        /// message bus do not accumulate every time the panel is (re)created (see GH824).
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesChildViewModelsFromMessageBus()
+        {
+            var domainSelector = this.viewModel.AddParameterViewModel.DomainOfExpertiseSelectorViewModel;
+            domainSelector.CurrentIteration = this.iteration;
+
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, this.foreignDomain));
+            Assert.That(domainSelector.CurrentIterationDomain, Is.EqualTo(this.foreignDomain), "The selector should react while subscribed.");
+
+            this.viewModel.Dispose();
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, this.currentDomain));
+
+            Assert.That(domainSelector.CurrentIterationDomain, Is.EqualTo(this.foreignDomain), "After disposal the selector must no longer react to bus events.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/EngineeringModel/FileStore/FileHandlerViewModelTestFixture.cs
@@ -27,6 +27,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using COMET.Web.Common.Services.SessionManagement;
 
@@ -121,6 +122,29 @@ namespace COMETwebapp.Tests.ViewModels.Components.EngineeringModel.FileStore
         {
             this.viewModel.Dispose();
             this.messageBus.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that disposing the view model disposes its <see cref="DomainOfExpertiseSelectorViewModel" /> — even
+        /// though this view model is <c>ApplicationBaseViewModel</c>-derived, its constructor opts out of the tab-move
+        /// dispose gate (it is a nested content view model, never a tab), so a plain <c>Dispose()</c> releases the
+        /// selector's circuit-scoped message-bus subscription instead of leaking it (see GH824).
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesDomainSelectorFromMessageBus()
+        {
+            var domainA = new DomainOfExpertise { Iid = Guid.NewGuid() };
+            var domainB = new DomainOfExpertise { Iid = Guid.NewGuid() };
+
+            this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIteration = this.iteration;
+
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, domainA));
+            Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIterationDomain, Is.EqualTo(domainA), "The selector should react while subscribed.");
+
+            this.viewModel.Dispose();
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, domainB));
+
+            Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIterationDomain, Is.EqualTo(domainA), "After disposal the selector must no longer react to bus events.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/BatchParameterEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/BatchParameterEditorViewModelTestFixture.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
     using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
@@ -166,6 +167,28 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         {
             this.viewModel.Dispose();
             this.messageBus.ClearSubscriptions();
+        }
+
+        /// <summary>
+        /// Verifies that disposing the view model disposes its <see cref="DomainOfExpertiseSelectorViewModel" />, so the
+        /// selector's subscription on the circuit-scoped message bus does not accumulate every time the view model is
+        /// (re)created (see GH824).
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesDomainSelectorFromMessageBus()
+        {
+            var domainA = new DomainOfExpertise { Iid = Guid.NewGuid() };
+            var domainB = new DomainOfExpertise { Iid = Guid.NewGuid() };
+
+            this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIteration = this.iteration;
+
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, domainA));
+            Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIterationDomain, Is.EqualTo(domainA), "The selector should react while subscribed.");
+
+            this.viewModel.Dispose();
+            this.messageBus.SendMessage(new DomainChangedEvent(this.iteration, domainB));
+
+            Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.CurrentIterationDomain, Is.EqualTo(domainA), "After disposal the selector must no longer react to bus events.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/Viewer/CanvasViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Viewer/CanvasViewModelTestFixture.cs
@@ -282,6 +282,33 @@ namespace COMETwebapp.Tests.ViewModels.Components.Viewer
         }
 
         /// <summary>
+        /// Verifies that disposing the view model unsubscribes from the <see cref="ISelectionMediator" /> events, so a
+        /// long-lived (circuit-scoped) mediator no longer keeps the disposed view model alive nor fires its callbacks.
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesFromSelectionMediator()
+        {
+            var original = new SceneObject(new Cube(1, 1, 1));
+            var clone = original.Clone();
+            this.selectionMediator.SetupGet(x => x.SelectedSceneObject).Returns(original);
+            this.selectionMediator.SetupGet(x => x.SelectedSceneObjectClone).Returns(clone);
+            this.selectionMediator.SetupGet(x => x.SceneObjectHasChanges).Returns(true);
+
+            this.viewModel.InitializeViewModel();
+            this.viewModel.Dispose();
+
+            var nodeViewModel = new ViewerNodeViewModel(original)
+            {
+                IsSelected = true,
+                IsSceneObjectVisible = true
+            };
+
+            this.selectionMediator.Raise(x => x.OnTreeSelectionChanged += null, nodeViewModel);
+
+            Assert.That(this.viewModel.GetAllTemporarySceneObjects(), Is.Empty);
+        }
+
+        /// <summary>
         /// Verifies the HandleMouseUp method.
         /// </summary>
         [Test]

--- a/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerProductTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerProductTreeViewModelTestFixture.cs
@@ -182,6 +182,30 @@ namespace COMETwebapp.Tests.ViewModels.Components.Viewer
         }
 
         /// <summary>
+        /// Verifies that disposing the view model unsubscribes from the <see cref="ISelectionMediator" /> events, so a
+        /// long-lived (circuit-scoped) mediator no longer keeps the disposed view model alive.
+        /// </summary>
+        [Test]
+        public void VerifyDisposeUnsubscribesFromSelectionMediator()
+        {
+            this.selectionMediator.SetupGet(m => m.SelectedSceneObject).Returns(this.node2.SceneObject);
+            var propertyChanged = false;
+
+            this.node2.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(this.node2.SceneObject))
+                {
+                    propertyChanged = true;
+                }
+            };
+
+            this.viewModel.Dispose();
+            this.selectionMediator.Raise(m => m.OnParameterSubmitted += null);
+
+            Assert.That(propertyChanged, Is.False);
+        }
+
+        /// <summary>
         /// Verifies the OnSearchFilterChange method.
         /// </summary>
         [Test]

--- a/COMETwebapp/Components/Viewer/ActualFiniteStateSelector.razor
+++ b/COMETwebapp/Components/Viewer/ActualFiniteStateSelector.razor
@@ -19,6 +19,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 
+@inherits DisposableComponent
+
 @{
     <div class="actual-finite-state-list">
         <p>@(((ActualFiniteStateList)this.ViewModel.ActualFiniteStates.First().Container).Name)</p>

--- a/COMETwebapp/Components/Viewer/ActualFiniteStateSelector.razor.cs
+++ b/COMETwebapp/Components/Viewer/ActualFiniteStateSelector.razor.cs
@@ -40,15 +40,24 @@ namespace COMETwebapp.Components.Viewer
         public IActualFiniteStateSelectorViewModel ViewModel { get; set; }
 
         /// <summary>
+        /// The subscription to the selected finite state, retained so it can be disposed and replaced when the parameters change
+        /// </summary>
+        private IDisposable selectedFiniteStateSubscription;
+
+        /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
         /// </summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            
-            this.WhenAnyValue(x => x.ViewModel.SelectedFiniteState)
+
+            this.selectedFiniteStateSubscription?.Dispose();
+
+            this.selectedFiniteStateSubscription = this.WhenAnyValue(x => x.ViewModel.SelectedFiniteState)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged));
+
+            this.Disposables.Add(this.selectedFiniteStateSubscription);
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
@@ -295,6 +295,13 @@ namespace COMETwebapp.ViewModels.Components.Common
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteParameterGroupCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedParameterGroupAsync)
             };
+
+            this.Disposables.Add((IDisposable)this.ElementDefinitionCreationViewModel);
+            this.Disposables.Add((IDisposable)this.AddParameterViewModel);
+            this.Disposables.Add((IDisposable)this.EditParameterViewModel);
+            this.Disposables.Add((IDisposable)this.EditParameterSubscriptionViewModel);
+            this.Disposables.Add((IDisposable)this.EditElementDefinitionViewModel);
+            this.Disposables.Add((IDisposable)this.EditElementUsageViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/CommonFileStore/CommonFileStoreTableViewModel.cs
@@ -60,6 +60,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.CommonFileStore
             {
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.CurrentThing.Owner = selectedOwner; })
             };
+
+            // This is a nested content view model, not a tabbed application, so it is never moved between panels; opt out of the ApplicationBaseViewModel tab-move dispose gate so it actually disposes (and releases its DomainOfExpertiseSelectorViewModel subscription) when its host unmounts.
+            this.IsAllowedToDispose = true;
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/DomainFileStore/DomainFileStoreTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/DomainFileStore/DomainFileStoreTableViewModel.cs
@@ -60,6 +60,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.DomainFileStore
             {
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.CurrentThing.Owner = selectedOwner; })
             };
+
+            // This is a nested content view model, not a tabbed application, so it is never moved between panels; opt out of the ApplicationBaseViewModel tab-move dispose gate so it actually disposes (and releases its DomainOfExpertiseSelectorViewModel subscription) when its host unmounts.
+            this.IsAllowedToDispose = true;
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/FileHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FileHandler/FileHandlerViewModel.cs
@@ -67,6 +67,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FileHandl
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.CurrentThing.Owner = selectedOwner; })
             };
 
+            // This is a nested content view model, not a tabbed application, so it is never moved between panels; opt out of the ApplicationBaseViewModel tab-move dispose gate so it actually disposes (and releases its DomainOfExpertiseSelectorViewModel subscription) when its host unmounts.
+            this.IsAllowedToDispose = true;
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
+
             this.InitializeSubscriptions([typeof(FileStore)]);
         }
 

--- a/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/FolderHandlerViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/EngineeringModel/FileStore/FolderHandler/FolderHandlerViewModel.cs
@@ -53,6 +53,10 @@ namespace COMETwebapp.ViewModels.Components.EngineeringModel.FileStore.FolderHan
                 OnSelectedDomainOfExpertiseChange = new EventCallbackFactory().Create<DomainOfExpertise>(this, selectedOwner => { this.CurrentThing.Owner = selectedOwner; })
             };
 
+            // This is a nested content view model, not a tabbed application, so it is never moved between panels; opt out of the ApplicationBaseViewModel tab-move dispose gate so it actually disposes (and releases its DomainOfExpertiseSelectorViewModel subscription) when its host unmounts.
+            this.IsAllowedToDispose = true;
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
+
             this.InitializeSubscriptions([typeof(FileStore)]);
         }
 

--- a/COMETwebapp/ViewModels/Components/ModelEditor/AddParameterViewModel/AddParameterViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/AddParameterViewModel/AddParameterViewModel.cs
@@ -61,6 +61,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.AddParameterViewModel
                 OnSelectedDomainOfExpertiseChange = callbackFactory.Create<DomainOfExpertise>(this, selectedOwner => { this.Parameter.Owner = selectedOwner; })
             };
 
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
+
             this.MeasurementScaleSelectorViewModel = new MeasurementScaleSelectorViewModel(sessionService)
             {
                 OnSelectedMeasurementScaleChange = callbackFactory.Create<MeasurementScale>(this, selectedScale => { this.Parameter.Scale = selectedScale; })

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
@@ -35,6 +35,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
 
     using Microsoft.AspNetCore.Components;
 
+    using ReactiveUI;
+
     /// <summary>
     /// View model driving the edit-Element-Definition popup. Holds a working clone of the target
     /// <see cref="ElementDefinition" /> so the form can mutate state without leaking changes back into
@@ -50,6 +52,21 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         /// <see cref="DefinedThing.Definition" /> categories.
         /// </summary>
         private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Backing field for the <see cref="SelectedCategories" /> property
+        /// </summary>
+        private IEnumerable<Category> selectedCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for the <see cref="IsTopElement" /> property
+        /// </summary>
+        private bool isTopElement;
+
+        /// <summary>
+        /// Backing field for the <see cref="OnValidSubmit" /> property
+        /// </summary>
+        private EventCallback onValidSubmit;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EditElementDefinitionViewModel" /> class.
@@ -91,7 +108,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         /// <summary>
         /// Gets or sets the categories selected by the user on the form.
         /// </summary>
-        public IEnumerable<Category> SelectedCategories { get; set; } = new List<Category>();
+        public IEnumerable<Category> SelectedCategories
+        {
+            get => this.selectedCategories;
+            set => this.RaiseAndSetIfChanged(ref this.selectedCategories, value);
+        }
 
         /// <summary>
         /// Gets the categories permitted on an <see cref="ElementDefinition" /> across all open
@@ -105,7 +126,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         /// promoted to <see cref="Iteration.TopElement" /> on save. Initialized to the iteration's current
         /// top-element identity.
         /// </summary>
-        public bool IsTopElement { get; set; }
+        public bool IsTopElement
+        {
+            get => this.isTopElement;
+            set => this.RaiseAndSetIfChanged(ref this.isTopElement, value);
+        }
 
         /// <summary>
         /// Gets the selector view model used by the form to pick the owning
@@ -117,7 +142,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         /// Gets or sets the callback invoked by the form when the user submits a valid edit. Wired by the
         /// owning <see cref="ModelEditorViewModel" /> to the actual save handler.
         /// </summary>
-        public EventCallback OnValidSubmit { get; set; }
+        public EventCallback OnValidSubmit
+        {
+            get => this.onValidSubmit;
+            set => this.RaiseAndSetIfChanged(ref this.onValidSubmit, value);
+        }
 
         /// <summary>
         /// Initializes the view model with a clone of the <see cref="ElementDefinition" /> to edit and the

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
 
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using Microsoft.AspNetCore.Components;
@@ -42,7 +43,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
     /// through the open <see cref="ISession" />; it is cloned at submit time when a
     /// <see cref="Iteration.TopElement" /> change must be persisted.
     /// </summary>
-    public class EditElementDefinitionViewModel : IEditElementDefinitionViewModel
+    public class EditElementDefinitionViewModel : DisposableObject, IEditElementDefinitionViewModel
     {
         /// <summary>
         /// The <see cref="ISessionService" /> queried for the available
@@ -69,6 +70,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
                     }
                 })
             };
+
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using Microsoft.AspNetCore.Components;
@@ -37,7 +38,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
     /// <see cref="ElementUsage" /> so the form can mutate state without leaking changes back into the
     /// cached domain graph until the surrounding commit succeeds.
     /// </summary>
-    public class EditElementUsageViewModel : IEditElementUsageViewModel
+    public class EditElementUsageViewModel : DisposableObject, IEditElementUsageViewModel
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EditElementUsageViewModel" /> class.
@@ -56,6 +57,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
                     }
                 })
             };
+
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementUsageViewModel/EditElementUsageViewModel.cs
@@ -33,6 +33,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
 
     using Microsoft.AspNetCore.Components;
 
+    using ReactiveUI;
+
     /// <summary>
     /// View model driving the edit-Element-Usage popup. Holds a working clone of the target
     /// <see cref="ElementUsage" /> so the form can mutate state without leaking changes back into the
@@ -75,11 +77,20 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
         public IReadOnlyList<Option> AvailableOptions { get; private set; } = [];
 
         /// <summary>
+        /// Backing field for the <see cref="SelectedOptions" /> property
+        /// </summary>
+        private IEnumerable<Option> selectedOptions = [];
+
+        /// <summary>
         /// Gets or sets the <see cref="Option" />s the element usage is included in (the complement of
         /// <see cref="ElementUsage.ExcludeOption" />). Updated by the multi-select in the form and applied
         /// back to the clone before the save is committed.
         /// </summary>
-        public IEnumerable<Option> SelectedOptions { get; set; } = [];
+        public IEnumerable<Option> SelectedOptions
+        {
+            get => this.selectedOptions;
+            set => this.RaiseAndSetIfChanged(ref this.selectedOptions, value);
+        }
 
         /// <summary>
         /// Gets the selector view model used by the form to pick the owning
@@ -88,10 +99,19 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementUsageViewMode
         public IDomainOfExpertiseSelectorViewModel DomainOfExpertiseSelectorViewModel { get; }
 
         /// <summary>
+        /// Backing field for the <see cref="OnValidSubmit" /> property
+        /// </summary>
+        private EventCallback onValidSubmit;
+
+        /// <summary>
         /// Gets or sets the callback invoked by the form when the user submits a valid edit. Wired by the
         /// owning <see cref="ModelEditorViewModel" /> to the actual save handler.
         /// </summary>
-        public EventCallback OnValidSubmit { get; set; }
+        public EventCallback OnValidSubmit
+        {
+            get => this.onValidSubmit;
+            set => this.RaiseAndSetIfChanged(ref this.onValidSubmit, value);
+        }
 
         /// <summary>
         /// Initializes the view model with the supplied clone of the <see cref="ElementUsage" /> and

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditParameterViewModel/EditParameterViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditParameterViewModel/EditParameterViewModel.cs
@@ -128,6 +128,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditParameterViewModel
                 })
             };
 
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
+
             this.MeasurementScaleSelectorViewModel = new MeasurementScaleSelectorViewModel(sessionService)
             {
                 OnSelectedMeasurementScaleChange = callbackFactory.Create<MeasurementScale>(this, selectedScale =>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionCreationViewModel/ElementDefinitionCreationViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionCreationViewModel/ElementDefinitionCreationViewModel.cs
@@ -36,6 +36,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
 
     using Microsoft.AspNetCore.Components;
 
+    using ReactiveUI;
+
     /// <summary>
     /// View model for the <see cref="ElementDefinitionCreation" /> component
     /// </summary>
@@ -45,6 +47,31 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
         /// The <see cref="ISessionService" />
         /// </summary>
         private readonly ISessionService sessionService;
+
+        /// <summary>
+        /// Backing field for the <see cref="AvailableCategories" /> property
+        /// </summary>
+        private IEnumerable<Category> availableCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for the <see cref="SelectedCategories" /> property
+        /// </summary>
+        private IEnumerable<Category> selectedCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for the <see cref="OnValidSubmit" /> property
+        /// </summary>
+        private EventCallback onValidSubmit;
+
+        /// <summary>
+        /// Backing field for the <see cref="IsTopElement" /> property
+        /// </summary>
+        private bool isTopElement;
+
+        /// <summary>
+        /// Backing field for the <see cref="ElementDefinition" /> property
+        /// </summary>
+        private ElementDefinition elementDefinition = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ElementDefinitionCreationViewModel" /> class.
@@ -69,7 +96,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
         /// <summary>
         /// A collection of available <see cref="Category" />s
         /// </summary>
-        public IEnumerable<Category> AvailableCategories { get; set; } = new List<Category>();
+        public IEnumerable<Category> AvailableCategories
+        {
+            get => this.availableCategories;
+            set => this.RaiseAndSetIfChanged(ref this.availableCategories, value);
+        }
 
         /// <summary>
         /// Gets the <see cref="IDomainOfExpertiseSelectorViewModel" />
@@ -79,22 +110,38 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
         /// <summary>
         /// Selected <see cref="Category" />
         /// </summary>
-        public IEnumerable<Category> SelectedCategories { get; set; } = new List<Category>();
+        public IEnumerable<Category> SelectedCategories
+        {
+            get => this.selectedCategories;
+            set => this.RaiseAndSetIfChanged(ref this.selectedCategories, value);
+        }
 
         /// <summary>
         /// An <see cref="EventCallback" /> to invoke on form submit
         /// </summary>
-        public EventCallback OnValidSubmit { get; set; }
+        public EventCallback OnValidSubmit
+        {
+            get => this.onValidSubmit;
+            set => this.RaiseAndSetIfChanged(ref this.onValidSubmit, value);
+        }
 
         /// <summary>
         /// Value indicating if the <see cref="ElementDefinition" /> is top element
         /// </summary>
-        public bool IsTopElement { get; set; }
+        public bool IsTopElement
+        {
+            get => this.isTopElement;
+            set => this.RaiseAndSetIfChanged(ref this.isTopElement, value);
+        }
 
         /// <summary>
         /// The <see cref="ElementDefinition" /> to create or edit
         /// </summary>
-        public ElementDefinition ElementDefinition { get; set; } = new();
+        public ElementDefinition ElementDefinition
+        {
+            get => this.elementDefinition;
+            set => this.RaiseAndSetIfChanged(ref this.elementDefinition, value);
+        }
 
         /// <summary>
         /// Initializes the current view model

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionCreationViewModel/ElementDefinitionCreationViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ElementDefinitionCreationViewModel/ElementDefinitionCreationViewModel.cs
@@ -29,6 +29,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using COMETwebapp.Components.ModelEditor;
@@ -38,7 +39,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
     /// <summary>
     /// View model for the <see cref="ElementDefinitionCreation" /> component
     /// </summary>
-    public class ElementDefinitionCreationViewModel : IElementDefinitionCreationViewModel
+    public class ElementDefinitionCreationViewModel : DisposableObject, IElementDefinitionCreationViewModel
     {
         /// <summary>
         /// The <see cref="ISessionService" />
@@ -61,6 +62,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreatio
                     ElementDefinition.Owner = selectedOwner;
                 })
             };
+
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -89,6 +89,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
             this.sessionService = sessionService;
             this.cacheService = cacheService;
             this.DetailsPanelViewModel = detailsPanelViewModel;
+            this.Disposables.Add((IDisposable)this.DetailsPanelViewModel);
 
             var eventCallbackFactory = new EventCallbackFactory();
 

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditorViewModel.cs
@@ -93,6 +93,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor.BatchParameterEditor
                 CurrentIteration = this.CurrentIteration
             };
 
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
+
             this.ConfirmCancelPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 OnCancel = eventCallbackFactory.Create(this, this.OnCancelPopup),

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
@@ -37,6 +37,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
     using Microsoft.AspNetCore.Components;
 
+    using ReactiveUI;
+
     /// <summary>
     /// Reusable view model that drives the create/edit dialog for a <see cref="Requirement" />, a
     /// <see cref="RequirementsGroup" /> or a <see cref="RequirementsSpecification" />. It holds a working clone (edit) or
@@ -55,6 +57,11 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// is shown and edited there.
         /// </summary>
         private string selectedLanguageCode = "en";
+
+        /// <summary>
+        /// Backing field for the <see cref="OnValidSubmit" /> property
+        /// </summary>
+        private EventCallback onValidSubmit;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EditRequirementThingViewModel" /> class.
@@ -217,7 +224,11 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// <summary>
         /// Gets or sets the callback invoked when the user submits a valid edit.
         /// </summary>
-        public EventCallback OnValidSubmit { get; set; }
+        public EventCallback OnValidSubmit
+        {
+            get => this.onValidSubmit;
+            set => this.RaiseAndSetIfChanged(ref this.onValidSubmit, value);
+        }
 
         /// <summary>
         /// Initializes the form for the given <paramref name="thing" />.

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using COMETwebapp.Utilities;
@@ -42,7 +43,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
     /// a fresh instance (create) of the target so the form can mutate short name, name, owner, categories, definitions and
     /// deprecation without leaking into the cached domain graph until the surrounding commit succeeds.
     /// </summary>
-    public class EditRequirementThingViewModel : IEditRequirementThingViewModel
+    public class EditRequirementThingViewModel : DisposableObject, IEditRequirementThingViewModel
     {
         /// <summary>
         /// The <see cref="ISessionService" /> queried for the available categories.
@@ -74,6 +75,8 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
                     }
                 })
             };
+
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -1179,10 +1179,17 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// </summary>
         private void EnsureEditViewModel()
         {
-            this.EditViewModel ??= new EditRequirementThingViewModel(this.SessionService, this.MessageBus)
+            if (this.EditViewModel is not null)
+            {
+                return;
+            }
+
+            this.EditViewModel = new EditRequirementThingViewModel(this.SessionService, this.MessageBus)
             {
                 OnValidSubmit = new EventCallbackFactory().Create(this, this.OnEditValidSubmitAsync)
             };
+
+            this.Disposables.Add((IDisposable)this.EditViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
@@ -63,6 +63,10 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
                     this.CurrentThing.DefaultDomain = selectedOwner;
                 })
             };
+
+            // This is a nested content view model, not a tabbed application, so it is never moved between panels; opt out of the ApplicationBaseViewModel tab-move dispose gate so it actually disposes (and releases its DomainOfExpertiseSelectorViewModel subscription) when its host unmounts.
+            this.IsAllowedToDispose = true;
+            this.Disposables.Add(this.DomainOfExpertiseSelectorViewModel);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
@@ -62,6 +62,7 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         {
             this.logger = logger;
             this.DetailsPanelViewModel = detailsPanelViewModel;
+            this.Disposables.Add((IDisposable)this.DetailsPanelViewModel);
             this.DetailsPanelViewModel.AutoAddCreatedDefinitionAsUsage = true;
 
             this.ProductTreeViewModel = new SystemRepresentationTreeViewModel

--- a/COMETwebapp/ViewModels/Components/Viewer/CanvasViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/CanvasViewModel.cs
@@ -94,6 +94,26 @@ namespace COMETwebapp.ViewModels.Components.Viewer
         private readonly Subject<Unit> parameterChangedSubject = new();
 
         /// <summary>
+        /// Handler registered on <see cref="ISelectionMediator.OnTreeSelectionChanged" />, retained so it can be unsubscribed on disposal
+        /// </summary>
+        private Action<ViewerNodeViewModel> onTreeSelectionChangedHandler;
+
+        /// <summary>
+        /// Handler registered on <see cref="ISelectionMediator.OnTreeVisibilityChanged" />, retained so it can be unsubscribed on disposal
+        /// </summary>
+        private Action<ViewerNodeViewModel> onTreeVisibilityChangedHandler;
+
+        /// <summary>
+        /// Handler registered on <see cref="ISelectionMediator.OnParameterChanged" />, retained so it can be unsubscribed on disposal
+        /// </summary>
+        private Action onParameterChangedHandler;
+
+        /// <summary>
+        /// Handler registered on <see cref="ISelectionMediator.OnParameterSubmitted" />, retained so it can be unsubscribed on disposal
+        /// </summary>
+        private Action onParameterSubmittedHandler;
+
+        /// <summary>
         /// Gets or sets if the user is about to change the selected primitive
         /// </summary>
         public bool IsOnChangePrimitiveMode
@@ -131,14 +151,38 @@ namespace COMETwebapp.ViewModels.Components.Viewer
         public void InitializeViewModel()
         {
             this.SelectionMediator.SceneObjectHasChanges = false;
-            this.SelectionMediator.OnTreeSelectionChanged += async (nodeViewModel) => await this.OnTreeSelectionChanged(nodeViewModel);
-            this.SelectionMediator.OnTreeVisibilityChanged += async (nodeViewModel) => await this.OnTreeVisibilityChanged(nodeViewModel);
-            this.SelectionMediator.OnParameterChanged += () => this.parameterChangedSubject.OnNext(Unit.Default);
-            this.SelectionMediator.OnParameterSubmitted += async () => await this.OnParameterSubmitted();
 
-            this.parameterChangedSubject
+            this.onTreeSelectionChangedHandler = async nodeViewModel => await this.OnTreeSelectionChanged(nodeViewModel);
+            this.onTreeVisibilityChangedHandler = async nodeViewModel => await this.OnTreeVisibilityChanged(nodeViewModel);
+            this.onParameterChangedHandler = () => this.parameterChangedSubject.OnNext(Unit.Default);
+            this.onParameterSubmittedHandler = async () => await this.OnParameterSubmitted();
+
+            this.SelectionMediator.OnTreeSelectionChanged += this.onTreeSelectionChangedHandler;
+            this.SelectionMediator.OnTreeVisibilityChanged += this.onTreeVisibilityChangedHandler;
+            this.SelectionMediator.OnParameterChanged += this.onParameterChangedHandler;
+            this.SelectionMediator.OnParameterSubmitted += this.onParameterSubmittedHandler;
+
+            this.Disposables.Add(this.parameterChangedSubject
                 .Throttle(TimeSpan.FromMilliseconds(50))
-                .SubscribeAsync(async _ => await this.OnParameterChanged());
+                .SubscribeAsync(async _ => await this.OnParameterChanged()));
+        }
+
+        /// <summary>
+        /// Unsubscribes from the <see cref="ISelectionMediator" /> events and releases the resources used by this view model
+        /// </summary>
+        /// <param name="disposing">Value asserting if this component should dispose or not</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.SelectionMediator.OnTreeSelectionChanged -= this.onTreeSelectionChangedHandler;
+                this.SelectionMediator.OnTreeVisibilityChanged -= this.onTreeVisibilityChangedHandler;
+                this.SelectionMediator.OnParameterChanged -= this.onParameterChangedHandler;
+                this.SelectionMediator.OnParameterSubmitted -= this.onParameterSubmittedHandler;
+                this.parameterChangedSubject.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Viewer/PropertiesPanel/PropertiesComponentViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/PropertiesPanel/PropertiesComponentViewModel.cs
@@ -33,12 +33,14 @@ namespace COMETwebapp.ViewModels.Components.Viewer.PropertiesPanel
     using CDP4Dal;
 
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities.DisposableObject;
 
     using COMETwebapp.Components.Viewer.PropertiesPanel;
     using COMETwebapp.Model;
     using COMETwebapp.Model.Viewer;
     using COMETwebapp.Services.Interoperability;
     using COMETwebapp.Utilities;
+    using COMETwebapp.ViewModels.Components.Viewer;
 
     using Microsoft.AspNetCore.Components;
 
@@ -47,8 +49,13 @@ namespace COMETwebapp.ViewModels.Components.Viewer.PropertiesPanel
     /// <summary>
     /// View Model for the <see cref="PropertiesComponent" />
     /// </summary>
-    public class PropertiesComponentViewModel : ReactiveObject, IPropertiesComponentViewModel
+    public class PropertiesComponentViewModel : DisposableObject, IPropertiesComponentViewModel
     {
+        /// <summary>
+        /// Handler registered on <see cref="ISelectionMediator.OnTreeSelectionChanged" />, retained so it can be unsubscribed on disposal
+        /// </summary>
+        private readonly Action<ViewerNodeViewModel> onTreeSelectionChangedHandler;
+
         /// <summary>
         /// Backing field for the <see cref="IsVisible" />
         /// </summary>
@@ -90,8 +97,24 @@ namespace COMETwebapp.ViewModels.Components.Viewer.PropertiesPanel
 
             this.OnParameterValueSetChanged = new EventCallbackFactory().Create(this, async ((IValueSet,int) valueSet) => { await this.ParameterValueSetChanged(valueSet); });
 
-            this.SelectionMediator.OnTreeSelectionChanged += nodeViewModel => this.OnSelectionChanged(nodeViewModel.SceneObject);
+            this.onTreeSelectionChangedHandler = nodeViewModel => this.OnSelectionChanged(nodeViewModel.SceneObject);
+            this.SelectionMediator.OnTreeSelectionChanged += this.onTreeSelectionChangedHandler;
             this.SelectionMediator.OnModelSelectionChanged += this.OnSelectionChanged;
+        }
+
+        /// <summary>
+        /// Unsubscribes from the <see cref="ISelectionMediator" /> events and releases the resources used by this view model
+        /// </summary>
+        /// <param name="disposing">Value asserting if this component should dispose or not</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.SelectionMediator.OnTreeSelectionChanged -= this.onTreeSelectionChangedHandler;
+                this.SelectionMediator.OnModelSelectionChanged -= this.OnSelectionChanged;
+            }
+
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Viewer/ViewerBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/ViewerBodyViewModel.cs
@@ -60,6 +60,10 @@ namespace COMETwebapp.ViewModels.Components.Viewer
 
             this.InitializeSubscriptions([typeof(ElementBase)]);
 
+            this.Disposables.Add(this.ProductTreeViewModel);
+            this.Disposables.Add((IDisposable)this.CanvasViewModel);
+            this.Disposables.Add((IDisposable)this.PropertiesViewModel);
+
             this.Disposables.Add(this.WhenAnyValue(x => x.MultipleFiniteStateSelector.SelectedFiniteStates,
                     x => x.OptionSelector.SelectedOption)
                 .Subscribe(_ => this.InitializeElementsAndCreateTree()));

--- a/COMETwebapp/ViewModels/Components/Viewer/ViewerProductTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/ViewerProductTreeViewModel.cs
@@ -54,6 +54,21 @@ namespace COMETwebapp.ViewModels.Components.Viewer
         }
 
         /// <summary>
+        /// Unsubscribes from the <see cref="ISelectionMediator" /> events and releases the resources used by this view model
+        /// </summary>
+        /// <param name="disposing">Value asserting if this component should dispose or not</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.SelectionMediator.OnModelSelectionChanged -= this.OnModelSelectionChanged;
+                this.SelectionMediator.OnParameterSubmitted -= this.OnParameterSubmitted;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
         /// Gets o sets the <see cref="SelectionMediator" />
         /// </summary>
         public ISelectionMediator SelectionMediator { get; private set; }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #824  app crash when switching between System Representation and 3D Viewer
Problem
Repeatedly switching between the 3D Viewer and System Representation tabs crashed the app after 5–10 switches. Root cause: transient ViewModels subscribed to circuit-scoped services (ISelectionMediator, ICDPMessageBus) but never unsubscribed, so every tab re-open piled more handlers onto long-lived services, each pinning a whole VM/scene graph until the circuit ran out of memory.

Fix
Completed the Disposables ownership chain so every subscription is released when its owner is disposed:

- Viewer : CanvasViewModel, ViewerProductTreeViewModel, PropertiesComponentViewModel now unsubscribe from ISelectionMediator on Dispose; PropertiesComponentViewModel becomes a DisposableObject; ViewerBodyViewModel disposes its child VMs. ActualFiniteStateSelector now disposes its Rx subscription.
- System Representation / Model Editor: wired the ElementDetailsPanelViewModel → edit-VMs → DomainOfExpertiseSelectorViewModel dispose chain end-to-end (three broken links); three edit VMs gained a DisposableObject base.
- Proactive sweep of the same leak shape elsewhere: 7 more DomainOfExpertiseSelectorViewModel owners (file-store tables, file/folder handlers, batch parameter editor, requirements edit dialog, user management) now register their selector for disposal.
- Uncovered a related gap: nested ApplicationBaseViewModel content VMs never disposed because the tab-only IsAllowedToDispose gate is never opened for them. Opted the 5 non-tab content VMs out of that gate (IsAllowedToDispose = true in their ctor) so their Dispose actually runs. The gate's behaviour for real tab VMs is unchanged.
