### PR TITLE
Feat #830 MoveElementUsages in model editor and system representation  also made the list scroll when drag-n-dropping

### DIFF
--- a/COMET.Web.Common.Tests/Utilities/ThingCreatorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Utilities/ThingCreatorTestFixture.cs
@@ -24,6 +24,7 @@
 namespace COMET.Web.Common.Tests.Utilities
 {
     using System.Collections.Concurrent;
+    using System.Linq;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
@@ -115,6 +116,62 @@ namespace COMET.Web.Common.Tests.Utilities
             iteration.Element.Add(elementDefinitionB);
 
             Assert.ThrowsAsync<Exception>(async () => await this.thingCreator.CreateElementUsageAsync(elementDefinitionA, elementDefinitionB, domainOfExpertise, this.sessionThatThrowsException.Object));
+        }
+
+        [Test]
+        public void VerifyThatArgumentNullExceptionsAreThrownOnMoveElementUsage()
+        {
+            var referencedElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, null);
+            var targetElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, null);
+
+            var elementUsage = new ElementUsage(Guid.NewGuid(), this.cache, null)
+            {
+                ElementDefinition = referencedElementDefinition
+            };
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.thingCreator.MoveElementUsageAsync(null, targetElementDefinition, this.session.Object));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.thingCreator.MoveElementUsageAsync(elementUsage, null, this.session.Object));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.thingCreator.MoveElementUsageAsync(elementUsage, targetElementDefinition, null));
+        }
+
+        [Test]
+        public async Task VerifyThatMoveElementUsageExecutesWrite()
+        {
+            var domainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), this.cache, null);
+            var engineeringModel = new EngineeringModel(Guid.NewGuid(), this.cache, null);
+            var iteration = new Iteration(Guid.NewGuid(), this.cache, null);
+            engineeringModel.Iteration.Add(iteration);
+
+            var sourceElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, null);
+            var targetElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, null);
+            var referencedElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, null);
+
+            iteration.Element.Add(sourceElementDefinition);
+            iteration.Element.Add(targetElementDefinition);
+            iteration.Element.Add(referencedElementDefinition);
+
+            var elementUsage = new ElementUsage(Guid.NewGuid(), this.cache, null)
+            {
+                Owner = domainOfExpertise,
+                ElementDefinition = referencedElementDefinition
+            };
+
+            sourceElementDefinition.ContainedElement.Add(elementUsage);
+
+            OperationContainer capturedOperationContainer = null;
+
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(operationContainer => capturedOperationContainer = operationContainer)
+                .Returns(Task.CompletedTask);
+
+            await this.thingCreator.MoveElementUsageAsync(elementUsage, targetElementDefinition, this.session.Object);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+
+            var modifiedIids = capturedOperationContainer.Operations.Select(x => x.ModifiedThing.Iid).ToList();
+
+            // The existing usage's Iid must be part of the operation, proving it was moved rather than re-created.
+            Assert.That(modifiedIids, Does.Contain(elementUsage.Iid));
         }
     }
 }

--- a/COMET.Web.Common/Utilities/DisposableObject/DisposableObject.cs
+++ b/COMET.Web.Common/Utilities/DisposableObject/DisposableObject.cs
@@ -51,7 +51,11 @@ namespace COMET.Web.Common.Utilities.DisposableObject
         {
             if (disposing)
             {
-                this.Disposables.ForEach(x => x.Dispose());
+                foreach (var disposable in this.Disposables.ToArray())
+                {
+                    disposable.Dispose();
+                }
+
                 this.Disposables.Clear();
             }
         }

--- a/COMET.Web.Common/Utilities/ThingCreator.cs
+++ b/COMET.Web.Common/Utilities/ThingCreator.cs
@@ -98,5 +98,62 @@ namespace COMET.Web.Common.Utilities
             var operationContainer = transaction.FinalizeTransaction();
             await session.Write(operationContainer);
         }
+
+        /// <summary>
+        /// Move (re-parent) an existing <see cref="ElementUsage"/> so that it becomes contained by a different
+        /// <see cref="ElementDefinition"/>, keeping its <see cref="ElementUsage.Iid"/>, name, owner, options and
+        /// <see cref="ElementUsage.ParameterOverride"/>s.
+        /// </summary>
+        /// <param name="elementUsage">
+        /// The existing <see cref="ElementUsage"/> to move.
+        /// </param>
+        /// <param name="targetContainer">
+        /// The <see cref="ElementDefinition"/> that becomes the new container of the <see cref="ElementUsage"/>.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the move is written.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous move operation.</returns>
+        public Task MoveElementUsageAsync(ElementUsage elementUsage, ElementDefinition targetContainer, ISession session)
+        {
+            ArgumentNullException.ThrowIfNull(elementUsage);
+            ArgumentNullException.ThrowIfNull(targetContainer);
+            ArgumentNullException.ThrowIfNull(session);
+
+            return MoveElementUsageImplAsync(elementUsage, targetContainer, session);
+        }
+
+        /// <summary>
+        /// Move (re-parent) an existing <see cref="ElementUsage"/> to a different container <see cref="ElementDefinition"/>.
+        /// </summary>
+        /// <param name="elementUsage">
+        /// The existing <see cref="ElementUsage"/> to move.
+        /// </param>
+        /// <param name="targetContainer">
+        /// The <see cref="ElementDefinition"/> that becomes the new container of the <see cref="ElementUsage"/>.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the move is written.
+        /// </param>
+        /// <remarks>
+        /// Only the target container clone (with the moved <see cref="ElementUsage"/> clone added to its
+        /// <see cref="ElementDefinition.ContainedElement"/>) is written. The server re-parents the usage and removes it
+        /// from its former container itself, so the old container must not be sent in the same transaction - mirroring the
+        /// composite re-parent already done for a <see cref="CDP4Common.EngineeringModelData.RequirementsGroup"/> move.
+        /// </remarks>
+        private static async Task MoveElementUsageImplAsync(ElementUsage elementUsage, ElementDefinition targetContainer, ISession session)
+        {
+            var targetClone = targetContainer.Clone(false);
+            var usageClone = elementUsage.Clone(false);
+
+            targetClone.ContainedElement.Add(usageClone);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(targetContainer);
+            var transaction = new ThingTransaction(transactionContext, targetClone);
+            transaction.CreateOrUpdate(usageClone);
+
+            var operationContainer = transaction.FinalizeTransaction();
+            await session.Write(operationContainer);
+        }
     }
 }

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -284,6 +284,37 @@ namespace COMETwebapp.Tests.Components.ModelEditor
         }
 
         /// <summary>
+        /// Verifies that dropping an existing <see cref="ElementUsage" /> onto an <see cref="ElementDefinition" /> node
+        /// routes to a move (re-parent), and not to a copy or a create-usage.
+        /// </summary>
+        [Test]
+        public async Task VerifyDroppingAnElementUsageOntoADefinitionMovesIt()
+        {
+            var owner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+            var referencedElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Referenced", ShortName = "REF", Owner = owner };
+            var draggedUsage = new ElementUsage { Iid = Guid.NewGuid(), Name = "Usage", ShortName = "USG", Owner = owner, ElementDefinition = referencedElement };
+            var targetElement = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Target", ShortName = "TGT", Owner = owner };
+            this.iteration.Element.Add(targetElement);
+
+            var usageRow = new ElementUsageTreeRowViewModel(draggedUsage);
+            var targetRow = new ElementDefinitionTreeRowViewModel(targetElement);
+
+            this.elementDefinitionTreeViewModel.Setup(x => x.Iteration).Returns(this.iteration);
+            this.viewModel.Setup(x => x.MoveElementUsageAsync(It.IsAny<ElementUsage>(), It.IsAny<ElementDefinition>())).Returns(Task.CompletedTask);
+
+            var renderedComponent = this.RenderModelEditor();
+            var trees = renderedComponent.FindComponents<ElementDefinitionTree>();
+            var sourceTree = trees[0].Instance;
+            var targetTree = trees[1].Instance;
+
+            await renderedComponent.InvokeAsync(() => sourceTree.OnDragStart.InvokeAsync((sourceTree, usageRow)));
+            await renderedComponent.InvokeAsync(() => targetTree.OnDrop.InvokeAsync((targetTree, targetRow, new DragEventArgs())));
+
+            this.viewModel.Verify(x => x.MoveElementUsageAsync(draggedUsage, targetElement), Times.Once);
+            this.viewModel.Verify(x => x.AddNewElementUsageAsync(It.IsAny<ElementBase>(), It.IsAny<ElementBase>()), Times.Never);
+        }
+
+        /// <summary>
         /// Verifies that selecting a node in either tree drives the details panel, and clears the selection of the other tree
         /// </summary>
         [Test]

--- a/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
@@ -347,11 +347,22 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
 
             Assert.That(detailsSearch.Instance, Is.Not.Null);
 
-            // Simulate a drag hovering over the root node so its drop-impact badge renders.
+            // Simulate a drag hovering over the root node so its drop-impact badge renders. The dragged node is an
+            // external usage whose container is a different ElementDefinition, so the drop is a valid move onto the
+            // root (dragging one of the root's own child usages back onto the root is a no-op and not a valid drop).
             var treeViewModel = this.viewModel.ProductTreeViewModel;
             var rootNode = treeViewModel.RootViewModel;
-            var childNode = rootNode.GetChildren().First();
-            treeViewModel.DraggedNode = childNode;
+
+            var externalUsage = new ElementUsage(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                Name = "ExternalUsage",
+                ShortName = "EXT",
+                Owner = this.domain,
+                Container = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "OtherContainer", ShortName = "OTH", Owner = this.domain },
+                ElementDefinition = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ExternalDefinition", ShortName = "EXTD", Owner = this.domain }
+            };
+
+            treeViewModel.DraggedNode = new SystemNodeViewModel(externalUsage);
             treeViewModel.DragOverNode = rootNode;
 
             var rootSystemNode = renderer.FindComponents<SystemNode>().First(node => ReferenceEquals(node.Instance.ViewModel, rootNode));

--- a/COMETwebapp.Tests/Javascript/dragScroll.test.js
+++ b/COMETwebapp.Tests/Javascript/dragScroll.test.js
@@ -1,0 +1,56 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="dragScroll.test.js" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+// Unit tests for the pure edge-detection logic of dragScroll.js. Uses only Node's built-in test runner - no packages.
+// Run from the repository root:  node --test COMETwebapp.Tests/Javascript/dragScroll.test.js
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const cometDragScroll = require(path.join(__dirname, '..', '..', 'COMETwebapp', 'wwwroot', 'js', 'dragScroll.js'));
+
+const rect = { top: 100, bottom: 500 };
+const edge = 40;
+const speed = 12;
+
+function velocity(clientY) {
+    return cometDragScroll.computeScrollVelocity(rect, clientY, edge, speed);
+}
+
+test('scrolls up (negative velocity) when the pointer is within the top edge band', () => {
+    assert.equal(velocity(rect.top), -speed);
+    assert.equal(velocity(rect.top + edge - 1), -speed);
+});
+
+test('scrolls down (positive velocity) when the pointer is within the bottom edge band', () => {
+    assert.equal(velocity(rect.bottom), speed);
+    assert.equal(velocity(rect.bottom - edge + 1), speed);
+});
+
+test('does not scroll when the pointer is in the middle, outside both edge bands', () => {
+    assert.equal(velocity(rect.top + edge), 0);
+    assert.equal(velocity(rect.bottom - edge), 0);
+    assert.equal(velocity((rect.top + rect.bottom) / 2), 0);
+});

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/ModelEditorViewModelTestFixture.cs
@@ -22,12 +22,17 @@
 
 namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
 {
+    using System.Collections.Concurrent;
+
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
+    using CDP4Dal.Permission;
 
     using CDP4Web.Enumerations;
 
@@ -82,6 +87,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
         private Mock<ISession> session;
 
         /// <summary>
+        /// The mocked <see cref="IPermissionService" /> used to gate <see cref="ModelEditorViewModel.MoveElementUsageAsync" />.
+        /// </summary>
+        private Mock<IPermissionService> permissionService;
+
+        /// <summary>
         /// Builds the iteration graph and the view model with mocked dependencies.
         /// </summary>
         [SetUp]
@@ -94,6 +104,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
             this.session = new Mock<ISession>();
             this.sessionService.Setup(x => x.Session).Returns(this.session.Object);
             this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            this.permissionService = new Mock<IPermissionService>();
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
 
             var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
             this.currentDomain = domain;
@@ -260,6 +275,128 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
                 Assert.That(isLoadingValues, Has.Some.EqualTo(true),
                     "IsLoading must toggle so that the Blazor component subscribed to it knows to re-render.");
             });
+        }
+
+        [Test]
+        public async Task VerifyMoveElementUsageWritesWhenValid()
+        {
+            var cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var movingIteration = new Iteration(Guid.NewGuid(), cache, null) { Container = new EngineeringModel { Iid = Guid.NewGuid() } };
+            var sourceElementDefinition = new ElementDefinition(Guid.NewGuid(), cache, null);
+            var targetElementDefinition = new ElementDefinition(Guid.NewGuid(), cache, null);
+            var referencedElementDefinition = new ElementDefinition(Guid.NewGuid(), cache, null);
+
+            movingIteration.Element.Add(sourceElementDefinition);
+            movingIteration.Element.Add(targetElementDefinition);
+            movingIteration.Element.Add(referencedElementDefinition);
+
+            var elementUsage = new ElementUsage(Guid.NewGuid(), cache, null)
+            {
+                Owner = this.currentDomain,
+                ElementDefinition = referencedElementDefinition
+            };
+
+            sourceElementDefinition.ContainedElement.Add(elementUsage);
+
+            OperationContainer capturedOperationContainer = null;
+
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(operationContainer => capturedOperationContainer = operationContainer)
+                .Returns(Task.CompletedTask);
+
+            await this.viewModel.MoveElementUsageAsync(elementUsage, targetElementDefinition);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+            Assert.That(capturedOperationContainer, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ModelEditorViewModel.MoveElementUsageAsync" /> silently refuses the move when
+        /// it would cross iterations, is a no-op (target equals the current container), would introduce a
+        /// containment cycle, or the current user lacks write permission on the target.
+        /// </summary>
+        [Test]
+        public async Task VerifyMoveElementUsageIsRejected()
+        {
+            // (a) cross-iteration: the target container belongs to a different Iteration.
+            var cacheA = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var iterationA1 = new Iteration(Guid.NewGuid(), cacheA, null);
+            var iterationA2 = new Iteration(Guid.NewGuid(), cacheA, null);
+            var sourceA = new ElementDefinition(Guid.NewGuid(), cacheA, null);
+            var targetA = new ElementDefinition(Guid.NewGuid(), cacheA, null);
+            var referencedA = new ElementDefinition(Guid.NewGuid(), cacheA, null);
+            iterationA1.Element.Add(sourceA);
+            iterationA1.Element.Add(referencedA);
+            iterationA2.Element.Add(targetA);
+
+            var usageA = new ElementUsage(Guid.NewGuid(), cacheA, null) { Owner = this.currentDomain, ElementDefinition = referencedA };
+            sourceA.ContainedElement.Add(usageA);
+
+            await this.viewModel.MoveElementUsageAsync(usageA, targetA);
+
+            // (b) already contained: the target equals the usage's current container.
+            var cacheB = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var iterationB = new Iteration(Guid.NewGuid(), cacheB, null);
+            var sourceB = new ElementDefinition(Guid.NewGuid(), cacheB, null);
+            var referencedB = new ElementDefinition(Guid.NewGuid(), cacheB, null);
+            iterationB.Element.Add(sourceB);
+            iterationB.Element.Add(referencedB);
+
+            var usageB = new ElementUsage(Guid.NewGuid(), cacheB, null) { Owner = this.currentDomain, ElementDefinition = referencedB };
+            sourceB.ContainedElement.Add(usageB);
+
+            await this.viewModel.MoveElementUsageAsync(usageB, sourceB);
+
+            // (c) containment cycle: the usage's referenced definition already (transitively) contains the target.
+            var cacheC = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var iterationC = new Iteration(Guid.NewGuid(), cacheC, null);
+            var sourceC = new ElementDefinition(Guid.NewGuid(), cacheC, null);
+            var referencedC = new ElementDefinition(Guid.NewGuid(), cacheC, null);
+            var targetC = new ElementDefinition(Guid.NewGuid(), cacheC, null);
+            iterationC.Element.Add(sourceC);
+            iterationC.Element.Add(referencedC);
+            iterationC.Element.Add(targetC);
+
+            var innerUsageC = new ElementUsage(Guid.NewGuid(), cacheC, null) { Owner = this.currentDomain, ElementDefinition = targetC };
+            referencedC.ContainedElement.Add(innerUsageC);
+
+            var usageC = new ElementUsage(Guid.NewGuid(), cacheC, null) { Owner = this.currentDomain, ElementDefinition = referencedC };
+            sourceC.ContainedElement.Add(usageC);
+
+            await this.viewModel.MoveElementUsageAsync(usageC, targetC);
+
+            // (d) no write permission on the target.
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(false);
+
+            var cacheD = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var iterationD = new Iteration(Guid.NewGuid(), cacheD, null);
+            var sourceD = new ElementDefinition(Guid.NewGuid(), cacheD, null);
+            var targetD = new ElementDefinition(Guid.NewGuid(), cacheD, null);
+            var referencedD = new ElementDefinition(Guid.NewGuid(), cacheD, null);
+            iterationD.Element.Add(sourceD);
+            iterationD.Element.Add(targetD);
+            iterationD.Element.Add(referencedD);
+
+            var usageD = new ElementUsage(Guid.NewGuid(), cacheD, null) { Owner = this.currentDomain, ElementDefinition = referencedD };
+            sourceD.ContainedElement.Add(usageD);
+
+            await this.viewModel.MoveElementUsageAsync(usageD, targetD);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+        }
+
+        [Test]
+        public void VerifyCanWriteElementUsageReflectsPermission()
+        {
+            var targetContainer = new ElementDefinition { Iid = Guid.NewGuid(), Owner = this.currentDomain };
+
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            Assert.That(this.viewModel.CanWriteElementUsage(targetContainer), Is.True);
+
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(false);
+            Assert.That(this.viewModel.CanWriteElementUsage(targetContainer), Is.False);
+
+            Assert.That(() => this.viewModel.CanWriteElementUsage(null), Throws.TypeOf<ArgumentNullException>());
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModelTestFixture.cs
@@ -29,6 +29,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
+    using CDP4Dal.Permission;
 
     using CDP4Web.Enumerations;
 
@@ -69,6 +71,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
         private Mock<ISession> session;
 
         /// <summary>
+        /// The mocked <see cref="IPermissionService" /> gating the drag-and-drop move/create pipeline.
+        /// </summary>
+        private Mock<IPermissionService> permissionService;
+
+        /// <summary>
         /// The message bus used by the view model.
         /// </summary>
         private CDPMessageBus messageBus;
@@ -99,6 +106,11 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
             this.session = new Mock<ISession>();
             this.sessionService.Setup(x => x.Session).Returns(this.session.Object);
             this.sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            this.permissionService = new Mock<IPermissionService>();
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
 
             this.currentDomain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
             this.sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.currentDomain);
@@ -418,6 +430,235 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
             Assert.That(() => rootNode.Title != originalTitle && rootNode.Title == this.topElement.UserFriendlyName, Is.True.After(2000, 25),
                 "After EndUpdate, the ROOT node must reflect the renamed top ElementDefinition, " +
                 "not just the ElementUsage nodes below it.");
+        }
+
+        [Test]
+        public void VerifyMovingAUsageRepositionsItInTheProductTree()
+        {
+            var definitionA = new ElementDefinition { Iid = Guid.NewGuid(), Name = "DefA", ShortName = "DA", Owner = this.currentDomain };
+            var definitionB = new ElementDefinition { Iid = Guid.NewGuid(), Name = "DefB", ShortName = "DB", Owner = this.currentDomain };
+            var definitionC = new ElementDefinition { Iid = Guid.NewGuid(), Name = "DefC", ShortName = "DC", Owner = this.currentDomain };
+
+            var usageA = new ElementUsage { Iid = Guid.NewGuid(), Name = "UsageA", ShortName = "UA", ElementDefinition = definitionA, Owner = this.currentDomain };
+            var usageB = new ElementUsage { Iid = Guid.NewGuid(), Name = "UsageB", ShortName = "UB", ElementDefinition = definitionB, Owner = this.currentDomain };
+            var usageC = new ElementUsage { Iid = Guid.NewGuid(), Name = "UsageC", ShortName = "UC", ElementDefinition = definitionC, Owner = this.currentDomain };
+
+            this.topElement.ContainedElement.Add(usageA);
+            this.topElement.ContainedElement.Add(usageB);
+            definitionA.ContainedElement.Add(usageC);
+
+            this.iteration.Element.Add(definitionA);
+            this.iteration.Element.Add(definitionB);
+            this.iteration.Element.Add(definitionC);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            var tree = this.viewModel.ProductTreeViewModel;
+
+            Assert.That(() => tree.RootViewModel != null && tree.RootViewModel.GetFlatListOfDescendants(true).Any(n => n.Thing?.Iid == usageC.Iid),
+                Is.True.After(2000, 25),
+                "the initial load never drew the usage that is about to be moved");
+
+            // Precondition: usageC is drawn under usageA, which represents definitionA.
+            var initialParent = tree.RootViewModel.GetFlatListOfDescendants(true).First(n => n.Thing?.Iid == usageC.Iid).Parent.Thing;
+            Assert.That((initialParent as ElementUsage)?.ElementDefinition.Iid, Is.EqualTo(definitionA.Iid),
+                "usageC must initially sit under definitionA.");
+
+            var isLoadingValues = new List<bool>();
+            this.viewModel.WhenAnyValue(x => x.IsLoading).Subscribe(isLoadingValues.Add);
+
+            // Re-parent usageC from definitionA to definitionB, as ThingCreator.MoveElementUsageAsync and the server would.
+            definitionA.ContainedElement.Remove(usageC);
+            definitionB.ContainedElement.Add(usageC);
+
+            this.messageBus.SendObjectChangeEvent(usageC, EventKind.Updated);
+            this.messageBus.SendObjectChangeEvent(definitionA, EventKind.Updated);
+            this.messageBus.SendObjectChangeEvent(definitionB, EventKind.Updated);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+
+            Assert.That(() => isLoadingValues.Contains(true) && !this.viewModel.IsLoading, Is.True.After(2000, 25),
+                "the view model never signalled a re-render in reaction to the move");
+
+            Assert.That(() =>
+                {
+                    var node = tree.RootViewModel.GetFlatListOfDescendants(true).FirstOrDefault(n => n.Thing?.Iid == usageC.Iid);
+                    var parentThing = node?.Parent?.Thing;
+                    var parentDefinition = parentThing as ElementDefinition ?? (parentThing as ElementUsage)?.ElementDefinition;
+                    return parentDefinition?.Iid == definitionB.Iid;
+                },
+                Is.True.After(2000, 25),
+                "After the move + EndUpdate, the product tree must redraw usageC under definitionB, not leave it under definitionA.");
+        }
+
+        /// <summary>
+        /// Verifies that dropping an existing <see cref="ElementUsage" /> node onto a different
+        /// <see cref="ElementDefinition" /> node moves (re-parents) the existing usage, rather than creating a
+        /// brand-new usage of its referenced definition.
+        /// </summary>
+        [Test]
+        public async Task VerifyDroppingAnElementUsageMovesIt()
+        {
+            var referencedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.currentDomain
+            };
+
+            var targetElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Target",
+                ShortName = "TGT",
+                Owner = this.currentDomain
+            };
+
+            this.iteration.Element.Add(referencedElementDefinition);
+            this.iteration.Element.Add(targetElementDefinition);
+
+            var elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = referencedElementDefinition,
+                Owner = this.currentDomain
+            };
+
+            this.topElement.ContainedElement.Add(elementUsage);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.CurrentDomain != null, Is.True.After(2000, 25),
+                "the current domain must be resolved before the drop can be evaluated");
+
+            OperationContainer capturedOperationContainer = null;
+
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(operationContainer => capturedOperationContainer = operationContainer)
+                .Returns(Task.CompletedTask);
+
+            var fromNode = new SystemNodeViewModel(elementUsage);
+            var toNode = new SystemNodeViewModel(targetElementDefinition);
+
+            await this.viewModel.ProductTreeViewModel.OnDrop.InvokeAsync((fromNode, toNode));
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+
+            var modifiedIids = capturedOperationContainer.Operations.Select(x => x.ModifiedThing.Iid).ToList();
+
+            Assert.That(modifiedIids, Does.Contain(elementUsage.Iid),
+                "The existing usage's Iid must be part of the written operation, proving it was moved rather than re-created.");
+        }
+
+        /// <summary>
+        /// Verifies that dropping an <see cref="ElementDefinition" /> node onto a different
+        /// <see cref="ElementDefinition" /> node still creates a new <see cref="ElementUsage" /> of it.
+        /// </summary>
+        [Test]
+        public async Task VerifyDroppingAnElementDefinitionCreatesAUsage()
+        {
+            var draggedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.currentDomain
+            };
+
+            var targetElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Target",
+                ShortName = "TGT",
+                Owner = this.currentDomain
+            };
+
+            this.iteration.Element.Add(draggedElementDefinition);
+            this.iteration.Element.Add(targetElementDefinition);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.CurrentDomain != null, Is.True.After(2000, 25),
+                "the current domain must be resolved before the drop can be evaluated");
+
+            var fromNode = new SystemNodeViewModel(draggedElementDefinition);
+            var toNode = new SystemNodeViewModel(targetElementDefinition);
+
+            await this.viewModel.ProductTreeViewModel.OnDrop.InvokeAsync((fromNode, toNode));
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once,
+                "Dropping an ElementDefinition onto another one must still create a new ElementUsage.");
+        }
+
+        /// <summary>
+        /// Verifies that the drop is rejected, without ever writing, when the current user lacks write
+        /// permission on the target <see cref="ElementDefinition" />.
+        /// </summary>
+        [Test]
+        public async Task VerifyDropIsRejectedWithoutWritePermission()
+        {
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(false);
+
+            var referencedElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box",
+                ShortName = "BOX",
+                Owner = this.currentDomain
+            };
+
+            var targetElementDefinition = new ElementDefinition
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Target",
+                ShortName = "TGT",
+                Owner = this.currentDomain
+            };
+
+            this.iteration.Element.Add(referencedElementDefinition);
+            this.iteration.Element.Add(targetElementDefinition);
+
+            var elementUsage = new ElementUsage
+            {
+                Iid = Guid.NewGuid(),
+                Name = "Box1",
+                ShortName = "BOX1",
+                ElementDefinition = referencedElementDefinition,
+                Owner = this.currentDomain
+            };
+
+            this.topElement.ContainedElement.Add(elementUsage);
+
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Option 1", ShortName = "OPT1" };
+            this.iteration.Option.Add(option);
+            this.iteration.DefaultOption = option;
+
+            this.viewModel.CurrentThing = this.iteration;
+
+            Assert.That(() => this.viewModel.CurrentDomain != null, Is.True.After(2000, 25),
+                "the current domain must be resolved before the drop can be evaluated");
+
+            var fromNode = new SystemNodeViewModel(elementUsage);
+            var toNode = new SystemNodeViewModel(targetElementDefinition);
+
+            await this.viewModel.ProductTreeViewModel.OnDrop.InvokeAsync((fromNode, toNode));
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never,
+                "Without write permission on the target, the drop must be rejected client-side and never reach Write.");
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModelTestFixture.cs
@@ -95,10 +95,9 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
             Assert.That(SystemRepresentationTreeViewModel.CanDrop(unrelatedNode, rootNode), Is.True,
                 "Dropping an unrelated element node onto the root must be permitted.");
 
-            // Child node dropped onto the root (inverted — valid, no cycle) → true
-            Assert.That(SystemRepresentationTreeViewModel.CanDrop(childNode, rootNode), Is.True,
-                "Dropping a child node back onto the root is a valid operation.");
-            
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(childNode, rootNode), Is.False,
+                "Dropping a usage back onto the container it already sits in is a no-op and must be rejected.");
+
             var rootUsage = new ElementUsage { Iid = Guid.NewGuid(), Name = "RootUsage", ShortName = "RU", Owner = domain, ElementDefinition = rootDefinition };
             var rootUsageNode = new SystemNodeViewModel(rootUsage);
             var freshRootNode = new SystemNodeViewModel(rootDefinition);
@@ -122,6 +121,35 @@ namespace COMETwebapp.Tests.ViewModels.Components.SystemRepresentation
 
             Assert.That(SystemRepresentationTreeViewModel.CanDrop(unrelatedNode, danglingNode), Is.False,
                 "Dropping onto a usage node with no ElementDefinition must be rejected.");
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="SystemRepresentationTreeViewModel.CanDrop" /> rejects moving an existing
+        /// <see cref="ElementUsage" /> back onto the <see cref="ElementDefinition" /> that already contains it
+        /// (a no-op move), while still permitting the move onto an unrelated <see cref="ElementDefinition" />.
+        /// </summary>
+        [Test]
+        public void VerifyCanDropRejectsMovingAUsageOntoItsOwnContainer()
+        {
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS" };
+
+            var containerDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Container", ShortName = "CONT", Owner = domain };
+            var referencedDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Referenced", ShortName = "REF", Owner = domain };
+
+            var usage = new ElementUsage { Iid = Guid.NewGuid(), Name = "Usage", ShortName = "USG", Owner = domain, ElementDefinition = referencedDefinition };
+            containerDefinition.ContainedElement.Add(usage);
+
+            var usageNode = new SystemNodeViewModel(usage);
+            var containerNode = new SystemNodeViewModel(containerDefinition);
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(usageNode, containerNode), Is.False,
+                "Dropping a usage back onto the container it already sits in is a no-op and must be rejected.");
+
+            var unrelatedDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Unrelated", ShortName = "UNR", Owner = domain };
+            var unrelatedNode = new SystemNodeViewModel(unrelatedDefinition);
+
+            Assert.That(SystemRepresentationTreeViewModel.CanDrop(usageNode, unrelatedNode), Is.True,
+                "Dropping the same usage onto a different, unrelated ElementDefinition must be permitted.");
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -84,7 +84,7 @@
                     OnDrop="@(async x => await this.OnDropAsync(x))"
                     ShowOwner="@this.ShowOwner"
                     ShowCategories="@this.ShowCategories"
-                    AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel"
+                    AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel or ElementUsageTreeRowViewModel"
                     IsModelSelectionEnabled="true">
                 </ElementDefinitionTree>
             </div>
@@ -119,7 +119,7 @@
                     OnDrop="@(async x => await this.OnDropAsync(x))"
                     ShowOwner="@this.ShowOwner"
                     ShowCategories="@this.ShowCategories"
-                    AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel"
+                    AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel or ElementUsageTreeRowViewModel"
                     IsModelSelectionEnabled="false">
                 </ElementDefinitionTree>
             </div>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -226,21 +226,27 @@ namespace COMETwebapp.Components.ModelEditor
         {
             this.ErrorMessage = string.Empty;
 
-            if (this.DragObject.Item2 is not ElementDefinitionTreeRowViewModel elementDefinitionTreeRowViewModel)
+            if (this.DragObject.Item2 is null)
             {
                 return;
             }
 
             try
             {
-                if (nodeData.Item2 == null)
+                switch (this.DragObject.Item2, nodeData.Item2)
                 {
-                    // Drop in the same model
-                    await this.ViewModel.CopyAndAddNewElementAsync(nodeData.Item1, elementDefinitionTreeRowViewModel.ElementBase, nodeData.Item3.GetCopyOperationKind());
-                }
-                else
-                {
-                    await this.ViewModel.AddNewElementUsageAsync(elementDefinitionTreeRowViewModel.ElementBase, nodeData.Item2.ElementBase);
+                    case (ElementDefinitionTreeRowViewModel draggedDefinition, null):
+                        // Drop in the empty area of a tree: copy the ElementDefinition there.
+                        await this.ViewModel.CopyAndAddNewElementAsync(nodeData.Item1, draggedDefinition.ElementBase, nodeData.Item3.GetCopyOperationKind());
+                        break;
+                    case (ElementUsageTreeRowViewModel draggedUsage, ElementDefinitionTreeRowViewModel targetDefinition):
+                        // Move (re-parent) the existing usage under the target ElementDefinition.
+                        await this.ViewModel.MoveElementUsageAsync((ElementUsage)draggedUsage.ElementBase, (ElementDefinition)targetDefinition.ElementBase);
+                        break;
+                    case (ElementDefinitionTreeRowViewModel draggedDefinition, ElementDefinitionTreeRowViewModel targetDefinition):
+                        // Dragging a definition onto a node creates a fresh usage of it.
+                        await this.ViewModel.AddNewElementUsageAsync(draggedDefinition.ElementBase, targetDefinition.ElementBase);
+                        break;
                 }
             }
             catch (Exception ex)
@@ -298,47 +304,40 @@ namespace COMETwebapp.Components.ModelEditor
             var dragOverObject = this.DragOverObject;
             var dragObject = this.DragObject;
 
-            if (!elementDefinitionTree.AllowDrop)
+            if (!elementDefinitionTree.AllowDrop || dragObject == (null, null) || dragOverObject == dragObject || dragObject.Item2 is null)
             {
                 return false;
             }
 
-            if (dragObject == (null, null))
+            // Hovering a node: only an ElementDefinition node is a valid drop target (a usage node is not).
+            if (dragOverObject.Item2 is ElementBaseTreeRowViewModel)
             {
-                return false;
-            }
-
-            if (dragOverObject == dragObject)
-            {
-                return false;
-            }
-
-            if (dragOverObject.Item2 is ElementDefinitionTreeRowViewModel dragOverVm)
-            {
-                if (dragObject.Item2 is not ElementDefinitionTreeRowViewModel dragVm)
+                if (dragOverObject.Item2 is not ElementDefinitionTreeRowViewModel dragOverVm)
                 {
                     return false;
                 }
 
-                if (dragOverVm.ElementBase == dragVm.ElementBase)
+                var targetDefinition = (ElementDefinition)dragOverVm.ElementBase;
+
+                // Both a move and a create-usage are only allowed within a single iteration and with write permission.
+                if (dragObject.Item2.ElementBase.GetContainerOfType<Iteration>() != targetDefinition.GetContainerOfType<Iteration>()
+                    || !this.ViewModel.CanWriteElementUsage(targetDefinition))
                 {
                     return false;
                 }
 
-                if (dragOverVm.ElementBase.GetContainerOfType<Iteration>() == dragVm.ElementBase.GetContainerOfType<Iteration>())
+                return dragObject.Item2 switch
                 {
-                    return true;
-                }
-
-                return false;
+                    ElementUsageTreeRowViewModel usageRow => ((ElementUsage)usageRow.ElementBase).Container != targetDefinition
+                                                             && !((ElementUsage)usageRow.ElementBase).ElementDefinition.HasUsageOf(targetDefinition),
+                    ElementDefinitionTreeRowViewModel definitionRow => (ElementDefinition)definitionRow.ElementBase != targetDefinition
+                                                                       && !((ElementDefinition)definitionRow.ElementBase).HasUsageOf(targetDefinition),
+                    _ => false
+                };
             }
 
-            if (dragOverObject.Item1 == elementDefinitionTree)
-            {
-                return true;
-            }
-
-            return false;
+            // Hovering the empty area of a tree: only an ElementDefinition can be copied there.
+            return dragOverObject.Item1 == elementDefinitionTree && dragObject.Item2 is ElementDefinitionTreeRowViewModel;
         }
     }
 }

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationTree.razor.cs
@@ -26,6 +26,7 @@ namespace COMETwebapp.Components.SystemRepresentation
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
 
     using Microsoft.AspNetCore.Components;
+    using Microsoft.JSInterop;
 
     using ReactiveUI;
 
@@ -39,6 +40,43 @@ namespace COMETwebapp.Components.SystemRepresentation
         /// </summary>
         [Parameter]
         public SystemRepresentationTreeViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the injected <see cref="IJSRuntime" /> used to wire drag auto-scroll onto the tree container.
+        /// </summary>
+        [Inject]
+        public IJSRuntime JsRuntime { get; set; }
+
+        /// <summary>
+        /// Whether the "View" display-options dropdown is open.
+        /// </summary>
+        private bool viewMenuOpen;
+
+        /// <summary>
+        /// Wires the drag auto-scroll behaviour onto the tree's scroll container on first render, so a node dragged
+        /// towards the top or bottom edge scrolls out-of-view rows into reach. Tolerates the JS interop being
+        /// unavailable during pre-rendering or in tests.
+        /// </summary>
+        /// <param name="firstRender"><see langword="true" /> on the first render cycle.</param>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (!firstRender)
+            {
+                return;
+            }
+
+            try
+            {
+                await this.JsRuntime.InvokeVoidAsync("cometDragScroll.init", "product-tree-nodes-section");
+            }
+            catch (Exception)
+            {
+                // JS interop failures during pre-rendering or test environments are non-fatal.
+            }
+        }
 
         /// <summary>
         /// Method invoked when the component is ready to start, having received its

--- a/COMETwebapp/Pages/_Host.cshtml
+++ b/COMETwebapp/Pages/_Host.cshtml
@@ -108,5 +108,6 @@
         <script src="Scripts/utilities.js"></script>
         <script src="js/masonry.js"></script>
         <script src="js/columnResizer.js"></script>
+        <script src="js/dragScroll.js"></script>
     </body>
 </html>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/IModelEditorViewModel.cs
@@ -89,5 +89,22 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
         /// <param name="fromElementBase">The <see cref="ElementBase"/> to be added as <see cref="ElementUsage"/></param>
         /// <param name="toElementBase">The <see cref="ElementBase"/> where to add the new <see cref="ElementUsage"/> to</param>
         Task AddNewElementUsageAsync(ElementBase fromElementBase, ElementBase toElementBase);
+
+        /// <summary>
+        /// Move (re-parent) an existing <see cref="ElementUsage"/> under a target <see cref="ElementDefinition"/>,
+        /// keeping its <see cref="CDP4Common.CommonData.Thing.Iid"/>, name, owner, options and
+        /// <see cref="ElementUsage.ParameterOverride"/>s.
+        /// </summary>
+        /// <param name="elementUsage">The existing <see cref="ElementUsage"/> to move.</param>
+        /// <param name="targetContainer">The <see cref="ElementDefinition"/> that becomes the new container.</param>
+        Task MoveElementUsageAsync(ElementUsage elementUsage, ElementDefinition targetContainer);
+
+        /// <summary>
+        /// Determines whether the current user may write an <see cref="ElementUsage"/> into
+        /// <paramref name="targetContainer"/>, so a drop can be rejected client-side instead of failing on the server.
+        /// </summary>
+        /// <param name="targetContainer">The target container <see cref="ElementDefinition"/>.</param>
+        /// <returns><see langword="true"/> when the write is permitted; otherwise <see langword="false"/>.</returns>
+        bool CanWriteElementUsage(ElementDefinition targetContainer);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/ModelEditorViewModel.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.ViewModels.Components.ModelEditor
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using CDP4Dal;
@@ -271,6 +272,63 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor
                 {
                     this.IsLoading = false;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Move (re-parent) an existing <see cref="ElementUsage"/> under a target <see cref="ElementDefinition"/>,
+        /// keeping its <see cref="Thing.Iid"/>, name, owner, options and <see cref="ElementUsage.ParameterOverride"/>s.
+        /// </summary>
+        /// <param name="elementUsage">The existing <see cref="ElementUsage"/> to move.</param>
+        /// <param name="targetContainer">The <see cref="ElementDefinition"/> that becomes the new container.</param>
+        public Task MoveElementUsageAsync(ElementUsage elementUsage, ElementDefinition targetContainer)
+        {
+            ArgumentNullException.ThrowIfNull(elementUsage);
+            ArgumentNullException.ThrowIfNull(targetContainer);
+
+            return this.MoveElementUsageImplAsync(elementUsage, targetContainer);
+        }
+
+        /// <summary>
+        /// Determines whether the current user may write an <see cref="ElementUsage"/> into
+        /// <paramref name="targetContainer"/>, so the drop can be rejected client-side instead of failing on the server.
+        /// </summary>
+        /// <param name="targetContainer">The target container <see cref="ElementDefinition"/>.</param>
+        /// <returns><see langword="true"/> when the write is permitted; otherwise <see langword="false"/>.</returns>
+        public bool CanWriteElementUsage(ElementDefinition targetContainer)
+        {
+            ArgumentNullException.ThrowIfNull(targetContainer);
+
+            return this.sessionService.Session.PermissionService.CanWrite(ClassKind.ElementUsage, targetContainer);
+        }
+
+        /// <summary>
+        /// Move (re-parent) an existing <see cref="ElementUsage"/> under a target <see cref="ElementDefinition"/>.
+        /// Silently refuses the move when it would cross iterations, is a no-op (already contained), would introduce a
+        /// containment cycle, or the user lacks write permission on the target.
+        /// </summary>
+        /// <param name="elementUsage">The existing <see cref="ElementUsage"/> to move.</param>
+        /// <param name="targetContainer">The <see cref="ElementDefinition"/> that becomes the new container.</param>
+        private async Task MoveElementUsageImplAsync(ElementUsage elementUsage, ElementDefinition targetContainer)
+        {
+            if (elementUsage.GetContainerOfType<Iteration>() != targetContainer.GetContainerOfType<Iteration>()
+                || elementUsage.Container == targetContainer
+                || elementUsage.ElementDefinition.HasUsageOf(targetContainer)
+                || !this.CanWriteElementUsage(targetContainer))
+            {
+                return;
+            }
+
+            this.IsLoading = true;
+
+            try
+            {
+                var thingCreator = new ThingCreator();
+                await thingCreator.MoveElementUsageAsync(elementUsage, targetContainer, this.sessionService.Session);
+            }
+            finally
+            {
+                this.IsLoading = false;
             }
         }
 

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationBodyViewModel.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.ViewModels.Components.SystemRepresentation
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -161,21 +162,28 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         }
 
         /// <summary>
-        /// Handles a drop event raised by the product tree: creates a new <see cref="ElementUsage" /> of the
-        /// dragged node's <see cref="ElementDefinition" /> under the target node's
-        /// <see cref="ElementDefinition" />.
+        /// Handles a drop event raised by the product tree. When the dragged node is an existing
+        /// <see cref="ElementUsage" /> it is <b>moved</b> (re-parented) under the target node's
+        /// <see cref="ElementDefinition" />, keeping its <see cref="Thing.Iid" />, name, owner, options and
+        /// <see cref="ElementUsage.ParameterOverride" />s. When the dragged node is an
+        /// <see cref="ElementDefinition" /> a fresh <see cref="ElementUsage" /> of it is created under the target
+        /// instead. The drop is rejected when the current user lacks write permission on the target.
         /// </summary>
         /// <param name="args">
         /// A tuple whose <c>From</c> member is the dragged <see cref="SystemNodeViewModel" /> and whose
         /// <c>To</c> member is the drop-target <see cref="SystemNodeViewModel" />.
         /// </param>
-        /// <returns>A <see cref="Task" /> representing the asynchronous create operation.</returns>
+        /// <returns>A <see cref="Task" /> representing the asynchronous move or create operation.</returns>
         private async Task OnElementDroppedAsync((SystemNodeViewModel From, SystemNodeViewModel To) args)
         {
-            var fromDefinition = args.From.Thing as ElementDefinition ?? (args.From.Thing as ElementUsage)?.ElementDefinition;
             var toDefinition = args.To.Thing as ElementDefinition ?? (args.To.Thing as ElementUsage)?.ElementDefinition;
 
-            if (fromDefinition is null || toDefinition is null || this.CurrentDomain is null)
+            if (toDefinition is null || this.CurrentDomain is null)
+            {
+                return;
+            }
+
+            if (!this.SessionService.Session.PermissionService.CanWrite(ClassKind.ElementUsage, toDefinition))
             {
                 return;
             }
@@ -185,11 +193,20 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
             try
             {
                 var thingCreator = new ThingCreator();
-                await thingCreator.CreateElementUsageAsync(toDefinition, fromDefinition, this.CurrentDomain, this.SessionService.Session);
+
+                switch (args.From.Thing)
+                {
+                    case ElementUsage usage:
+                        await thingCreator.MoveElementUsageAsync(usage, toDefinition, this.SessionService.Session);
+                        break;
+                    case ElementDefinition fromDefinition:
+                        await thingCreator.CreateElementUsageAsync(toDefinition, fromDefinition, this.CurrentDomain, this.SessionService.Session);
+                        break;
+                }
             }
             catch (Exception exception)
             {
-                this.logger.LogError(exception, "An error occurred while creating an Element Usage of '{From}' under '{To}' from a drag-and-drop operation", fromDefinition.ShortName, toDefinition.ShortName);
+                this.logger.LogError(exception, "An error occurred while moving or creating an Element Usage under '{To}' from a drag-and-drop operation", toDefinition.ShortName);
             }
             finally
             {
@@ -291,7 +308,12 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
                 return excluded == drawnUsageIids.Contains(usage.Iid);
             });
 
-            if (optionMembershipChanged)
+            // A re-parented (moved) usage arrives as an Update with a changed Container: the tree node still sits under
+            // its old parent, and updating it in place would not move it. Detect that and rebuild the whole tree, which
+            // reconstructs the structure from the actual containment (and preserves the expansion state).
+            var usageMoved = updatedElements.Any(this.HasUsageMovedInTree);
+
+            if (optionMembershipChanged || usageMoved)
             {
                 this.ApplyFilters();
             }
@@ -305,6 +327,27 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
 
             this.ClearRecordedChanges();
             this.IsLoading = false;
+        }
+
+        /// <summary>
+        /// Determines whether the given <see cref="ElementUsage" /> is drawn in the product tree under a parent node
+        /// whose <see cref="ElementDefinition" /> no longer matches the usage's current <see cref="ElementUsage.Container" />,
+        /// which is the signature of a re-parent (move).
+        /// </summary>
+        /// <param name="usage">The updated <see cref="ElementUsage" /> to test.</param>
+        /// <returns><see langword="true" /> when a drawn node for the usage sits under the wrong parent; otherwise <see langword="false" />.</returns>
+        private bool HasUsageMovedInTree(ElementUsage usage)
+        {
+            var drawnNodes = this.ProductTreeViewModel.RootViewModel?.GetFlatListOfDescendants(true)
+                .Where(node => node.Thing != null && node.Thing.Iid == usage.Iid);
+
+            return drawnNodes?.Any(node =>
+            {
+                var parentThing = node.Parent?.Thing;
+                var parentDefinition = parentThing as ElementDefinition ?? (parentThing as ElementUsage)?.ElementDefinition;
+
+                return parentDefinition != null && parentDefinition != usage.Container;
+            }) ?? false;
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SystemRepresentation/SystemRepresentationTreeViewModel.cs
@@ -103,12 +103,13 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
         /// Determines whether <paramref name="from" /> may be dropped onto <paramref name="to" />.
         /// The drop is rejected when either argument is <see langword="null" />, the two nodes are
         /// the same instance, either node's <see cref="COMETwebapp.ViewModels.Components.Shared.BaseNodeViewModel{T}.Thing" />
-        /// is not an <see cref="ElementBase" />, or it would introduce a containment cycle. A drop creates a new
-        /// <see cref="ElementUsage" /> of <paramref name="from" />'s <see cref="ElementDefinition" /> inside
-        /// <paramref name="to" />'s <see cref="ElementDefinition" />, so the comparison is made by
+        /// is not an <see cref="ElementBase" />, or it would introduce a containment cycle. A drop either moves an
+        /// existing <see cref="ElementUsage" /> under <paramref name="to" />'s <see cref="ElementDefinition" /> or
+        /// creates a new usage of the dragged <see cref="ElementDefinition" /> there, so the comparison is made by
         /// <see cref="ElementDefinition" /> (not by tree-node instance): the drop is refused when the target's
-        /// definition is the dragged definition itself or is already (transitively) contained by it. This also
-        /// catches dropping a definition onto a separate node that represents that same definition.
+        /// definition is the dragged definition itself or is already (transitively) contained by it, and a move onto
+        /// the container the dragged usage already sits in is likewise refused. This also catches dropping a
+        /// definition onto a separate node that represents that same definition.
         /// </summary>
         /// <param name="from">The node being dragged.</param>
         /// <param name="to">The node being dropped onto.</param>
@@ -128,6 +129,12 @@ namespace COMETwebapp.ViewModels.Components.SystemRepresentation
             var toDefinition = GetElementDefinition(to);
 
             if (toDefinition is null)
+            {
+                return false;
+            }
+
+            // Moving an existing usage onto the container it already sits in is a no-op, so it is rejected.
+            if (from.Thing is ElementUsage draggedUsage && draggedUsage.Container == toDefinition)
             {
                 return false;
             }

--- a/COMETwebapp/wwwroot/js/dragScroll.js
+++ b/COMETwebapp/wwwroot/js/dragScroll.js
@@ -1,0 +1,112 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="dragScroll.js" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+(function () {
+    'use strict';
+
+    const cometDragScroll = {
+        /**
+         * Computes the vertical auto-scroll velocity while a drag is in progress, so a node dragged towards the top or
+         * bottom edge of a scroll container brings the out-of-view rows into reach. Returns a negative velocity (scroll
+         * up) when the pointer is within edge px of the top, a positive one (scroll down) when within edge px of the
+         * bottom, and 0 in between. Kept free of DOM globals (the rect is passed in) so it is unit testable with
+         * node:test - see COMETwebapp.Tests/Javascript/dragScroll.test.js.
+         * @param {DOMRect} rect  - The bounding rectangle of the scroll container.
+         * @param {number} clientY - The pointer's Y coordinate (e.g. from a dragover event).
+         * @param {number} edge   - The distance, in pixels, from an edge within which scrolling is triggered.
+         * @param {number} speed  - The scroll step, in pixels, applied each animation frame.
+         * @returns {number} The signed scroll velocity in pixels per frame.
+         */
+        computeScrollVelocity: function (rect, clientY, edge, speed) {
+            if (clientY < rect.top + edge) {
+                return -speed;
+            }
+
+            if (clientY > rect.bottom - edge) {
+                return speed;
+            }
+
+            return 0;
+        },
+
+        /**
+         * Wires drag auto-scroll onto a scroll container. While a drag hovers near the top or bottom edge the container
+         * keeps scrolling (via requestAnimationFrame) until the pointer leaves the edge or the drag ends.
+         * @param {string} containerId - The id of the scroll container element.
+         * @param {number} [edge]      - Distance from an edge that triggers scrolling. Defaults to 40px.
+         * @param {number} [speed]     - Scroll step per frame. Defaults to 12px.
+         */
+        init: function (containerId, edge, speed) {
+            const container = document.getElementById(containerId);
+
+            if (!container || container._cometDragScrollInitialised) {
+                return;
+            }
+
+            container._cometDragScrollInitialised = true;
+            edge = edge || 40;
+            speed = speed || 12;
+
+            let velocity = 0;
+            let frame = null;
+
+            function step() {
+                if (velocity === 0) {
+                    frame = null;
+                    return;
+                }
+
+                container.scrollTop += velocity;
+                frame = window.requestAnimationFrame(step);
+            }
+
+            function stop() {
+                velocity = 0;
+            }
+
+            container.addEventListener('dragover', function (e) {
+                velocity = cometDragScroll.computeScrollVelocity(container.getBoundingClientRect(), e.clientY, edge, speed);
+
+                if (velocity !== 0 && frame === null) {
+                    frame = window.requestAnimationFrame(step);
+                }
+            });
+
+            container.addEventListener('dragleave', function (e) {
+                if (e.target === container) {
+                    stop();
+                }
+            });
+
+            container.addEventListener('drop', stop);
+            container.addEventListener('dragend', stop);
+        }
+    };
+
+    if (typeof window !== 'undefined') {
+        window.cometDragScroll = cometDragScroll;
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = cometDragScroll;
+    }
+})();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #830 Move/re-parent an existing ElementUsage in Model Editor & System Representation

### What
Drag-drop now moves (re-parents) an existing `ElementUsage` instead of always creating a fresh one. The behaviour is decided by what you drag: dragging a usage moves it, dragging a definition still creates a new usage. The move keeps the usage's `Iid`, name, owner, options and all `ParameterOverride`s.

### Changes
- **Shared:** new `ThingCreator.MoveElementUsageAsync(usage, target, session)` re-parents in one transaction (clone target + usage, add the usage clone to the target's `ContainedElement`, write only the new container so the server re-parents it and drops it from the old one).
- **System Representation:** drop now branches on payload type (usage to move, definition to create); removed the old "create a fresh usage from the dragged node's definition" behaviour. Added drag auto-scroll so the tree scrolls when you drag near the top or bottom edge (new `wwwroot/js/dragScroll.js`).
- **Model Editor:** usage rows are now draggable; dropping a usage onto a different definition moves it. `CalculateDropIsAllowed` now also enforces the containment-cycle guard (`ElementDefinition.HasUsageOf`) and a client-side write-permission check, fixing the reported cycle bug.
- **Guards (both views):** write permission on the target, same iteration only, reject if already contained, reject containment cycles.
- **Product-tree refresh fix:** a move arrives as an `Updated` event (only the `Container` changes), so the System Representation tree updated the node in place but never re-homed it, and the change only showed after a manual refresh. `RefreshProductTree` now detects a re-parented usage and rebuilds the tree (preserving expansion state). The Model Editor tree already handled this via its container-row refresh.
