### PR TITLE
Feat #850 SelectedDataItemBase: add StartCreate/StartEdit and obsolete the grid-specific members

### DIFF
--- a/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SiteDirectory/EngineeringModels/ParticipantsTableTestFixture.cs
@@ -46,7 +46,6 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
 
     using NUnit.Framework;
 
-
     [TestFixture]
     public class ParticipantsTableTestFixture
     {
@@ -163,6 +162,37 @@ namespace COMETwebapp.Tests.Components.SiteDirectory.EngineeringModels
             var saveParticipantsButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "saveParticipantsButton");
             await this.renderer.InvokeAsync(saveParticipantsButton.Instance.Click.InvokeAsync);
             this.viewModel.Verify(x => x.CreateOrEditParticipant(It.IsAny<bool>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyStartCreate()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.ShouldCreateThing, Is.False);
+                Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
+            });
+
+            await this.renderer.InvokeAsync(() => this.renderer.Instance.StartCreate());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.ShouldCreateThing, Is.True);
+                Assert.That(this.renderer.Instance.IsOnEditMode, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task VerifyStartEdit()
+        {
+            var row = new ParticipantRowViewModel(this.participant1);
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
+
+            await this.renderer.InvokeAsync(() => this.renderer.Instance.StartEdit(null));
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
+
+            await this.renderer.InvokeAsync(() => this.renderer.Instance.StartEdit(row));
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.True);
         }
     }
 }

--- a/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
@@ -59,6 +59,7 @@ namespace COMETwebapp.Components.Common
         /// <summary>
         /// Gets or sets the grid control that is being customized.
         /// </summary>
+        [Obsolete("Grid-editing members are obsolete. Use StartCreate() and StartEdit(TRow) instead.")]
         protected IGrid Grid { get; set; }
 
         /// <summary>
@@ -82,6 +83,7 @@ namespace COMETwebapp.Components.Common
         /// Method invoked when creating a new thing
         /// </summary>
         /// <param name="e">A <see cref="GridCustomizeEditModelEventArgs" /></param>
+        [Obsolete("Grid-editing members are obsolete. Use StartCreate() and StartEdit(TRow) instead.")]
         protected virtual void CustomizeEditThing(GridCustomizeEditModelEventArgs e)
         {
         }
@@ -102,6 +104,31 @@ namespace COMETwebapp.Components.Common
         protected virtual void OnSelectedDataItemChanged(TRow row)
         {
             this.IsOnEditMode = true;
+        }
+
+        /// <summary>
+        /// Starts the creation flow for a new <typeparamref name="T"/> item.
+        /// </summary>
+        public virtual void StartCreate()
+        {
+            this.ShouldCreateThing = true;
+            this.IsOnEditMode = true;
+
+            this.InvokeAsync(this.StateHasChanged);
+        }
+
+        /// <summary>
+        /// Starts the edit flow for the specified <paramref name="row"/>.
+        /// </summary>
+        /// <param name="row">The selected row to edit.</param>
+        public virtual void StartEdit(TRow row)
+        {
+            if (row == null)
+            {
+                return;
+            }
+
+            this.OnSelectedDataItemChanged(row);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Closes #850 SelectedDataItemBase: add StartCreate/StartEdit and obsolete the grid-specific members

Blocking #875 
<!-- Thanks for contributing to COMET-WEB! -->

