### PR TITLE
Fix #838 Remove unused 'using DevExpress.Blazor' from ShowHideDeprecatedThingsService

### DIFF
--- a/COMETwebapp/Services/ShowHideDeprecatedThingsService/IShowHideDeprecatedThingsService.cs
+++ b/COMETwebapp/Services/ShowHideDeprecatedThingsService/IShowHideDeprecatedThingsService.cs
@@ -20,8 +20,6 @@
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
-using DevExpress.Blazor;
-
 namespace COMETwebapp.Services.ShowHideDeprecatedThingsService
 {
     /// <summary>

--- a/COMETwebapp/Services/ShowHideDeprecatedThingsService/ShowHideDeprecatedThingsService.cs
+++ b/COMETwebapp/Services/ShowHideDeprecatedThingsService/ShowHideDeprecatedThingsService.cs
@@ -22,8 +22,6 @@
 
 namespace COMETwebapp.Services.ShowHideDeprecatedThingsService
 {
-    using DevExpress.Blazor;
-
     using ReactiveUI;
 
     /// <summary>


### PR DESCRIPTION
Fixes #838

Both `IShowHideDeprecatedThingsService` and `ShowHideDeprecatedThingsService` declared `using DevExpress.Blazor;` without referencing anything from that namespace. A service-layer type should not carry a UI component library import.

### Changes

- `IShowHideDeprecatedThingsService.cs` - removed the `using` (which also sat above the namespace, contrary to the CONTRIBUTING.md style rule)
- `ShowHideDeprecatedThingsService.cs` - removed the `using`, leaving `ReactiveUI` as the sole import

No behaviour, signature or DI-registration changes.

### Verification

- `dotnet build COMETwebapp.sln` - build succeeded, 0 errors
- `dotnet test COMETwebapp.sln --no-build --filter FullyQualifiedName!~IntegrationTests` - 1121 passed, 0 failed (252 COMET.Web.Common.Tests + 869 COMETwebapp.Tests)