### PR TITLE
Fix #843, #840 ViewModels should not reference UI component library types

### DIFF
--- a/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
+++ b/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
@@ -1,0 +1,56 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CometButtonStyleExtensionsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//   --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Extensions
+{
+    using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Extensions;
+
+    using DevExpress.Blazor;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CometButtonStyleExtensions" /> class.
+    /// </summary>
+    [TestFixture]
+    public class CometButtonStyleExtensionsTestFixture
+    {
+        [Test]
+        public void VerifyToButtonRenderStyle()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(CometButtonStyle.Primary.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Primary));
+                Assert.That(CometButtonStyle.Secondary.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Secondary));
+                Assert.That(CometButtonStyle.Danger.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Danger));
+                Assert.That(CometButtonStyle.Success.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Success));
+                Assert.That(CometButtonStyle.Warning.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Warning));
+                Assert.That(CometButtonStyle.Info.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Info));
+                Assert.That(CometButtonStyle.Light.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Light));
+                Assert.That(CometButtonStyle.Dark.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Dark));
+                Assert.That(CometButtonStyle.Link.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Link));
+                Assert.That(((CometButtonStyle)99).ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Primary));
+            }
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/ViewModels/Components/ConfirmCancelPopupViewModelTestFixture.cs
+++ b/COMET.Web.Common.Tests/ViewModels/Components/ConfirmCancelPopupViewModelTestFixture.cs
@@ -1,0 +1,80 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ConfirmCancelPopupViewModelTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//   --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.ViewModels.Components
+{
+    using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.ViewModels.Components;
+
+    using NUnit.Framework;
+
+#pragma warning disable CS0618
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ConfirmCancelPopupViewModel" /> class.
+    /// </summary>
+    [TestFixture]
+    public class ConfirmCancelPopupViewModelTestFixture
+    {
+        private ConfirmCancelPopupViewModel viewModel;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.viewModel = new ConfirmCancelPopupViewModel();
+        }
+
+        [Test]
+        public void VerifyProperties()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.CancelStyle, Is.EqualTo(CometButtonStyle.Secondary));
+                Assert.That(this.viewModel.ConfirmStyle, Is.EqualTo(CometButtonStyle.Primary));
+                Assert.That(this.viewModel.CancelRenderStyle, Is.EqualTo(CometButtonStyle.Secondary));
+                Assert.That(this.viewModel.ConfirmRenderStyle, Is.EqualTo(CometButtonStyle.Primary));
+                Assert.That(this.viewModel.HeaderText, Is.EqualTo("Please confirm"));
+                Assert.That(this.viewModel.IsVisible, Is.False);
+            }
+
+            this.viewModel.CancelStyle = CometButtonStyle.Danger;
+            this.viewModel.ConfirmStyle = CometButtonStyle.Success;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.CancelStyle, Is.EqualTo(CometButtonStyle.Danger));
+                Assert.That(this.viewModel.ConfirmStyle, Is.EqualTo(CometButtonStyle.Success));
+                Assert.That(this.viewModel.CancelRenderStyle, Is.EqualTo(CometButtonStyle.Danger));
+                Assert.That(this.viewModel.ConfirmRenderStyle, Is.EqualTo(CometButtonStyle.Success));
+            }
+
+            this.viewModel.CancelRenderStyle = CometButtonStyle.Warning;
+            this.viewModel.ConfirmRenderStyle = CometButtonStyle.Info;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.CancelStyle, Is.EqualTo(CometButtonStyle.Warning));
+                Assert.That(this.viewModel.ConfirmStyle, Is.EqualTo(CometButtonStyle.Info));
+            }
+        }
+    }
+}

--- a/COMET.Web.Common/COMET.Web.Common.csproj
+++ b/COMET.Web.Common/COMET.Web.Common.csproj
@@ -23,6 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReleaseNotes>
+      Breaking change: Replaced ButtonRenderStyle references in ViewModels with presentation-agnostic CometButtonStyle enum (CancelStyle and ConfirmStyle properties on IConfirmCancelPopupViewModel). CancelRenderStyle and ConfirmRenderStyle are marked Obsolete.
     </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/COMET.Web.Common/Components/ConfirmCancelPopup.razor
+++ b/COMET.Web.Common/Components/ConfirmCancelPopup.razor
@@ -1,4 +1,4 @@
-﻿<!------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------
 // Copyright (c) 2023-2026 Starion Group S.A.
 //
 //   This file is part of CDP4-COMET WEB Community Edition
@@ -26,8 +26,8 @@
 	</Content>
 	<FooterTemplate>
 		<div class="modal-footer">
-			<DxButton Text="Cancel" RenderStyle="@this.ViewModel.CancelRenderStyle" Click="@this.ViewModel.OnCancel" Enabled="this.buttonsEnabled"/>
-			<DxButton Text="Confirm" RenderStyle="@this.ViewModel.ConfirmRenderStyle" Click="@this.OnConfirmClicked" Enabled="this.buttonsEnabled"/>
+			<DxButton Text="Cancel" RenderStyle="@this.ViewModel.CancelStyle.ToButtonRenderStyle()" Click="@this.ViewModel.OnCancel" Enabled="this.buttonsEnabled"/>
+			<DxButton Text="Confirm" RenderStyle="@this.ViewModel.ConfirmStyle.ToButtonRenderStyle()" Click="@this.OnConfirmClicked" Enabled="this.buttonsEnabled"/>
 		</div>
 	</FooterTemplate>
 </DxPopup>

--- a/COMET.Web.Common/Enumerations/CometButtonStyle.cs
+++ b/COMET.Web.Common/Enumerations/CometButtonStyle.cs
@@ -1,0 +1,76 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CometButtonStyle.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Enumerations
+{
+    /// <summary>
+    /// Represents the style intent of a button component in COMET WEB applications.
+    /// </summary>
+    public enum CometButtonStyle
+    {
+        /// <summary>
+        /// Primary button style intent.
+        /// </summary>
+        Primary = 0,
+
+        /// <summary>
+        /// Secondary button style intent.
+        /// </summary>
+        Secondary = 1,
+
+        /// <summary>
+        /// Danger button style intent.
+        /// </summary>
+        Danger = 2,
+
+        /// <summary>
+        /// Success button style intent.
+        /// </summary>
+        Success = 3,
+
+        /// <summary>
+        /// Warning button style intent.
+        /// </summary>
+        Warning = 4,
+
+        /// <summary>
+        /// Info button style intent.
+        /// </summary>
+        Info = 5,
+
+        /// <summary>
+        /// Light button style intent.
+        /// </summary>
+        Light = 6,
+
+        /// <summary>
+        /// Dark button style intent.
+        /// </summary>
+        Dark = 7,
+
+        /// <summary>
+        /// Link button style intent.
+        /// </summary>
+        Link = 8
+    }
+}

--- a/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
+++ b/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
@@ -1,0 +1,57 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CometButtonStyleExtensions.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Extensions
+{
+    using COMET.Web.Common.Enumerations;
+
+    using DevExpress.Blazor;
+
+    /// <summary>
+    /// Extension methods for <see cref="CometButtonStyle" />
+    /// </summary>
+    public static class CometButtonStyleExtensions
+    {
+        /// <summary>
+        /// Maps a <see cref="CometButtonStyle" /> to the corresponding <see cref="ButtonRenderStyle" />.
+        /// </summary>
+        /// <param name="style">The <see cref="CometButtonStyle" /> to map.</param>
+        /// <returns>The mapped <see cref="ButtonRenderStyle" />.</returns>
+        public static ButtonRenderStyle ToButtonRenderStyle(this CometButtonStyle style)
+        {
+            return style switch
+            {
+                CometButtonStyle.Primary => ButtonRenderStyle.Primary,
+                CometButtonStyle.Secondary => ButtonRenderStyle.Secondary,
+                CometButtonStyle.Danger => ButtonRenderStyle.Danger,
+                CometButtonStyle.Success => ButtonRenderStyle.Success,
+                CometButtonStyle.Warning => ButtonRenderStyle.Warning,
+                CometButtonStyle.Info => ButtonRenderStyle.Info,
+                CometButtonStyle.Light => ButtonRenderStyle.Light,
+                CometButtonStyle.Dark => ButtonRenderStyle.Dark,
+                CometButtonStyle.Link => ButtonRenderStyle.Link,
+                _ => ButtonRenderStyle.Primary
+            };
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/ConfirmCancelPopupViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/ConfirmCancelPopupViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ConfirmCancelPopupViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -23,7 +23,9 @@
 
 namespace COMET.Web.Common.ViewModels.Components
 {
-    using DevExpress.Blazor;
+    using System;
+
+    using COMET.Web.Common.Enumerations;
 
     using Microsoft.AspNetCore.Components;
 
@@ -59,14 +61,34 @@ namespace COMET.Web.Common.ViewModels.Components
         public EventCallback OnConfirm { get; set; }
 
         /// <summary>
-        /// The <see cref="ButtonRenderStyle" /> to apply for the Cancel button
+        /// The <see cref="CometButtonStyle" /> to apply for the Cancel button
         /// </summary>
-        public ButtonRenderStyle CancelRenderStyle { get; set; } = ButtonRenderStyle.Secondary;
+        public CometButtonStyle CancelStyle { get; set; } = CometButtonStyle.Secondary;
 
         /// <summary>
-        /// The <see cref="ButtonRenderStyle" /> to apply for the Confirm button
+        /// The <see cref="CometButtonStyle" /> to apply for the Confirm button
         /// </summary>
-        public ButtonRenderStyle ConfirmRenderStyle { get; set; } = ButtonRenderStyle.Primary;
+        public CometButtonStyle ConfirmStyle { get; set; } = CometButtonStyle.Primary;
+
+        /// <summary>
+        /// The <see cref="CometButtonStyle" /> to apply for the Cancel button
+        /// </summary>
+        [Obsolete("Use CancelStyle instead. Will be removed in next release.")]
+        public CometButtonStyle CancelRenderStyle
+        {
+            get => this.CancelStyle;
+            set => this.CancelStyle = value;
+        }
+
+        /// <summary>
+        /// The <see cref="CometButtonStyle" /> to apply for the Confirm button
+        /// </summary>
+        [Obsolete("Use ConfirmStyle instead. Will be removed in next release.")]
+        public CometButtonStyle ConfirmRenderStyle
+        {
+            get => this.ConfirmStyle;
+            set => this.ConfirmStyle = value;
+        }
 
         /// <summary>
         /// The content of the header of the popup

--- a/COMET.Web.Common/ViewModels/Components/IConfirmCancelPopupViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/IConfirmCancelPopupViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="IConfirmCancelPopupViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -23,7 +23,9 @@
 
 namespace COMET.Web.Common.ViewModels.Components
 {
-    using DevExpress.Blazor;
+    using System;
+
+    using COMET.Web.Common.Enumerations;
 
     using Microsoft.AspNetCore.Components;
 
@@ -48,14 +50,26 @@ namespace COMET.Web.Common.ViewModels.Components
         EventCallback OnConfirm { get; set; }
 
         /// <summary>
-        /// The <see cref="ButtonRenderStyle" /> to apply for the Cancel button
+        /// The <see cref="CometButtonStyle" /> to apply for the Cancel button
         /// </summary>
-        ButtonRenderStyle CancelRenderStyle { get; set; }
+        CometButtonStyle CancelStyle { get; set; }
 
         /// <summary>
-        /// The <see cref="ButtonRenderStyle" /> to apply for the Confirm button
+        /// The <see cref="CometButtonStyle" /> to apply for the Confirm button
         /// </summary>
-        ButtonRenderStyle ConfirmRenderStyle { get; set; }
+        CometButtonStyle ConfirmStyle { get; set; }
+
+        /// <summary>
+        /// The <see cref="CometButtonStyle" /> to apply for the Cancel button
+        /// </summary>
+        [Obsolete("Use CancelStyle instead. Will be removed in next release.")]
+        CometButtonStyle CancelRenderStyle { get; set; }
+
+        /// <summary>
+        /// The <see cref="CometButtonStyle" /> to apply for the Confirm button
+        /// </summary>
+        [Obsolete("Use ConfirmStyle instead. Will be removed in next release.")]
+        CometButtonStyle ConfirmRenderStyle { get; set; }
 
         /// <summary>
         /// The content of the header of the popup

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ISessionMenuViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ISessionMenuViewModel.cs
@@ -58,8 +58,7 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
 
         /// <summary>
         /// Gets or sets a value indicating whether the self-service "Edit my profile" popup is open.
-        /// Bound to the <see cref="DevExpress.Blazor.DxPopup" /> visibility from
-        /// <see cref="Shared.TopMenuEntry.SessionMenu" />.
+        /// Bound to the popup visibility from the session menu
         /// </summary>
         bool IsOnEditPersonMode { get; set; }
 

--- a/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ModelMenuViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Shared/TopMenuEntry/ModelMenuViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ModelMenuViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -26,12 +26,11 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components;
-
-    using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
 
@@ -79,8 +78,8 @@ namespace COMET.Web.Common.ViewModels.Shared.TopMenuEntry
 
             this.ConfirmCancelViewModel = new ConfirmCancelPopupViewModel
             {
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
                 HeaderText = "Close Iteration",
                 OnCancel = new EventCallbackFactory().Create(this, () => { this.ConfirmCancelViewModel.IsVisible = false; }),
                 OnConfirm = new EventCallbackFactory().Create(this, this.CloseIteration)

--- a/COMET.Web.Common/_Imports.razor
+++ b/COMET.Web.Common/_Imports.razor
@@ -5,6 +5,7 @@
 @using COMET.Web.Common.Components.CardView
 @using COMET.Web.Common.Shared
 @using COMET.Web.Common.Shared.TopMenuEntry
+@using COMET.Web.Common.Extensions
 @using System.Net.Http
 @using System.Net.Http.Json
 @using System.Security.Claims

--- a/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Viewer/ViewerBodyViewModelTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ViewerBodyViewModelTestFixture.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 // 
@@ -190,7 +190,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Viewer
                 Assert.That(this.viewModel.Elements, Does.Not.Contain(deletedElementUsage));
 
                 // Verify Babylon calls for updatedElementWithShape
-                this.babylonInterop.Verify(x => x.ClearSceneObject(It.Is<SceneObject>(so => so.ElementBase.Iid == updatedElementWithShape.Iid)), Times.Once);
+                this.babylonInterop.Verify(x => x.ClearSceneObject(It.Is<SceneObject>(so => so.ElementBase.Iid == updatedElementWithShape.Iid)), Times.AtLeastOnce);
                 this.babylonInterop.Verify(x => x.AddSceneObject(It.Is<SceneObject>(so => so.ElementBase.Iid == updatedElementWithShape.Iid)), Times.AtLeastOnce);
                 this.babylonInterop.Verify(x => x.SetVisibility(It.Is<SceneObject>(so => so.ElementBase.Iid == updatedElementWithShape.Iid), false), Times.Once);
 

--- a/COMETwebapp/Components/Common/ConfirmRemovalPopup.razor.cs
+++ b/COMETwebapp/Components/Common/ConfirmRemovalPopup.razor.cs
@@ -23,9 +23,8 @@
 namespace COMETwebapp.Components.Common
 {
     using COMET.Web.Common.Components;
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.ViewModels.Components;
-
-    using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
 
@@ -64,7 +63,7 @@ namespace COMETwebapp.Components.Common
         /// </summary>
         public IConfirmCancelPopupViewModel ViewModel { get; } = new ConfirmCancelPopupViewModel
         {
-            ConfirmRenderStyle = ButtonRenderStyle.Danger
+            ConfirmStyle = CometButtonStyle.Danger
         };
 
         /// <summary>

--- a/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/UserManagement/UserManagementTable.razor
@@ -56,7 +56,7 @@
                             var row = (PersonRowViewModel)context.DataItem;
 
                             <DxCheckBox Id="activatePerson"
-                                        CheckedChanged="@((bool value) => this.ViewModel.ActivateOrDeactivatePerson(context, value))"
+                                        CheckedChanged="@((bool value) => this.ViewModel.ActivateOrDeactivatePerson(row, value))"
                                         Checked="(bool)context.Value"
                                         Enabled="row.IsAllowedToWrite"/>
                         }

--- a/COMETwebapp/ViewModels/Components/Common/DeprecatableDataItemTable/DeprecatableDataItemTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/DeprecatableDataItemTable/DeprecatableDataItemTableViewModel.cs
@@ -22,8 +22,6 @@
 
 namespace COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable
 {
-    using AntDesign;
-
     using CDP4Common.CommonData;
 
     using CDP4Dal;

--- a/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/ElementDetailsPanelViewModel.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.ViewModels.Components.Common
     using CDP4Dal;
 
     using COMET.Web.Common.Model;
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components;
@@ -42,8 +43,6 @@ namespace COMETwebapp.ViewModels.Components.Common
     using COMETwebapp.ViewModels.Components.ModelEditor.ElementDefinitionCreationViewModel;
     using COMETwebapp.ViewModels.Components.SystemRepresentation;
     using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows;
-
-    using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
     using Microsoft.Extensions.Logging;
@@ -226,8 +225,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.DeleteElementPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Delete element",
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedElementAsync)
             };
@@ -235,8 +234,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.DeleteParameterPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Delete parameter",
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteParameterCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedParameterAsync)
             };
@@ -244,8 +243,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.CreateSubscriptionPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Create Parameter Subscription",
-                ConfirmRenderStyle = ButtonRenderStyle.Primary,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Primary,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnCreateSubscriptionCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.CreateSubscriptionAsync)
             };
@@ -253,8 +252,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.DeleteSubscriptionPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Delete Parameter Subscription",
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteSubscriptionCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedSubscriptionAsync)
             };
@@ -262,8 +261,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.CreateOverridePopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Create Parameter Override",
-                ConfirmRenderStyle = ButtonRenderStyle.Primary,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Primary,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnCreateOverrideCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.CreateOverrideAsync)
             };
@@ -271,8 +270,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.DeleteOverridePopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Delete Parameter Override",
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteOverrideCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedOverrideAsync)
             };
@@ -290,8 +289,8 @@ namespace COMETwebapp.ViewModels.Components.Common
             this.DeleteParameterGroupPopupViewModel = new ConfirmCancelPopupViewModel
             {
                 HeaderText = "Delete Parameter Group",
-                ConfirmRenderStyle = ButtonRenderStyle.Danger,
-                CancelRenderStyle = ButtonRenderStyle.Secondary,
+                ConfirmStyle = CometButtonStyle.Danger,
+                CancelStyle = CometButtonStyle.Secondary,
                 OnCancel = eventCallbackFactory.Create(this, this.OnDeleteParameterGroupCancelled),
                 OnConfirm = eventCallbackFactory.Create(this, this.DeleteSelectedParameterGroupAsync)
             };

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/IUserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/IUserManagementTableViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IUserManagementTableViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -29,8 +29,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
 
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
-
-    using DevExpress.Blazor;
 
     /// <summary>
     /// View model used to manage <see cref="Person" />
@@ -105,8 +103,10 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         /// <summary>
         /// Tries to activate or disactivate a <see cref="Thing" />
         /// </summary>
+        /// <param name="personRow">The <see cref="PersonRowViewModel" /> of the person</param>
+        /// <param name="value">The new active status</param>
         /// <returns>A <see cref="Task" /></returns>
-        Task ActivateOrDeactivatePerson(GridDataColumnCellDisplayTemplateContext context, bool value);
+        Task ActivateOrDeactivatePerson(PersonRowViewModel personRow, bool value);
 
         /// <summary>
         /// Tries to create or edit an existing <see cref="Thing"/>

--- a/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SiteDirectory/UserManagement/UserManagementTableViewModel.cs
@@ -35,8 +35,6 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
     using COMETwebapp.ViewModels.Components.SiteDirectory.Rows;
 
-    using DevExpress.Blazor;
-
     using Microsoft.AspNetCore.Components;
 
     /// <summary>
@@ -234,11 +232,12 @@ namespace COMETwebapp.ViewModels.Components.SiteDirectory.UserManagement
         /// <summary>
         /// Tries to activate or disactivate a <see cref="Thing" />
         /// </summary>
+        /// <param name="personRow">The <see cref="PersonRowViewModel" /> of the person</param>
+        /// <param name="value">The new active status</param>
         /// <returns>A <see cref="Task" /></returns>
-        public async Task ActivateOrDeactivatePerson(GridDataColumnCellDisplayTemplateContext context, bool value)
+        public async Task ActivateOrDeactivatePerson(PersonRowViewModel personRow, bool value)
         {
             var siteDirectoryClone = this.SessionService.GetSiteDirectory().Clone(false);
-            var personRow = (PersonRowViewModel)context.DataItem;
             var personToUpdate = personRow.Thing;
             var clonedPerson = personToUpdate.Clone(false);
             clonedPerson.IsActive = value;

--- a/COMETwebapp/ViewModels/Components/Viewer/CanvasViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Viewer/CanvasViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="CanvasViewModel.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.ViewModels.Components.Viewer
 {
+    using COMET.Web.Common.Enumerations;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components;
@@ -34,8 +35,6 @@ namespace COMETwebapp.ViewModels.Components.Viewer
     using COMETwebapp.Model;
     using COMETwebapp.Services.Interoperability;
     using COMETwebapp.Utilities;
-
-    using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
 
@@ -134,8 +133,8 @@ namespace COMETwebapp.ViewModels.Components.Viewer
             {
                 HeaderText = "Alert!",
                 ContentText = "You are about to select another primitive. The changes on the previous one haven't been saved. Do you want to continue?",
-                CancelRenderStyle = ButtonRenderStyle.Danger,
-                ConfirmRenderStyle = ButtonRenderStyle.Success,
+                CancelStyle = CometButtonStyle.Danger,
+                ConfirmStyle = CometButtonStyle.Success,
                 OnConfirm = new EventCallback(null, async () =>
                 {
                     await this.SelectSceneObjectUnderMouse();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Closes #843 ViewModels should not reference UI component library types
Closes #840 IUserManagementTableViewModel exposes a UI component type in its public API


<!-- Thanks for contributing to COMET-WEB! -->

