### PR TITLE
Fix #839 Stop AssemblyVersion/FileVersion drifting from the package Version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,6 +49,12 @@ When you're ready to go you should confirm that you are up to date and rebased w
 
 And remember; **A pull-request with tests is a pull-request that's likely to be pulled in.** :grin: Bonus points if you document your feature in our [wiki](https://github.com/RHEAGROUP/COMET-WEB-Community-Edition/wiki) once it has been pulled in
 
+## Versioning Policy
+
+Packable projects (currently `COMET.Web.Common` and `COMET.Web.Common.Test`, published to NuGet as `CDP4.WEB.Common` and `CDP4.WEB.Common.Test`) declare only `<Version>` in their `.csproj`. Do **not** add explicit `<AssemblyVersion>` or `<FileVersion>` — MSBuild derives both from `Version` automatically, which keeps the assembly's strong identity, the file-properties version, and the NuGet package version in lockstep by construction. An assembly and file version that silently drifts from the package version defeats diagnostics: crash dumps, logs and `dotnet --info`-style tooling all report the (wrong) frozen number, and two functionally different releases become indistinguishable to the loader.
+
+When cutting a release that bumps `Version` on a packable project, call out the change in that package's `PackageReleaseNotes`.
+
 ## Style Guidelines
 
 - Indent with 4 spaces, **not** tabs.

--- a/COMET.Web.Common.Test/COMET.Web.Common.Test.csproj
+++ b/COMET.Web.Common.Test/COMET.Web.Common.Test.csproj
@@ -5,9 +5,10 @@
       <LangVersion>Latest</LangVersion>
       <ImplicitUsings>enable</ImplicitUsings>
       <Title>CDP4 WEB Common Test</Title>
+      <!-- AssemblyVersion and FileVersion are intentionally not set here: MSBuild derives
+           both from Version, keeping the assembly's strong identity and file-properties
+           version in lockstep with the package version by construction. -->
       <Version>8.1.0</Version>
-      <AssemblyVersion>5.2.0</AssemblyVersion>
-      <FileVersion>5.2.0</FileVersion>
       <Description>A Common Library that includes DevExpress Blazor and Tasks test helpers</Description>
       <Company>Starion Group S.A.</Company>
       <Copyright>Copyright 2023-2025 Starion Group S.A.</Copyright>

--- a/COMET.Web.Common.Test/COMET.Web.Common.Test.csproj
+++ b/COMET.Web.Common.Test/COMET.Web.Common.Test.csproj
@@ -5,9 +5,6 @@
       <LangVersion>Latest</LangVersion>
       <ImplicitUsings>enable</ImplicitUsings>
       <Title>CDP4 WEB Common Test</Title>
-      <!-- AssemblyVersion and FileVersion are intentionally not set here: MSBuild derives
-           both from Version, keeping the assembly's strong identity and file-properties
-           version in lockstep with the package version by construction. -->
       <Version>8.1.0</Version>
       <Description>A Common Library that includes DevExpress Blazor and Tasks test helpers</Description>
       <Company>Starion Group S.A.</Company>

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
-    <!-- AssemblyVersion and FileVersion are intentionally not set here: MSBuild derives
-         both from Version, keeping the assembly's strong identity and file-properties
-         version in lockstep with the package version by construction. -->
     <Version>8.1.0</Version>
     <Title>CDP4 WEB Common</Title>
     <Description>A Common Library for any Blazor based application related to ECSS-E-TM-10-25</Description>

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
+    <!-- AssemblyVersion and FileVersion are intentionally not set here: MSBuild derives
+         both from Version, keeping the assembly's strong identity and file-properties
+         version in lockstep with the package version by construction. -->
     <Version>8.1.0</Version>
-    <AssemblyVersion>6.3.0</AssemblyVersion>
-    <FileVersion>6.3.0</FileVersion>
     <Title>CDP4 WEB Common</Title>
     <Description>A Common Library for any Blazor based application related to ECSS-E-TM-10-25</Description>
     <Company>Starion Group S.A.</Company>


### PR DESCRIPTION
Fixes #839

`COMET.Web.Common` and `COMET.Web.Common.Test` each pinned `AssemblyVersion`/`FileVersion` to a literal that had frozen while `Version` moved on — 6.3.0 and 5.2.0 respectively, against a shipped package version of 8.1.0. `AssemblyVersion` is part of the assembly's strong identity, so two functionally different releases were indistinguishable to the loader, and crash dumps / logs / Windows file properties all reported the stale number.

## Policy decided

The issue offered two options: align all three fields, or adopt `AssemblyVersion = <major>.0.0.0` with `FileVersion` carrying the full version. The major-only convention exists to avoid forcing binding redirects on consumers of strong-named, GAC-style assemblies. Neither project is signed/strong-named here — they're Razor class libraries consumed via `PackageReference` — so that rationale doesn't apply, and the issue's actual pain point (diagnostics reporting an inaccurate version) argues for full alignment instead.

**Chosen approach:** remove the explicit `AssemblyVersion`/`FileVersion` overrides entirely, rather than just setting matching literals. MSBuild derives both from `Version` by default, so there is nothing left to remember to bump on release — the values cannot drift again by construction, closing off the exact failure mode that produced this issue.

Documented in `.github/CONTRIBUTING.md` under a new **Versioning Policy** section, satisfying the issue's "record the decision" task.

## Verification

- Confirmed MSBuild's default derivation behavior on a throwaway project before relying on it: `Version=8.1.0` alone produces `AssemblyVersion=8.1.0.0` and `FileVersion=8.1.0.0`
- `dotnet build` — succeeded, 0 errors
- `dotnet pack` both projects, then **extracted the produced `.nupkg` files and inspected the actual built DLLs** (not just that packing succeeded): `COMET.Web.Common.dll` and `COMET.Web.Common.Test.dll` both report `AssemblyVersion=8.1.0.0`, `FileVersion=8.1.0.0`, matching the `8.1.0` package version
- `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 1121 passed, 0 failed
- Grepped all `*.csproj` for `AssemblyVersion`/`FileVersion` — no project sets them anymore; the two changed files are the only place they were ever set

## Outstanding: release notes

The issue's third acceptance criterion — "called out in the next release notes" — isn't done here. `PackageReleaseNotes` in both `.csproj` files is currently empty and gets filled at actual release time via the manual `release.bat` process (per CLAUDE.md, NuGet releases are not automated). Filling it now would just get overwritten or go stale before the next real release. Flagging so whoever cuts the next release remembers to mention this fix.
