### PR TITLE
Fix #835 Remove the unused BlazorStrap dependency

### DIFF
--- a/COMETwebapp/COMETwebapp.csproj
+++ b/COMETwebapp/COMETwebapp.csproj
@@ -28,7 +28,6 @@
 
     <ItemGroup>
         <PackageReference Include="AntDesign" Version="1.6.2" />
-        <PackageReference Include="BlazorStrap" Version="5.2.104" />
         <PackageReference Include="ClosedXML" Version="0.105.0" />
         <PackageReference Include="Feather.Blazor" Version="1.0.1" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/COMETwebapp/_Imports.razor
+++ b/COMETwebapp/_Imports.razor
@@ -33,7 +33,6 @@
 @using COMETwebapp.ViewModels.Components.SiteDirectory.Rows
 @using COMETwebapp.ViewModels.Components.ReferenceData.Rows
 @using COMETwebapp.ViewModels.Components.EngineeringModel.Rows
-@using BlazorStrap
 @using DevExpress.Blazor
 @using COMET.Web.Common.Components
 @using COMET.Web.Common.Components.Applications

--- a/NOTICE
+++ b/NOTICE
@@ -54,8 +54,6 @@ COMETwebapp (AGPL-3.0-only)
 
     AntDesign                                       MIT
         https://github.com/ant-design-blazor/ant-design-blazor
-    BlazorStrap                                     MIT
-        https://github.com/Blazor-Bootstrap/BlazorStrap
     ClosedXML                                       MIT
         https://github.com/ClosedXML/ClosedXML
     Feather.Blazor                                  MIT


### PR DESCRIPTION
Fixes #835

`BlazorStrap` was declared as a `PackageReference` and globally imported in `_Imports.razor`, but a repository-wide search finds no BlazorStrap component tag (`<BS...>`) and no use of the `BlazorStrap.` namespace. The package was restored, built against and shipped for nothing.

### Changes

- `COMETwebapp/COMETwebapp.csproj` - removed `<PackageReference Include=BlazorStrap Version=5.2.104 />`
- `COMETwebapp/_Imports.razor` - removed `@using BlazorStrap`
- `NOTICE` - removed the BlazorStrap third-party attribution entry (**beyond the issue task list**: the attribution is stale once the package is no longer shipped. Say the word if you would rather keep it separate.)

### Verification

- `dotnet build COMETwebapp.sln` - build succeeded, 0 errors
- `dotnet test COMETwebapp.sln --no-build --filter FullyQualifiedName!~IntegrationTests` - 1121 passed, 0 failed
- `dotnet list COMETwebapp.sln package --include-transitive` - no BlazorStrap entry remains, including transitively

### Note on a flaky test

`ViewerBodyViewModelTestFixture.VerifyOnSessionRefreshed` failed intermittently during verification. It is unrelated to this change - it depends on a fixed `await Task.Delay(200)` (line 185) for async Babylon interop calls to land, so it fails under load. It passed 5/5 on both `development` and this branch when re-run. Might be worth its own issue.