### PR TITLE
Fix #837 Removed dead ng-deep css styles

### DIFF
--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.css
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.css
@@ -1,21 +1,4 @@
-﻿::ng-deep .dx-datagrid-rowsview .dx-selection.dx-row:not(.dx-row-focused):not(.dx-row-removed) > td {
-    background-color: orange;
-    color: unset;
-}
-
-::ng-deep .dx-datagrid-rowsview .dx-row-focused.dx-data-row .dx-command-edit:not(.dx-focused) .dx-link,
-::ng-deep .dx-datagrid-rowsview .dx-row-focused.dx-data-row > td:not(.dx-focused),
-::ng-deep .dx-datagrid-rowsview .dx-row-focused.dx-data-row > tr > td:not(.dx-focused) {
-    background-color: red;
-    color: #fff;
-}
-
-::ng-deep .dx-datagrid-rowsview .dx-row-focused.dx-data-row > td,
-::ng-deep .dx-datagrid-rowsview .dx-row-focused.dx-data-row > tr:last-child > td {
-    border-bottom: 1px solid yellow;
-}
-
-.table-container {
+﻿.table-container {
     width: fit-content;
     margin-top: 15px;
     max-height: 80vh;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
#837  Remove dead ::ng-deep CSS from ParameterTable.razor.css
deleted the 3 dead ::ng-deep blocks (lines 1–16), kept the live .table-container rule. File is not empty, so not deleted. .razor.css files carry no license header.

Didnt find it anywhere else was always obsolete so everything looks the same before:
<img width="940" height="544" alt="image" src="https://github.com/user-attachments/assets/d4dda940-6094-44f3-9d1d-9f7b125c5ece" />
after
<img width="940" height="544" alt="image" src="https://github.com/user-attachments/assets/5917d146-0123-49f0-9bf0-133520b8e838" />
