### PR TITLE
Fix #811 and #820 Fixed bug and made layout in 3d-viewer similar to system representation

### DIFF
--- a/COMET.Web.Common.Tests/ViewModels/Components/ParameterEditors/OrientationViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/ParameterEditors/OrientationViewModelTestFixture.cs
@@ -136,5 +136,55 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.ParameterEditors
                 Assert.That(localViewModel.Orientation.Matrix[0], Is.EqualTo(1.0));
             }
         }
+
+        [Test]
+        public void VerifyMalformedValueArrayDoesNotThrow()
+        {
+            // Neither 3 (Euler) nor 9 (matrix) values: data anomaly. The view model must degrade to an
+            // identity orientation instead of letting the underlying ArgumentException surface.
+            var valueSet = new ParameterValueSet()
+            {
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                Manual = new ValueArray<string>(new List<string>() { "0", "0", "0", "0", "0" })
+            };
+
+            OrientationViewModel localViewModel = null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => localViewModel = new OrientationViewModel(valueSet, this.onParameterValueSetChanged), Throws.Nothing);
+                Assert.That(localViewModel.Orientation.Matrix, Is.EquivalentTo(Orientation.Identity().Matrix));
+                Assert.That(() => localViewModel.OnMatrixValuesChanged(0, "1.0"), Throws.Nothing);
+            });
+        }
+
+        [Test]
+        public async Task VerifySendChangesBackWritesToTheCurrentSwitchSlot()
+        {
+            (IValueSet ValueSet, int Index) capturedValue = default;
+
+            var identityValues = new List<string> { "1", "0", "0", "0", "1", "0", "0", "0", "1" };
+
+            var valueSet = new ParameterValueSet()
+            {
+                ValueSwitch = ParameterSwitchKind.REFERENCE,
+                Manual = new ValueArray<string>(identityValues),
+                Reference = new ValueArray<string>(identityValues)
+            };
+
+            var callback = new EventCallbackFactory().Create<(IValueSet, int)>(this, tuple => capturedValue = tuple);
+            var localViewModel = new OrientationViewModel(valueSet, callback, ParameterSwitchKind.REFERENCE);
+
+            await localViewModel.OnEulerAnglesChanged("Rx", "10.0");
+
+            var emittedValueSet = capturedValue.ValueSet as ParameterValueSetBase;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(emittedValueSet, Is.Not.Null);
+                Assert.That(emittedValueSet.Reference, Is.Not.EqualTo(valueSet.Reference).AsCollection, "The Reference slot must carry the edited orientation.");
+                Assert.That(emittedValueSet.Manual, Is.EqualTo(valueSet.Manual).AsCollection, "The Manual slot must be untouched while editing on the Reference switch.");
+            });
+        }
     }
 }

--- a/COMET.Web.Common.Tests/ViewModels/Components/ParameterEditors/QuantityKindParameterTypeEditorViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/ParameterEditors/QuantityKindParameterTypeEditorViewModelTestFixture.cs
@@ -86,5 +86,30 @@ namespace COMET.Web.Common.Tests.ViewModels.Components.ParameterEditors
                 Assert.That(this.viewModel.ParameterValueChanged, Is.Not.Null);
             });
         }
+
+        [Test]
+        public void VerifyShortValueArrayIsPaddedForHighComponentIndex()
+        {
+            var shortParameterValueSet = new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                Manual = new ValueArray<string>(["0", "0", "0"]),
+                Reference = new ValueArray<string>(["0", "0", "0"])
+            };
+
+            var orientationParameterType = new SimpleQuantityKind
+            {
+                Iid = Guid.NewGuid()
+            };
+
+            var componentViewModel = new QuantityKindParameterTypeEditorViewModel(orientationParameterType, shortParameterValueSet, false, 8);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => componentViewModel.ValueArray[componentViewModel.ValueArrayIndex], Throws.Nothing);
+                Assert.That(componentViewModel.ValueArray.Count, Is.GreaterThan(componentViewModel.ValueArrayIndex));
+            });
+        }
     }
 }

--- a/COMET.Web.Common/Extensions/ValueSetExtensions.cs
+++ b/COMET.Web.Common/Extensions/ValueSetExtensions.cs
@@ -56,14 +56,27 @@ namespace COMET.Web.Common.Extensions
         /// <param name="valueSet">the value set to parse</param>
         /// <param name="angleFormat">The format of the angle</param>
         /// <returns>And array of type [Rx,Ry,Rz]</returns>
+        /// <remarks>
+        /// Falls back to an identity <see cref="Orientation" /> when the value set holds neither 3 (Euler angles) nor
+        /// 9 (rotation matrix) values, instead of letting <see cref="MatrixExtensions.ToOrientation" /> throw. This is
+        /// a UI-side guard against a malformed persisted orientation value set; the underlying data
+        /// anomaly is a server/import concern outside this repository.
+        /// </remarks>
         public static Orientation ParseIValueToOrientation(this IValueSet valueSet, AngleFormat angleFormat)
         {
-            if (valueSet.ToDoubles(out var result))
+            if (!valueSet.ToDoubles(out var result))
+            {
+                return new Orientation(0, 0, 0);
+            }
+
+            try
             {
                 return result.ToArray().ToOrientation(valueSet.ActualValue.Count == 9, angleFormat);
             }
-
-            return new Orientation(0, 0, 0);
+            catch (ArgumentException)
+            {
+                return new Orientation(0, 0, 0);
+            }
         }
 
         /// <summary>

--- a/COMET.Web.Common/ViewModels/Components/ParameterEditors/CompoundParameterTypeEditorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/ParameterEditors/CompoundParameterTypeEditorViewModel.cs
@@ -55,7 +55,7 @@ namespace COMET.Web.Common.ViewModels.Components.ParameterEditors
         /// <returns>The <see cref="IOrientationViewModel" /></returns>
         public IOrientationViewModel CreateOrientationViewModel()
         {
-            return new OrientationViewModel(this.ValueSet, this.ParameterValueChanged);
+            return new OrientationViewModel(this.ValueSet, this.ParameterValueChanged, this.CurrentParameterSwitchKind);
         }
 
         /// <summary>

--- a/COMET.Web.Common/ViewModels/Components/ParameterEditors/OrientationViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/ParameterEditors/OrientationViewModel.cs
@@ -47,15 +47,26 @@ namespace COMET.Web.Common.ViewModels.Components.ParameterEditors
         private AngleFormat angleFormat = AngleFormat.Degrees;
 
         /// <summary>
+        /// The <see cref="ParameterSwitchKind" /> the emitted value must be written to (Manual or Reference); mirrors
+        /// the switch the rest of the parameter's editors are currently on so all of them stage the same slot.
+        /// </summary>
+        private readonly ParameterSwitchKind currentParameterSwitchKind;
+
+        /// <summary>
         /// Creates a new instance of type <see cref="Orientation" />
         /// </summary>
         /// <param name="valueSet">the current value set that's being changed</param>
         /// <param name="onParameterValueSetChanged">event callback for when a value has changed</param>
-        public OrientationViewModel(IValueSet valueSet, EventCallback<(IValueSet, int)> onParameterValueSetChanged)
+        /// <param name="currentParameterSwitchKind">
+        /// the <see cref="ParameterSwitchKind" /> the emitted array is written to (defaults to
+        /// <see cref="ParameterSwitchKind.MANUAL" /> for callers that only ever edit the Manual value)
+        /// </param>
+        public OrientationViewModel(IValueSet valueSet, EventCallback<(IValueSet, int)> onParameterValueSetChanged, ParameterSwitchKind currentParameterSwitchKind = ParameterSwitchKind.MANUAL)
         {
             this.CurrentValueSet = valueSet ?? throw new ArgumentNullException(nameof(valueSet));
             this.Orientation = valueSet.ParseIValueToOrientation(AngleFormat.Degrees);
             this.ParameterValueChanged = onParameterValueSetChanged;
+            this.currentParameterSwitchKind = currentParameterSwitchKind;
         }
 
         /// <summary>
@@ -185,20 +196,34 @@ namespace COMET.Web.Common.ViewModels.Components.ParameterEditors
         }
 
         /// <summary>
-        /// Send the changes back to the parent components
+        /// Send the changes back to the parent components. The array is written to the slot matching
+        /// <see cref="currentParameterSwitchKind" /> (Manual or Reference) without forcing the switch itself, so
+        /// editing while on the Reference switch stages a Reference edit instead of silently switching the parameter
+        /// to Manual. Nothing is sent while on <see cref="ParameterSwitchKind.COMPUTED" />, which stays
+        /// read-only just like the scalar editors.
         /// </summary>
         /// <param name="modifiedValueArray">the value array to send back</param>
         /// <returns>A <see cref="Task" /></returns>
         private async Task SendChangesBack(ValueArray<string> modifiedValueArray)
         {
-            if (this.CurrentValueSet is ParameterValueSetBase parameterValueSetBase)
+            if (this.CurrentValueSet is not ParameterValueSetBase parameterValueSetBase || this.currentParameterSwitchKind == ParameterSwitchKind.COMPUTED)
             {
-                var sendingParameterValueSetBase = parameterValueSetBase.Clone(true);
-                sendingParameterValueSetBase.Manual = modifiedValueArray;
-                sendingParameterValueSetBase.ValueSwitch = ParameterSwitchKind.MANUAL;
-
-                await this.ParameterValueChanged.InvokeAsync((sendingParameterValueSetBase,0));
+                return;
             }
+
+            var sendingParameterValueSetBase = parameterValueSetBase.Clone(true);
+
+            switch (this.currentParameterSwitchKind)
+            {
+                case ParameterSwitchKind.MANUAL:
+                    sendingParameterValueSetBase.Manual = modifiedValueArray;
+                    break;
+                case ParameterSwitchKind.REFERENCE:
+                    sendingParameterValueSetBase.Reference = modifiedValueArray;
+                    break;
+            }
+
+            await this.ParameterValueChanged.InvokeAsync((sendingParameterValueSetBase, 0));
         }
     }
 }

--- a/COMET.Web.Common/ViewModels/Components/ParameterEditors/ParameterTypeEditorBaseViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/ParameterEditors/ParameterTypeEditorBaseViewModel.cs
@@ -239,11 +239,16 @@ namespace COMET.Web.Common.ViewModels.Components.ParameterEditors
         }
 
         /// <summary>
-        /// Pads the ValueArray to ensure it can be safely accessed at the current ValueArrayIndex
+        /// Pads the <see cref="ValueArray" /> with empty entries so it can be safely accessed at the current
+        /// <see cref="ValueArrayIndex" />.
         /// </summary>
+        /// <remarks>
+        /// Guards against a malformed persisted value set whose <see cref="ValueArray{T}" /> has fewer entries than the
+        /// number of components its <see cref="ParameterType" /> declares. This is
+        /// the UI-side defense; the underlying data anomaly is a server/import concern outside this repository.
+        /// </remarks>
         private void PadValueArray()
         {
-            // TODO: Check the data for potential data issues in the ValueArray for the orientation parameter edition in system representation tab. Ticket #811
             if (this.valueArray == null || this.valueArray.Count > this.ValueArrayIndex)
             {
                 return;

--- a/COMETwebapp.Tests/Components/Shared/NodePillsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Shared/NodePillsTestFixture.cs
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="NodePillsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Shared
+{
+    using System;
+    using System.Collections.Concurrent;
+
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Shared;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="NodePills" />.
+    /// </summary>
+    [TestFixture]
+    public class NodePillsTestFixture
+    {
+        private BunitContext context;
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+        private Uri uri;
+        private DomainOfExpertise owner;
+        private Category category;
+        private ElementDefinition elementDefinition;
+
+        /// <summary>
+        /// Set up the test run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            this.uri = new Uri("http://test.com");
+
+            this.owner = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { ShortName = "SYS", Name = "System" };
+            this.category = new Category(Guid.NewGuid(), this.cache, this.uri) { ShortName = "KUR", Name = "Key User Requirement" };
+
+            this.elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Owner = this.owner };
+            this.elementDefinition.Category.Add(this.category);
+        }
+
+        /// <summary>
+        /// Tears down the test run.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Renders the <see cref="NodePills" /> component with the given parameters.
+        /// </summary>
+        /// <param name="elementBase">the <see cref="ElementBase" /> to render pills for</param>
+        /// <param name="showOwner">whether the owner pill should be shown</param>
+        /// <param name="showCategories">whether the category pills should be shown</param>
+        /// <returns>the rendered <see cref="NodePills" /> component</returns>
+        private IRenderedComponent<NodePills> Render(ElementBase elementBase, bool showOwner, bool showCategories)
+        {
+            return this.context.Render<NodePills>(parameters => parameters
+                .Add(p => p.ElementBase, elementBase)
+                .Add(p => p.ShowOwner, showOwner)
+                .Add(p => p.ShowCategories, showCategories));
+        }
+
+        /// <summary>
+        /// Verifies that the owner and category pills are rendered when both toggles are enabled.
+        /// </summary>
+        [Test]
+        public void VerifyOwnerAndCategoryPillsRenderWhenEnabled()
+        {
+            var component = this.Render(this.elementDefinition, true, true);
+            var pills = component.FindAll("span.starion-pill");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pills, Has.Count.EqualTo(2));
+                Assert.That(component.Markup, Does.Contain(this.owner.ShortName));
+                Assert.That(component.Markup, Does.Contain(this.category.ShortName));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that no pill is rendered when both toggles are disabled.
+        /// </summary>
+        [Test]
+        public void VerifyPillsHiddenWhenTogglesOff()
+        {
+            var component = this.Render(this.elementDefinition, false, false);
+            var pills = component.FindAll("span.starion-pill");
+
+            Assert.That(pills, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies that the component renders nothing, and does not throw, when the <see cref="ElementBase" /> is null.
+        /// </summary>
+        [Test]
+        public void VerifyNullElementBaseRendersNothing()
+        {
+            IRenderedComponent<NodePills> component = null;
+
+            Assert.That(() => component = this.Render(null, true, true), Throws.Nothing);
+            Assert.That(component.FindAll("span.starion-pill"), Is.Empty);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/Shared/ProductTreeToolbarTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Shared/ProductTreeToolbarTestFixture.cs
@@ -1,0 +1,85 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ProductTreeToolbarTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Shared
+{
+    using Bunit;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Shared;
+    using COMETwebapp.Utilities;
+    using COMETwebapp.ViewModels.Components.Viewer;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="ProductTreeToolbar" />.
+    /// </summary>
+    [TestFixture]
+    public class ProductTreeToolbarTestFixture
+    {
+        private BunitContext context;
+        private ViewerProductTreeViewModel viewModel;
+
+        /// <summary>
+        /// Set up the test run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.viewModel = new ViewerProductTreeViewModel(new Mock<ISelectionMediator>().Object);
+        }
+
+        /// <summary>
+        /// Tears down the test run.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Verifies that the shared <see cref="COMET.Web.Common.Components.SearchBar" /> and the "View" cog
+        /// trigger button, identified by the caller-supplied <see cref="ProductTreeToolbar.ButtonId" />, are rendered.
+        /// </summary>
+        [Test]
+        public void VerifySearchBarAndViewMenuButtonAreRendered()
+        {
+            var component = this.context.Render<ProductTreeToolbar>(parameters => parameters
+                .Add(p => p.ViewModel, this.viewModel)
+                .Add(p => p.ButtonId, "testTreeViewMenuButton"));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => component.FindComponent<COMET.Web.Common.Components.SearchBar>(), Throws.Nothing);
+                Assert.That(() => component.Find("#testTreeViewMenuButton"), Throws.Nothing);
+            }
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/Shared/StarionPillTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Shared/StarionPillTestFixture.cs
@@ -1,0 +1,118 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="StarionPillTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Shared
+{
+    using Bunit;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Shared;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="StarionPill" />.
+    /// </summary>
+    [TestFixture]
+    public class StarionPillTestFixture
+    {
+        private BunitContext context;
+
+        /// <summary>
+        /// Set up the test run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+        }
+
+        /// <summary>
+        /// Tears down the test run.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Renders the <see cref="StarionPill" /> component with the given parameters.
+        /// </summary>
+        /// <param name="colorSeed">the seed used to compute the pill's background colour</param>
+        /// <param name="title">the pill's title attribute</param>
+        /// <param name="style">an optional extra inline style</param>
+        /// <returns>the rendered <see cref="StarionPill" /> component</returns>
+        private IRenderedComponent<StarionPill> Render(string colorSeed, string title, string style = null)
+        {
+            return this.context.Render<StarionPill>(parameters => parameters
+                .Add(p => p.ColorSeed, colorSeed)
+                .Add(p => p.Title, title)
+                .Add(p => p.Style, style)
+                .AddChildContent("SYS"));
+        }
+
+        /// <summary>
+        /// Verifies that a colored pill renders a <c>span.starion-pill</c> with a background-color style,
+        /// the given title and the given child content.
+        /// </summary>
+        [Test]
+        public void VerifyColoredPillRendersBackgroundColorAndTitle()
+        {
+            var component = this.Render("owner:SYS", "Owning Domain Of Expertise: SYS");
+            var pill = component.Find("span.starion-pill");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pill.GetAttribute("style"), Does.Contain("background-color:"));
+                Assert.That(pill.GetAttribute("title"), Is.EqualTo("Owning Domain Of Expertise: SYS"));
+                Assert.That(pill.TextContent, Is.EqualTo("SYS"));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that an empty <see cref="StarionPill.ColorSeed" /> renders a pill with no
+        /// background-color style.
+        /// </summary>
+        [Test]
+        public void VerifyEmptyColorSeedRendersNoBackgroundColor()
+        {
+            var component = this.Render(string.Empty, "states", "white-space:nowrap;");
+            var pill = component.Find("span.starion-pill");
+
+            Assert.That(pill.GetAttribute("style"), Does.Not.Contain("background-color:"));
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="StarionPill.Style" /> parameter is appended to the rendered style.
+        /// </summary>
+        [Test]
+        public void VerifyStyleParameterIsAppended()
+        {
+            var component = this.Render("category:KUR", "Category: KUR", "margin-right:4px;");
+            var pill = component.Find("span.starion-pill");
+
+            Assert.That(pill.GetAttribute("style"), Does.Contain("margin-right:4px;"));
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/Viewer/ViewerProductTreeTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Viewer/ViewerProductTreeTestFixture.cs
@@ -1,0 +1,85 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ViewerProductTreeTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Viewer
+{
+    using Bunit;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Viewer;
+    using COMETwebapp.Utilities;
+    using COMETwebapp.ViewModels.Components.Viewer;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="ViewerProductTree" />.
+    /// </summary>
+    [TestFixture]
+    public class ViewerProductTreeTestFixture
+    {
+        private BunitContext context;
+        private ViewerProductTreeViewModel viewModel;
+        private Mock<ISelectionMediator> selectionMediator;
+
+        /// <summary>
+        /// Set up the test run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.selectionMediator = new Mock<ISelectionMediator>();
+            this.viewModel = new ViewerProductTreeViewModel(this.selectionMediator.Object);
+        }
+
+        /// <summary>
+        /// Tears down the test run.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Verifies that the shared <see cref="COMET.Web.Common.Components.SearchBar" /> and the "View" display-options
+        /// cog trigger button are rendered, matching the System Representation tree's layout.
+        /// </summary>
+        [Test]
+        public void VerifySearchBarAndViewMenuButtonAreRendered()
+        {
+            var component = this.context.Render<ViewerProductTree>(parameters => parameters.Add(p => p.ViewModel, this.viewModel));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => component.FindComponent<COMET.Web.Common.Components.SearchBar>(), Throws.Nothing);
+                Assert.That(() => component.Find("#viewerTreeViewMenuButton"), Throws.Nothing);
+            }
+        }
+    }
+}

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ViewerPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ViewerPageModel.cs
@@ -60,6 +60,11 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator SearchBar => this.Page.Locator("#product-tree-search-bar");
 
         /// <summary>
+        /// Gets the tree "View" display-options cog button.
+        /// </summary>
+        public ILocator ViewMenuButton => this.Page.Locator("#viewerTreeViewMenuButton");
+
+        /// <summary>
         /// Gets the properties/details panel.
         /// </summary>
         public ILocator PropertiesPanel => this.Page.Locator("#rightColumn");

--- a/COMETwebapp.Tests/IntegrationTests/ViewerTestFixture.cs
+++ b/COMETwebapp.Tests/IntegrationTests/ViewerTestFixture.cs
@@ -22,11 +22,15 @@
 
 namespace COMETwebapp.Tests.IntegrationTests
 {
+    using System.Threading.Tasks;
+
     using COMETwebapp.Tests.IntegrationTests.PageModels;
 
     using Microsoft.Playwright;
 
     using NUnit.Framework;
+
+    using static Microsoft.Playwright.Assertions;
 
     /// <summary>
     /// End-to-end tests for the 3D Viewer application. Add Viewer-specific tests here.
@@ -45,5 +49,18 @@ namespace COMETwebapp.Tests.IntegrationTests
         /// <param name="page">The Playwright <see cref="IPage" />.</param>
         /// <returns>The page object.</returns>
         protected override ViewerPageModel CreatePageModel(IPage page) => new(page);
+
+        /// <summary>
+        /// Verifies that the 3D Viewer product tree exposes the same controls as the System Representation tree
+        /// the shared search bar and the "View" display-options cog.
+        /// </summary>
+        /// <returns>A <see cref="Task" />.</returns>
+        [Test]
+        public async Task VerifyProductTreeControlsAreDisplayed()
+        {
+            await Expect(this.PageModel.SearchBar).ToBeVisibleAsync();
+            await Expect(this.PageModel.ViewMenuButton).ToBeVisibleAsync();
+            await Expect(this.Tabs.BlazorError).ToBeHiddenAsync();
+        }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditParameterViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditParameterViewModelTestFixture.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 
     using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.Utilities;
 
     using COMETwebapp.ViewModels.Components.ModelEditor.EditParameterViewModel;
 
@@ -249,6 +250,43 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
                 Assert.That(this.viewModel.ValueRows.Select(row => row.ParameterTypeName), Is.EquivalentTo(new[] { "x", "y" }));
                 Assert.That(this.viewModel.ValueRows[0].ActualValue, Is.EqualTo("1"));
                 Assert.That(this.viewModel.ValueRows[1].ActualValue, Is.EqualTo("2"));
+            });
+        }
+
+        [Test]
+        public void VerifyOrientationParameterIsNotFlattenedIntoComponentRows()
+        {
+            var orientationParameterType = new CompoundParameterType { Iid = Guid.NewGuid(), Name = "orientation", ShortName = ConstantValues.OrientationShortName };
+            var quantityKind = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "n", ShortName = "n" };
+
+            var components = Enumerable.Range(1, 9)
+                .Select(index => new ParameterTypeComponent { Iid = Guid.NewGuid(), ShortName = $"c{index}", ParameterType = quantityKind });
+
+            orientationParameterType.Component.AddRange(components);
+
+            var orientationValues = Enumerable.Repeat("0", 9).ToList();
+
+            var orientationParameter = new Parameter { Iid = Guid.NewGuid(), Owner = this.currentDomain, ParameterType = orientationParameterType };
+
+            orientationParameter.ValueSet.Add(new ParameterValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(orientationValues),
+                Computed = new ValueArray<string>(orientationValues),
+                Reference = new ValueArray<string>(orientationValues),
+                Formula = new ValueArray<string>(orientationValues),
+                Published = new ValueArray<string>(orientationValues),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            this.elementDefinition.Parameter.Add(orientationParameter);
+
+            this.viewModel.SetParameter(orientationParameter, this.iteration, this.currentDomain);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ValueRows, Has.Count.EqualTo(1), "An orientation parameter must be edited as a single compound row, not flattened per component.");
+                Assert.That(this.viewModel.ValueRows[0].ManualEditorViewModel.ParameterType, Is.InstanceOf<CompoundParameterType>(), "The dedicated orientation editor needs the whole compound parameter type, not a scalar component.");
             });
         }
 

--- a/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerNodeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerNodeViewModelTestFixture.cs
@@ -22,6 +22,14 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.Viewer
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Types;
+
     using COMETwebapp.Model;
     using COMETwebapp.Model.Viewer.Primitives;
     using COMETwebapp.ViewModels.Components.Viewer;
@@ -157,6 +165,27 @@ namespace COMETwebapp.Tests.ViewModels.Components.Viewer
 
             this.rootNode.UpdateSceneObjectProperty();
             Assert.That(propertyChanged, Is.True);
+        }
+
+        [Test]
+        public void VerifyElementBaseResolvesFromSceneObject()
+        {
+            var cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var uri = new Uri("http://test.com");
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), cache, uri) { Name = "Bus" };
+
+            var sceneObject = SceneObject.Create(elementDefinition, null, new List<ActualFiniteState>());
+            var nodeWithElementBase = new ViewerNodeViewModel(sceneObject);
+
+            var nodeWithoutSceneObject = new ViewerNodeViewModel(null);
+            var nodeWithEmptySceneObject = new ViewerNodeViewModel(new SceneObject(null));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(nodeWithElementBase.ElementBase, Is.EqualTo(elementDefinition));
+                Assert.That(nodeWithoutSceneObject.ElementBase, Is.Null);
+                Assert.That(nodeWithEmptySceneObject.ElementBase, Is.Null);
+            });
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerProductTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerProductTreeViewModelTestFixture.cs
@@ -250,6 +250,64 @@ namespace COMETwebapp.Tests.ViewModels.Components.Viewer
         }
 
         /// <summary>
+        /// Verifies that the three display-option toggles (<see cref="ViewerProductTreeViewModel.ShowName" />,
+        /// <see cref="ViewerProductTreeViewModel.ShowOwner" /> and <see cref="ViewerProductTreeViewModel.ShowCategories" />)
+        /// default to <c>true</c> and that setting each to <c>false</c> round-trips through
+        /// <c>RaiseAndSetIfChanged</c>.
+        /// </summary>
+        [Test]
+        public void VerifyDisplayOptionDefaultsAndReactivity()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.ShowName, Is.True);
+                Assert.That(this.viewModel.ShowOwner, Is.True);
+                Assert.That(this.viewModel.ShowCategories, Is.True);
+            }
+
+            this.viewModel.ShowName = false;
+            this.viewModel.ShowOwner = false;
+            this.viewModel.ShowCategories = false;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.ShowName, Is.False);
+                Assert.That(this.viewModel.ShowOwner, Is.False);
+                Assert.That(this.viewModel.ShowCategories, Is.False);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ViewerProductTreeViewModel.ShowOnlyNodesWithGeometry" /> defaults to <c>false</c>
+        /// and round-trips through the underlying <see cref="ViewerProductTreeViewModel.SelectedFilter" />.
+        /// </summary>
+        [Test]
+        public void VerifyShowOnlyNodesWithGeometry()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.ShowOnlyNodesWithGeometry, Is.False);
+                Assert.That(this.viewModel.SelectedFilter, Is.EqualTo(TreeFilter.ShowFullTree));
+            }
+
+            this.viewModel.ShowOnlyNodesWithGeometry = true;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.SelectedFilter, Is.EqualTo(TreeFilter.ShowNodesWithGeometry));
+                Assert.That(this.viewModel.ShowOnlyNodesWithGeometry, Is.True);
+            }
+
+            this.viewModel.ShowOnlyNodesWithGeometry = false;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.SelectedFilter, Is.EqualTo(TreeFilter.ShowFullTree));
+                Assert.That(this.viewModel.ShowOnlyNodesWithGeometry, Is.False);
+            }
+        }
+
+        /// <summary>
         /// Verifies the UpdateElementsFromTree method.
         /// </summary>
         [Test]

--- a/COMETwebapp/Components/Common/ParameterCard.razor
+++ b/COMETwebapp/Components/Common/ParameterCard.razor
@@ -19,7 +19,6 @@
 ------------------------------------------------------------------------------->
 
 @namespace COMETwebapp.Components.Common
-@using COMETwebapp.Utilities
 
 <div class="parameter-card"
      draggable="true"
@@ -36,11 +35,9 @@
             }
         </h6>
         <div class="d-flex align-items-center flex-nowrap" style="flex-shrink:0;">
-            <button class="starion-pill"
-                    title="Owning Domain Of Expertise: @this.Row.Owner"
-                    style="white-space:nowrap;flex-shrink:0;background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.Row.Owner}") !important;">
+            <StarionPill ColorSeed="@($"owner:{this.Row.Owner}")" Title="@($"Owning Domain Of Expertise: {this.Row.Owner}")" Style="white-space:nowrap;flex-shrink:0;">
                 @this.Row.Owner
-            </button>
+            </StarionPill>
             @if (this.OnCreateSubscription.HasDelegate && this.Row.CanSubscribe)
             {
                 <DxButton IconCssClass="oi oi-bell"
@@ -114,9 +111,9 @@
     {
         <div class="row" style="border-top:1px dotted darkgray;margin-top:8px;padding-top:8px;">
             <div class="col d-flex align-items-center" style="gap:6px;">
-                <button class="starion-pill" style="white-space:nowrap;">
+                <StarionPill Style="white-space:nowrap;">
                     @this.Row.StateValues.Count states
-                </button>
+                </StarionPill>
                 <button class="btn btn-sm btn-link p-0"
                         title="@(this.statesExpanded ? "Collapse state values" : "Expand state values")"
                         @onclick="this.ToggleStatesExpanded">
@@ -134,10 +131,9 @@
                         <div class="row" style="margin-top:4px;">
                             <div class="col-6">
                                 <span>
-                                    <button class="starion-pill"
-                                            title="Value Switch: @stateRow.SwitchValue">
+                                    <StarionPill Title="@($"Value Switch: {stateRow.SwitchValue}")">
                                         @stateRow.SwitchValue
-                                    </button>
+                                    </StarionPill>
                                 </span>
                                 <span>Actual:</span>
                             </div>
@@ -167,10 +163,9 @@
         <div class="row" style="border-top:1px dotted darkgray;margin-top:8px;padding-top:8px;">
             <div class="col-6">
                 <span>
-                    <button class="starion-pill"
-                            title="Actual Value's Value Switch: @this.Row.SwitchValue">
+                    <StarionPill Title="@($"Actual Value's Value Switch: {this.Row.SwitchValue}")">
                         @this.Row.SwitchValue
-                    </button>
+                    </StarionPill>
                 </span>
                 <span>Actual:</span>
             </div>

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -20,7 +20,6 @@
 @using COMET.Web.Common.Extensions
 @using CDP4Common.EngineeringModelData
 @using COMETwebapp.Components.Common
-@using COMETwebapp.Utilities
 @using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows
 @using Microsoft.JSInterop
 @inherits DisposableComponent
@@ -38,11 +37,9 @@
                 <small class="text-muted">@this.ViewModel.SelectedSystemNode.ShortName</small>
             </div>
             <div class="col-5" align="right">
-                <button class="starion-pill"
-                        title="Owning Domain Of Expertise: @this.ViewModel.SelectedSystemNode.Owner.ShortName"
-                        style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.ViewModel.SelectedSystemNode.Owner.ShortName}") !important;">
+                <StarionPill ColorSeed="@($"owner:{this.ViewModel.SelectedSystemNode.Owner.ShortName}")" Title="@($"Owning Domain Of Expertise: {this.ViewModel.SelectedSystemNode.Owner.ShortName}")">
                     @this.ViewModel.SelectedSystemNode.Owner.ShortName
-                </button>
+                </StarionPill>
                 @if (this.OnEditDefinition.HasDelegate && this.ViewModel.SelectedSystemNode is ElementUsage)
                 {
                     <DxButton Id="editDefinition"
@@ -83,9 +80,9 @@
                 <div class="col-12">
                     @foreach (var category in categories)
                     {
-                        <button class="starion-pill" title="Category: @category.Name" style="margin-right:4px; background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;">
+                        <StarionPill ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.Name}")" Style="margin-right:4px;">
                             @category.Name
-                        </button>
+                        </StarionPill>
                     }
                 </div>
             </div>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
@@ -18,7 +18,6 @@
 //    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMETwebapp.Extensions
-@using COMETwebapp.Utilities
 
 <div class="@this.CssClass" style="display: flex; justify-content: space-between; align-items: center;" @attributes="this.AdditionalAttributes">
     <span>
@@ -28,24 +27,20 @@
         @if (this.ShowOwner)
         {
             <span>
-                <button class="starion-pill"
-                        title="Owning Domain Of Expertise: @this.ElementBaseTreeRowViewModel.OwnerShortName"
-                        style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.ElementBaseTreeRowViewModel.OwnerShortName}") !important;">
+                <StarionPill ColorSeed="@($"owner:{this.ElementBaseTreeRowViewModel.OwnerShortName}")" Title="@($"Owning Domain Of Expertise: {this.ElementBaseTreeRowViewModel.OwnerShortName}")">
                     <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="OwnerShortName"/>
-                </button>
+                </StarionPill>
             </span>
         }
-     
+
         @if (this.ShowCategories)
         {
             @foreach (var categoryShortName in this.ElementBaseTreeRowViewModel.ElementBase.GetDisplayCategories().Select(x => x.ShortName))
             {
                 <span @key="categoryShortName">
-                    <button class="starion-pill"
-                            title="Category: @categoryShortName"
-                            style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{categoryShortName}") !important;">
+                    <StarionPill ColorSeed="@($"category:{categoryShortName}")" Title="@($"Category: {categoryShortName}")">
                         <CardField Context="@categoryShortName"/>
-                    </button>
+                    </StarionPill>
                 </span>
             }
         }

--- a/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementPills.razor
@@ -18,19 +18,17 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
-@using COMETwebapp.Utilities
-
 <span class="req-pills">
     @if (this.ViewModel.ShowOwner && this.Owner != null)
     {
-        <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.Owner.ShortName}") !important;" title="Owner: @this.Owner.Name">@this.Owner.ShortName</span>
+        <StarionPill ColorSeed="@($"owner:{this.Owner.ShortName}")" Title="@($"Owner: {this.Owner.Name}")">@this.Owner.ShortName</StarionPill>
     }
     <span class="req-pill-categories">
         @if (this.ViewModel.ShowCategory)
         {
             @foreach (var category in this.Categories)
             {
-                <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                <StarionPill ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.Name}")">@category.ShortName</StarionPill>
             }
         }
     </span>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementRowActions.razor
@@ -18,8 +18,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
-@using COMETwebapp.Utilities
-
 @if (this.Requirement.IsDeprecated)
 {
     <span class="req-deprecated-badge" title="This requirement is deprecated">Deprecated</span>
@@ -38,7 +36,7 @@ else
     <div class="req-pill-action-row">
         @if (this.ViewModel.ShowOwner && this.Requirement.Owner != null)
         {
-            <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{this.Requirement.Owner.ShortName}") !important;" title="Owner: @this.Requirement.Owner.Name">@this.Requirement.Owner.ShortName</span>
+            <StarionPill ColorSeed="@($"owner:{this.Requirement.Owner.ShortName}")" Title="@($"Owner: {this.Requirement.Owner.Name}")">@this.Requirement.Owner.ShortName</StarionPill>
         }
         <span class="req-actions"><EditThingButton ViewModel="@this.ViewModel" Thing="@this.Requirement" /></span>
     </div>
@@ -48,7 +46,7 @@ else
             {
                 @foreach (var category in this.Requirement.Category)
                 {
-                    <span class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.Name">@category.ShortName</span>
+                    <StarionPill ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.Name}")">@category.ShortName</StarionPill>
                 }
             }
         </span>

--- a/COMETwebapp/Components/Shared/NodePills.razor
+++ b/COMETwebapp/Components/Shared/NodePills.razor
@@ -1,0 +1,37 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+This file is part of CDP4-COMET WEB Community Edition
+The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@using CDP4Common.EngineeringModelData
+@using COMETwebapp.Extensions
+
+@if (this.ElementBase is not null)
+{
+    @if (this.ShowOwner && this.ElementBase.Owner != null)
+    {
+        <StarionPill ColorSeed="@($"owner:{this.ElementBase.Owner.ShortName}")" Title="@($"Owning Domain Of Expertise: {this.ElementBase.Owner.ShortName}")">@this.ElementBase.Owner.ShortName</StarionPill>
+    }
+
+    @if (this.ShowCategories)
+    {
+        @foreach (var category in this.ElementBase.GetDisplayCategories())
+        {
+            <StarionPill @key="category.Iid" ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.ShortName}")">@category.ShortName</StarionPill>
+        }
+    }
+}

--- a/COMETwebapp/Components/Shared/NodePills.razor.cs
+++ b/COMETwebapp/Components/Shared/NodePills.razor.cs
@@ -1,0 +1,53 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="NodePills.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Shared
+{
+    using CDP4Common.EngineeringModelData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders the owner and category pills of an <see cref="ElementBase" /> tree node, shared by the
+    /// System Representation and 3D Viewer product trees so the pill markup and styling stay in one place.
+    /// </summary>
+    public partial class NodePills
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ElementBase" /> whose owner and categories are rendered as pills.
+        /// </summary>
+        [Parameter]
+        public ElementBase ElementBase { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owner pill is shown.
+        /// </summary>
+        [Parameter]
+        public bool ShowOwner { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category pills are shown.
+        /// </summary>
+        [Parameter]
+        public bool ShowCategories { get; set; }
+    }
+}

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor
@@ -1,0 +1,48 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+This file is part of CDP4-COMET WEB Community Edition
+The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+
+<div id="product-tree-top-section">
+    <div id="product-tree-search-bar">
+        <SearchBar @bind-Text="@this.ViewModel.SearchText"/>
+    </div>
+
+    <DxButton Id="@this.ButtonId"
+              RenderStyle="ButtonRenderStyle.Light"
+              IconCssClass="oi oi-cog"
+              Text="View"
+              title="Display options"
+              Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
+
+    <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
+                PositionMode="DropDownPositionMode.Bottom"
+                PositionTarget="@($"#{this.ButtonId}")"
+                CloseMode="DropDownCloseMode.Close"
+                HeaderVisible="false"
+                FooterVisible="false">
+        <BodyTemplate>
+            <div class="product-tree-view-menu">
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
+                @this.ChildContent
+            </div>
+        </BodyTemplate>
+    </DxDropDown>
+</div>

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.cs
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.cs
@@ -1,0 +1,63 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ProductTreeToolbar.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Shared
+{
+    using COMETwebapp.ViewModels.Components.Shared;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Shared toolbar rendered above a product tree (System Representation / 3D Viewer): a search box and a
+    /// "View" cog that opens a dropdown with the display-option toggles (<see cref="IProductTreeDisplayOptions.ShowName" />,
+    /// <see cref="IProductTreeDisplayOptions.ShowOwner" />, <see cref="IProductTreeDisplayOptions.ShowCategories" />).
+    /// Callers can append feature-specific toggles through <see cref="ChildContent" />.
+    /// </summary>
+    public partial class ProductTreeToolbar
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IProductTreeDisplayOptions" /> the toolbar reads and toggles.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public IProductTreeDisplayOptions ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id given to the "View" cog <c>DxButton</c>, also used as the <c>DxDropDown</c>
+        /// <c>PositionTarget</c>. Must be unique per page so two toolbars can coexist.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public string ButtonId { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional display-option toggles rendered after the shared ones.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Whether the "View" display-options dropdown is open.
+        /// </summary>
+        private bool viewMenuOpen;
+    }
+}

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.css
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.css
@@ -1,0 +1,26 @@
+#product-tree-top-section {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 8px 0;
+    flex: 0 0 auto;
+}
+
+#product-tree-search-bar {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.product-tree-view-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    min-width: 180px;
+}
+
+::deep #tree-search-filter {
+    width: 100%;
+    margin-left: 0;
+}

--- a/COMETwebapp/Components/Shared/StarionPill.razor
+++ b/COMETwebapp/Components/Shared/StarionPill.razor
@@ -1,0 +1,21 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+This file is part of COMET WEB Community Edition
+The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+The COMET WEB Community Edition is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+The COMET WEB Community Edition is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+
+<span class="starion-pill" style="@this.ComputedStyle" title="@this.ComputedTitle">@this.ChildContent</span>

--- a/COMETwebapp/Components/Shared/StarionPill.razor.cs
+++ b/COMETwebapp/Components/Shared/StarionPill.razor.cs
@@ -1,0 +1,88 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="StarionPill.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Shared
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders a single "pill" badge, the small rounded tag used throughout the application to display an
+    /// owner Domain Of Expertise, a Category, or any other short piece of information. The pill's background
+    /// colour is derived from <see cref="ColorSeed" /> via <see cref="COMETwebapp.Utilities.TagColorGenerator" />,
+    /// so that pills sharing the same seed always share the same colour.
+    /// </summary>
+    public partial class StarionPill
+    {
+        /// <summary>
+        /// Gets or sets the seed passed to <see cref="COMETwebapp.Utilities.TagColorGenerator.GetBackgroundColor(string)" />
+        /// to compute the pill's background colour. When <see langword="null" /> or empty, no background-color
+        /// style is rendered, so uncoloured pills (e.g. the state-count or switch-value pills in a parameter card)
+        /// keep their default appearance.
+        /// </summary>
+        [Parameter]
+        public string ColorSeed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text rendered as the pill's <c>title</c> attribute. When <see langword="null" /> or
+        /// empty, no <c>title</c> attribute is rendered.
+        /// </summary>
+        [Parameter]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional extra inline style, appended after the computed background-color style, used
+        /// to preserve per-site tweaks such as spacing or text wrapping.
+        /// </summary>
+        [Parameter]
+        public string Style { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content rendered inside the pill.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Gets the computed inline <c>style</c> attribute value, combining the background colour derived from
+        /// <see cref="ColorSeed" /> (when set) with any additional <see cref="Style" />. Returns
+        /// <see langword="null" /> when both are empty so no <c>style</c> attribute is rendered.
+        /// </summary>
+        private string ComputedStyle
+        {
+            get
+            {
+                var backgroundStyle = string.IsNullOrEmpty(this.ColorSeed)
+                    ? string.Empty
+                    : $"background-color:{Utilities.TagColorGenerator.GetBackgroundColor(this.ColorSeed)} !important;";
+
+                var combinedStyle = $"{backgroundStyle}{this.Style}";
+                return string.IsNullOrEmpty(combinedStyle) ? null : combinedStyle;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Title" />, or <see langword="null" /> when it is empty so no <c>title</c> attribute
+        /// is rendered.
+        /// </summary>
+        private string ComputedTitle => string.IsNullOrEmpty(this.Title) ? null : this.Title;
+    }
+}

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor
@@ -18,10 +18,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMETwebapp.ViewModels.Components.SystemRepresentation
-@using CDP4Common.EngineeringModelData
-@using COMET.Web.Common.Extensions
-@using COMETwebapp.Extensions
-@using COMETwebapp.Utilities
 @inherits DisposableComponent
 @{
     @if (this.ViewModel is null)
@@ -83,7 +79,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
                 }
 
                 @{
-                    var elementBase = this.ViewModel.Thing as ElementBase;
+                    var elementBase = this.ViewModel.ElementBase;
                     var label = this.TreeViewModel is { ShowName: false } ? elementBase?.ShortName : elementBase?.Name;
                     label ??= this.ViewModel.Title;
                 }
@@ -91,21 +87,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
                     <p class="node-text">@label</p>
 
                     <span class="node-pills">
-                        @if (elementBase is not null)
-                        {
-                            @if (this.TreeViewModel?.ShowOwner != false && elementBase.Owner != null)
-                            {
-                                <button class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"owner:{elementBase.Owner.ShortName}") !important;" title="Owning Domain Of Expertise: @elementBase.Owner.ShortName">@elementBase.Owner.ShortName</button>
-                            }
-
-                            @if (this.TreeViewModel?.ShowCategories != false)
-                            {
-                                @foreach (var category in elementBase.GetDisplayCategories())
-                                {
-                                    <button @key="category.Iid" class="starion-pill" style="background-color:@TagColorGenerator.GetBackgroundColor($"category:{category.ShortName}") !important;" title="Category: @category.ShortName">@category.ShortName</button>
-                                }
-                            }
-                        }
+                        <NodePills ElementBase="@elementBase" ShowOwner="@(this.TreeViewModel?.ShowOwner != false)" ShowCategories="@(this.TreeViewModel?.ShowCategories != false)"/>
                         @if (this.IsValidDropTarget)
                         {
                             <span class="drop-impact-badge" title="This usage and everything it brings">+@this.DraggedItemImpactCount</span>

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor
@@ -20,33 +20,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 @inherits DisposableComponent
 
 <div id="product-tree-container">
-    <div id="product-tree-top-section">
-        <div id="product-tree-search-bar">
-            <SearchBar @bind-Text="@this.ViewModel.SearchText"/>
-        </div>
-
-        <DxButton Id="systemTreeViewMenuButton"
-                  RenderStyle="ButtonRenderStyle.Light"
-                  IconCssClass="oi oi-cog"
-                  Text="View"
-                  title="Display options"
-                  Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
-
-        <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
-                    PositionMode="DropDownPositionMode.Bottom"
-                    PositionTarget="#systemTreeViewMenuButton"
-                    CloseMode="DropDownCloseMode.Close"
-                    HeaderVisible="false"
-                    FooterVisible="false">
-            <BodyTemplate>
-                <div class="product-tree-view-menu">
-                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
-                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
-                    <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
-                </div>
-            </BodyTemplate>
-        </DxDropDown>
-    </div>
+    <ProductTreeToolbar ViewModel="this.ViewModel" ButtonId="systemTreeViewMenuButton"/>
 
     <div id="product-tree-nodes-section">
         @if (this.ViewModel.RootViewModel is not null)

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
@@ -41,11 +41,6 @@ namespace COMETwebapp.Components.SystemRepresentation
         public SystemRepresentationTreeViewModel ViewModel { get; set; }
 
         /// <summary>
-        /// Whether the "View" display-options dropdown is open.
-        /// </summary>
-        private bool viewMenuOpen;
-
-        /// <summary>
         /// Method invoked when the component is ready to start, having received its
         /// initial parameters from its parent in the render tree.
         /// </summary>

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.css
@@ -7,37 +7,10 @@
     flex: 1 1 auto;
 }
 
-#product-tree-top-section {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
-    margin: 0 0 8px 0;
-    flex: 0 0 auto;
-}
-
-#product-tree-search-bar {
-    flex: 1 1 auto;
-    min-width: 0;
-}
-
-.product-tree-view-menu {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 12px;
-    min-width: 180px;
-}
-
 #product-tree-nodes-section {
     flex: 1 1 auto;
     min-height: 0;
     overflow-x: auto;
     overflow-y: auto;
     position: relative;
-}
-
-::deep #tree-search-filter {
-    width: 100%;
-    margin-left: 0;
 }

--- a/COMETwebapp/Components/Viewer/ViewerBody.razor
+++ b/COMETwebapp/Components/Viewer/ViewerBody.razor
@@ -22,14 +22,12 @@
 @inherits COMET.Web.Common.Components.Applications.SingleIterationApplicationBase<COMETwebapp.ViewModels.Components.Viewer.IViewerBodyViewModel>
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
-    <div id="@WebAppConstantValues.ViewerPage.QueryPageBodyName()" class="row">
-        <div class="col">
-            <div class="width-fit-content">
-                <OptionSelector ViewModel="@(this.ViewModel.OptionSelector)"/>
-            </div> 
-        </div> 
+    <div id="@WebAppConstantValues.ViewerPage.QueryPageBodyName()" class="viewer-page-body">
         <div id="gridParent">
             <div id="leftColumn">
+                <div id="option-filter">
+                    <OptionSelector ViewModel="@(this.ViewModel.OptionSelector)"/>
+                </div>
                 <ViewerProductTree ViewModel="this.ViewModel.ProductTreeViewModel" />
             </div>
             <div id="center-container">

--- a/COMETwebapp/Components/Viewer/ViewerBody.razor.css
+++ b/COMETwebapp/Components/Viewer/ViewerBody.razor.css
@@ -1,22 +1,39 @@
-﻿#gridParent {
+﻿.viewer-page-body {
+    height: 100%;
+}
+
+#gridParent {
     position: relative;
-    margin: 1% 0;
+    margin: 0;
     display: grid;
     grid-template-columns: 0.2fr 1fr 0.2fr;
     grid-template-rows: 1fr;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
     gap: 10px;
+    height: 100%;
+    overflow: hidden;
 }
 
 #leftColumn {
     grid-area: 1 / 1 / 2 / 2;
     margin: 0;
     margin-right: 2%;
-    overflow-y: auto;
-    max-height: 67vh;
+    height: 100%;
     top: 0;
-    border: 1px solid #EEE;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
+#option-filter {
+    flex: 0 0 auto;
+    margin-bottom: 8px;
+}
+
+#option-filter ::deep h6 {
+    display: none;
 }
 
 #center-container {

--- a/COMETwebapp/Components/Viewer/ViewerNode.razor
+++ b/COMETwebapp/Components/Viewer/ViewerNode.razor
@@ -72,8 +72,19 @@ along with this program. If not, see http://www.gnu.org/licenses/.
                     <img class="expandIcon" alt="" src="@uri" @onclick="@(()=>{ this.ViewModel.IsExpanded = !this.ViewModel.IsExpanded; })" />
                 }
 
-                <p class="node-text">@this.ViewModel.Title</p>
-                
+                @{
+                    var elementBase = this.ViewModel.ElementBase;
+                    var label = this.TreeViewModel is { ShowName: false } ? elementBase?.ShortName : elementBase?.Name;
+                    label ??= this.ViewModel.Title;
+                }
+                <div class="node-label-tags">
+                    <p class="node-text">@label</p>
+
+                    <span class="node-pills">
+                        <NodePills ElementBase="@elementBase" ShowOwner="@(this.TreeViewModel?.ShowOwner != false)" ShowCategories="@(this.TreeViewModel?.ShowCategories != false)"/>
+                    </span>
+                </div>
+
                 @if (this.ViewModel.SceneObject?.Primitive is not null)
                 {
                     var uri = this.ViewModel.IsSceneObjectVisible ? "images/Show.svg" : "images/Hide.svg";

--- a/COMETwebapp/Components/Viewer/ViewerNode.razor.cs
+++ b/COMETwebapp/Components/Viewer/ViewerNode.razor.cs
@@ -45,7 +45,16 @@ namespace COMETwebapp.Components.Viewer
         /// </summary>
         [Parameter]
         public int Level { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the <see cref="ViewerProductTreeViewModel" /> cascaded from the tree root,
+        /// used to read display-option toggles (<see cref="ViewerProductTreeViewModel.ShowName" />,
+        /// <see cref="ViewerProductTreeViewModel.ShowOwner" />,
+        /// <see cref="ViewerProductTreeViewModel.ShowCategories" />).
+        /// </summary>
+        [CascadingParameter]
+        public ViewerProductTreeViewModel TreeViewModel { get; set; }
+
         /// <summary>
         /// Method invoked when the component has received parameters from its parent in
         /// the render tree, and the incoming values have been assigned to properties.
@@ -90,6 +99,9 @@ namespace COMETwebapp.Components.Viewer
                         break;
                     case nameof(this.Level):
                         this.Level = (int)parameter.Value;
+                        break;
+                    case nameof(this.TreeViewModel):
+                        this.TreeViewModel = parameter.Value as ViewerProductTreeViewModel;
                         break;
                 }
             }

--- a/COMETwebapp/Components/Viewer/ViewerNode.razor.css
+++ b/COMETwebapp/Components/Viewer/ViewerNode.razor.css
@@ -42,6 +42,26 @@
     margin-right: 10px;
 }
 
+.node-label-tags {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.node-pills {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
 .expandIcon {
     width: 1.5rem;
     height: 1.5rem;

--- a/COMETwebapp/Components/Viewer/ViewerProductTree.razor
+++ b/COMETwebapp/Components/Viewer/ViewerProductTree.razor
@@ -20,21 +20,16 @@
 @inherits DisposableComponent
 
 <div id="product-tree-container">
-    <h4 id="product-tree-title">Product Tree</h4>
-
-    <div id="product-tree-top-section">
-        <div id="product-tree-filters">
-            <DxComboBox Data="this.ViewModel.TreeFilters" @bind-Value="@this.ViewModel.SelectedFilter"></DxComboBox>
-        </div>
-        <div id="product-tree-search-bar">
-            <DxTextBox NullText="Search..." @bind-Text="@this.ViewModel.SearchText" BindValueMode="BindValueMode.OnInput" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"></DxTextBox>
-        </div>
-    </div>
+    <ProductTreeToolbar ViewModel="this.ViewModel" ButtonId="viewerTreeViewMenuButton">
+        <DxCheckBox @bind-Checked="@this.ViewModel.ShowOnlyNodesWithGeometry" CheckType="CheckType.Switch">Only nodes with geometry</DxCheckBox>
+    </ProductTreeToolbar>
 
     <div id="product-tree-nodes-section">
         @if (this.ViewModel.RootViewModel is not null)
         {
-            <ViewerNode ViewModel="this.ViewModel.RootViewModel" Level="0"/>
+            <CascadingValue Value="this.ViewModel" IsFixed="false">
+                <ViewerNode ViewModel="this.ViewModel.RootViewModel" Level="0"/>
+            </CascadingValue>
         }
     </div>
 </div>

--- a/COMETwebapp/Components/Viewer/ViewerProductTree.razor.cs
+++ b/COMETwebapp/Components/Viewer/ViewerProductTree.razor.cs
@@ -52,6 +52,12 @@ namespace COMETwebapp.Components.Viewer
                 x => x.ViewModel.SelectedFilter,
                 x => x.ViewModel.SearchText)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+            this.Disposables.Add(this.WhenAnyValue(
+                    x => x.ViewModel.ShowName,
+                    x => x.ViewModel.ShowOwner,
+                    x => x.ViewModel.ShowCategories)
+                .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
         }
     }
 }

--- a/COMETwebapp/Components/Viewer/ViewerProductTree.razor.css
+++ b/COMETwebapp/Components/Viewer/ViewerProductTree.razor.css
@@ -1,40 +1,16 @@
-﻿#product-tree-title {
-    background: #eaecee;
-    padding: 2%;
-}
-
 #product-tree-container {
-    margin: auto;
     margin: 0;
     padding: 0;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1 1 auto;
 }
 
 #product-tree-nodes-section {
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-x: auto;
     overflow-y: auto;
     position: relative;
-}
-
-#product-tree-top-section {
-    display: flex;
-    flex-direction: column;
-    margin: 3%;
-}
-
-#product-tree-filters {
-    margin-bottom: 1%;
-}
-
-#product-tree-search-bar {
-    margin-top: 1%;
-}
-
-::deep #tree-filter-drop-down {
-    margin: 4%;
-}
-
-::deep #tree-search-filter {
-    width: 90%;
-    margin-left: 2%;
 }

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditParameterViewModel/EditParameterValueSetGroupViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditParameterViewModel/EditParameterValueSetGroupViewModel.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditParameterViewModel
 
     using CDP4Dal;
 
+    using COMET.Web.Common.Utilities;
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
@@ -38,6 +39,9 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditParameterViewModel
     /// one row; a <see cref="CompoundParameterType" /> produces one row per component (each with its own parameter
     /// type and scale, mirroring the desktop IME). The switch and the staged clone are shared by all the rows of the
     /// value set, so edits to different components accumulate onto the same clone and commit as a single value set.
+    /// An orientation parameter is the one exception: although it is a <see cref="CompoundParameterType" />,
+    /// it produces a single row backed by the dedicated <c>OrientationComponent</c> editor, which owns the whole
+    /// array, instead of nine flattened scalar rows.
     /// </summary>
     public class EditParameterValueSetGroupViewModel : DisposableObject
     {
@@ -63,12 +67,19 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditParameterViewModel
         public EditParameterValueSetGroupViewModel(ParameterType parameterType, ParameterValueSetBase valueSet, ICDPMessageBus messageBus)
         {
             this.OriginalValueSet = valueSet;
-            this.isCompound = parameterType is CompoundParameterType;
+
+            // An orientation parameter (issue #811) is a CompoundParameterType, but it must not be flattened into a
+            // scalar row per matrix/euler component: it has its own dedicated OrientationComponent editor that owns
+            // the whole array, exactly like a SampledFunctionParameterType's table.
+            var isOrientation = parameterType is CompoundParameterType { ShortName: var shortName }
+                                 && string.Equals(shortName, ConstantValues.OrientationShortName, StringComparison.InvariantCultureIgnoreCase);
+
+            this.isCompound = parameterType is CompoundParameterType && !isOrientation;
             this.ParameterSwitchKindSelectorViewModel = new ParameterSwitchKindSelectorViewModel(valueSet.ValueSwitch, false);
 
             var rows = new List<EditParameterValueSetRowViewModel>();
 
-            if (parameterType is CompoundParameterType compoundParameterType)
+            if (parameterType is CompoundParameterType compoundParameterType && !isOrientation)
             {
                 var index = 0;
 

--- a/COMETwebapp/ViewModels/Components/Shared/BaseNodeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Shared/BaseNodeViewModel.cs
@@ -23,6 +23,7 @@
 namespace COMETwebapp.ViewModels.Components.Shared
 {
     using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
 
     using COMET.Web.Common.Utilities.DisposableObject;
 
@@ -77,6 +78,13 @@ namespace COMETwebapp.ViewModels.Components.Shared
         /// Gets or sets the current thing
         /// </summary>
         public Thing Thing { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ElementBase" /> this node represents. Base implementation resolves it from
+        /// <see cref="Thing" />; overridden by node view models (e.g. <see cref="COMETwebapp.ViewModels.Components.Viewer.ViewerNodeViewModel" />)
+        /// whose underlying element comes from a different source.
+        /// </summary>
+        public virtual ElementBase ElementBase => this.Thing as ElementBase;
 
         /// <summary>
         /// Field for containing the children of this <see cref="BaseNodeViewModel{T}" />

--- a/COMETwebapp/ViewModels/Components/Shared/IProductTreeDisplayOptions.cs
+++ b/COMETwebapp/ViewModels/Components/Shared/IProductTreeDisplayOptions.cs
@@ -1,0 +1,54 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IProductTreeDisplayOptions.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.ViewModels.Components.Shared
+{
+    /// <summary>
+    /// Non-generic contract exposing the search text and node display-option toggles shared by every
+    /// product tree view model, so a single non-generic component (<see cref="COMETwebapp.Components.Shared.ProductTreeToolbar" />)
+    /// can bind to them without depending on the generic <see cref="ProductTreeViewModel{T}" />.
+    /// </summary>
+    public interface IProductTreeDisplayOptions
+    {
+        /// <summary>
+        /// Gets or sets the search text used for filtering the tree
+        /// </summary>
+        string SearchText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether nodes should display their <see cref="CDP4Common.CommonData.DefinedThing.Name" />
+        /// (<c>true</c>) or <see cref="CDP4Common.CommonData.DefinedThing.ShortName" /> (<c>false</c>).
+        /// </summary>
+        bool ShowName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owning <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />
+        /// pill is shown on each tree node.
+        /// </summary>
+        bool ShowOwner { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether category pills are shown on each tree node.
+        /// </summary>
+        bool ShowCategories { get; set; }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/Shared/ProductTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Shared/ProductTreeViewModel.cs
@@ -33,13 +33,13 @@ namespace COMETwebapp.ViewModels.Components.Shared
     /// <summary>
     /// View Model for building the product tree
     /// </summary>
-    public abstract class ProductTreeViewModel<T> : DisposableObject, IProductTreeViewModel<T> where T : IBaseNodeViewModel
+    public abstract class ProductTreeViewModel<T> : DisposableObject, IProductTreeViewModel<T>, IProductTreeDisplayOptions where T : IBaseNodeViewModel
     {
         /// <summary>
         /// Backing field for the <see cref="RootViewModel" />s
         /// </summary>
         private T rootViewModel;
-        
+
         /// <summary>
         /// Gets or sets the root of the <see cref="ProductTreeViewModel{T}" />
         /// </summary>
@@ -80,6 +80,50 @@ namespace COMETwebapp.ViewModels.Components.Shared
         {
             get => this.searchText;
             set => this.RaiseAndSetIfChanged(ref this.searchText, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="ShowName" />.
+        /// </summary>
+        private bool showName = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether nodes should display their <see cref="CDP4Common.CommonData.DefinedThing.Name" />
+        /// (<c>true</c>) or <see cref="CDP4Common.CommonData.DefinedThing.ShortName" /> (<c>false</c>).
+        /// </summary>
+        public bool ShowName
+        {
+            get => this.showName;
+            set => this.RaiseAndSetIfChanged(ref this.showName, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="ShowOwner" />.
+        /// </summary>
+        private bool showOwner = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owning <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />
+        /// pill is shown on each tree node.
+        /// </summary>
+        public bool ShowOwner
+        {
+            get => this.showOwner;
+            set => this.RaiseAndSetIfChanged(ref this.showOwner, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="ShowCategories" />.
+        /// </summary>
+        private bool showCategories = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether category pills are shown on each tree node.
+        /// </summary>
+        public bool ShowCategories
+        {
+            get => this.showCategories;
+            set => this.RaiseAndSetIfChanged(ref this.showCategories, value);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
@@ -38,21 +38,6 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
     public class SystemRepresentationTreeViewModel : ProductTreeViewModel<SystemNodeViewModel>
     {
         /// <summary>
-        /// Backing field for <see cref="ShowName" />.
-        /// </summary>
-        private bool showName = true;
-
-        /// <summary>
-        /// Backing field for <see cref="ShowOwner" />.
-        /// </summary>
-        private bool showOwner = true;
-
-        /// <summary>
-        /// Backing field for <see cref="ShowCategories" />.
-        /// </summary>
-        private bool showCategories = true;
-
-        /// <summary>
         /// Backing field for <see cref="DraggedNode" />.
         /// </summary>
         private SystemNodeViewModel draggedNode;
@@ -80,35 +65,6 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
 
             this.Disposables.Add(this.WhenAnyValue(x => x.SearchText).Subscribe(_ => this.OnSearchFilterChange()));
             this.Disposables.Add(this.WhenAnyValue(x => x.SelectedFilter).Subscribe(_ => this.OnFilterChanged()));
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether nodes should display their <see cref="CDP4Common.CommonData.DefinedThing.Name" />
-        /// (<c>true</c>) or <see cref="CDP4Common.CommonData.DefinedThing.ShortName" /> (<c>false</c>).
-        /// </summary>
-        public bool ShowName
-        {
-            get => this.showName;
-            set => this.RaiseAndSetIfChanged(ref this.showName, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the owning <see cref="CDP4Common.SiteDirectoryData.DomainOfExpertise" />
-        /// pill is shown on each tree node.
-        /// </summary>
-        public bool ShowOwner
-        {
-            get => this.showOwner;
-            set => this.RaiseAndSetIfChanged(ref this.showOwner, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether category pills are shown on each tree node.
-        /// </summary>
-        public bool ShowCategories
-        {
-            get => this.showCategories;
-            set => this.RaiseAndSetIfChanged(ref this.showCategories, value);
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/Viewer/ViewerNodeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/ViewerNodeViewModel.cs
@@ -22,6 +22,8 @@
 
 namespace COMETwebapp.ViewModels.Components.Viewer
 {
+    using CDP4Common.EngineeringModelData;
+
     using COMETwebapp.Model;
     using COMETwebapp.Utilities;
     using COMETwebapp.ViewModels.Components.Shared;
@@ -37,6 +39,13 @@ namespace COMETwebapp.ViewModels.Components.Viewer
         /// The <see cref="SceneObject"/> that this <see cref="ViewerNodeViewModel"/> represents
         /// </summary>
         public SceneObject SceneObject { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ElementBase"/> this node represents, resolved from the <see cref="SceneObject"/>
+        /// since a <see cref="ViewerNodeViewModel"/> is created with a title-only base constructor and never
+        /// has its <see cref="COMETwebapp.ViewModels.Components.Shared.BaseNodeViewModel{T}.Thing"/> set.
+        /// </summary>
+        public override ElementBase ElementBase => this.SceneObject?.ElementBase;
 
         /// <summary>
         /// Gets or set the <see cref="ISelectionMediator"/>

--- a/COMETwebapp/ViewModels/Components/Viewer/ViewerProductTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/ViewerProductTreeViewModel.cs
@@ -74,6 +74,17 @@ namespace COMETwebapp.ViewModels.Components.Viewer
         public ISelectionMediator SelectionMediator { get; private set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the tree only shows nodes that have a 3D geometry
+        /// primitive.
+        /// </summary>
+        // One-way convenience wrapper over SelectedFilter for the "View" cog checkbox; the Viewer never mutates SelectedFilter elsewhere.
+        public bool ShowOnlyNodesWithGeometry
+        {
+            get => this.SelectedFilter == TreeFilter.ShowNodesWithGeometry;
+            set => this.SelectedFilter = value ? TreeFilter.ShowNodesWithGeometry : TreeFilter.ShowFullTree;
+        }
+
+        /// <summary>
         /// Creates the product tree
         /// </summary>
         /// <param name="productTreeElements">the product tree elements</param>

--- a/COMETwebapp/wwwroot/css/app.css
+++ b/COMETwebapp/wwwroot/css/app.css
@@ -319,13 +319,16 @@ sub {
 
 .starion-pill {
     margin: 1px;
-    height: 19px;
     width: auto;
     border-radius: 30px;
     background-color: white;
     border: 1px solid dimgray;
     color: dimgray;
-    padding-top: 0px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 18px;
+    padding: 1px 8px;
 }
 
 .search-mark {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #820 and #811, plus shared-component and layout cleanup for the 3D Viewer.

### #820: reuse the System Representation tree control in the 3D Viewer
The Viewer and System Representation trees were parallel copies that could drift apart. The shared, drift-prone parts are now single components used by both:
- **`ProductTreeToolbar`** search bar + "View" cog + display-option toggles.
- **`NodePills`**  owner/category node badges.
- `ShowName`/`ShowOwner`/`ShowCategories` hoisted onto the shared `ProductTreeViewModel<T>` base; shared `ElementBase` accessor on `BaseNodeViewModel<T>`.

The Viewer also now matches System Representation's layout: the option selector sits inside the tree column (no "Filter on Option:" label), the option/search/View bar stays pinned while only the tree scrolls, and the panel fills the viewport height with no page scrollbar.

### #811  editing an orientation parameter crashed
Orientation edits are now routed to the dedicated `OrientationComponent` instead of being flattened into 9 scalar fields. 

### Shared pill badge
The `starion-pill` markup was duplicated ~10 times across 6 components. Extracted a single **`StarionPill`** atom (`ColorSeed` / `Title` / `Style` / `ChildContent`) and migrated every site (Viewer, System Rep, Model Editor, Requirements, Parameter cards) onto it. Behaviour is identical; click-less `<button>` pills became `<span>`, and the shared `.starion-pill` style gained the padding it previously borrowed from the button default.




