### PR TITLE
Feat #842 Remove third party dependence on css classes for playwright tests

### DIFF
--- a/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/BookEditor/EditotPopupTestFixture.cs
@@ -107,6 +107,17 @@ namespace COMET.Web.Common.Tests.Components.BookEditor
         }
         
         [Test]
+        public async Task VerifyClosingThePopupCancels()
+        {
+            this.onCancelCalled = false;
+            var popup = this.component.FindComponent<DxPopup>();
+
+            await this.component.InvokeAsync(() => popup.Instance.Closed.InvokeAsync());
+
+            Assert.That(this.onCancelCalled, Is.True);
+        }
+
+        [Test]
         public void VerifyComponent()
         {
             var popup = this.component.FindComponent<DxPopup>();

--- a/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
@@ -87,6 +87,14 @@ namespace COMET.Web.Common.Tests.Components
         }
 
         [Test]
+        public void VerifyReadinessMarkerIsPublished()
+        {
+            var renderer = this.context.Render<Login>();
+            var form = renderer.Find("#login-form");
+            Assert.That(form.GetAttribute("data-app-ready"), Is.EqualTo("true"));
+        }
+
+        [Test]
         public async Task VerifyErrorsShown()
         {
             var renderer = this.context.Render<Login>();

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
@@ -20,8 +20,8 @@
 @namespace COMET.Web.Common.Components.BookEditor
 @inherits DisposableComponent
 
-<DxPopup @bind-Visible="@this.ViewModel.IsVisible" CloseOnOutsideClick="false" ShowCloseButton="true" ShowFooter="true" HeaderText="@this.ViewModel.HeaderText" Closed="@(()=> this.ViewModel.OnCancelClick.InvokeAsync())">
-    <Content>
+<DxPopup @bind-Visible="@this.ViewModel.IsVisible" CssClass="book-editor-popup" CloseOnOutsideClick="false" ShowCloseButton="true" ShowFooter="true" HeaderText="@this.ViewModel.HeaderText" Closed="@(()=> this.ViewModel.OnCancelClick.InvokeAsync())">
+    <BodyContentTemplate>
         <InputEditor Item="@this.ViewModel.Item" ActiveDomains="@this.ViewModel.ActiveDomains" AvailableCategories="@this.ViewModel.AvailableCategories" ShowName="@this.showName" ShowShortName="@this.showShortName" />
         <div style="display:flex; flex-direction:column">
             @foreach (var validationError in this.ViewModel.ValidationErrors.Items)
@@ -29,7 +29,7 @@
                 <ValidationMessageComponent ValidationMessage="@validationError"/>
             }
         </div>
-    </Content>
+    </BodyContentTemplate>
     <FooterTemplate>
         <div class="modal-footer">
             <DxButton CssClass="ok-button" Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(async () => await this.OnConfirmClick())" />

--- a/COMET.Web.Common/Components/Login.razor
+++ b/COMET.Web.Common/Components/Login.razor
@@ -26,7 +26,7 @@
                 IsContentBlocked="true"
                 ApplyBackgroundShading="false"
                 Text="Trying to restore previous session, if possible...">
-<EditForm Context="editFormContext" Model="@this.ViewModel.AuthenticationDto" OnValidSubmit="this.HandleSubmitAsync" >
+<EditForm Context="editFormContext" Model="@this.ViewModel.AuthenticationDto" OnValidSubmit="this.HandleSubmitAsync" id="login-form" data-app-ready="@(this.formReady ? "true" : null)">
     <FluentValidationValidator />
     <DxFormLayout CaptionPosition="CaptionPosition.Vertical">
         @if (string.IsNullOrEmpty(this.ServerConfiguration.ServerAddress) && this.ShouldProvideServerInformationInput())

--- a/COMET.Web.Common/Components/Login.razor.cs
+++ b/COMET.Web.Common/Components/Login.razor.cs
@@ -120,6 +120,13 @@ namespace COMET.Web.Common.Components
         private bool checkingRestoreSession = true;
 
         /// <summary>
+        /// Asserts that the login form has rendered and its editors are interactive. Exposed to the DOM as the
+        /// application-owned <c>data-app-ready</c> readiness marker the end-to-end tests wait on before typing, so the
+        /// tests no longer depend on a third-party "editor loaded" attribute.
+        /// </summary>
+        private bool formReady;
+
+        /// <summary>
         /// Handles the focus event of the given fieldName
         /// </summary>
         /// <param name="fieldName">Form field name, as indexed in <see cref="FieldsFocusedStatus" /></param>
@@ -215,6 +222,11 @@ namespace COMET.Web.Common.Components
             {
                 await this.AuthenticationService.TryRestoreLastSessionAsync();
                 this.checkingRestoreSession = false;
+                await this.InvokeAsync(this.StateHasChanged);
+            }
+            else if (!this.checkingRestoreSession && !this.formReady)
+            {
+                this.formReady = true;
                 await this.InvokeAsync(this.StateHasChanged);
             }
         }

--- a/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
@@ -120,7 +120,7 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 Assert.That(selectedModel, Is.Null);
             });
 
-            var firstSourceRow = treeView.Find(".dxbl-treeview-item-container");
+            var firstSourceRow = treeView.Find("[data-testid=element-node]");
             firstSourceRow.Click();
 
             Assert.Multiple(() =>
@@ -240,13 +240,13 @@ namespace COMETwebapp.Tests.Components.ModelEditor
         [Test]
         public void VerifyDragIsNotAllowed()
         {
-            var firstItem = renderedComponent.Find(".dxbl-text").FirstElementChild;
+            var firstItem = renderedComponent.Find("[data-testid=element-node]");
 
             Assert.Multiple(() =>
             {
                 Assert.That(firstItem, Is.Not.Null);
                 Assert.That(firstItem.InnerHtml, Contains.Substring("Test1"));
-                Assert.That(firstItem.Attributes.Length, Is.EqualTo(2));
+                Assert.That(firstItem.Attributes.Length, Is.EqualTo(3));
             });
         }
 
@@ -259,13 +259,13 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                     .Add(p => p.AllowDrag, true);
             });
 
-            var firstItem = renderedComponent.Find(".dxbl-text").FirstElementChild;
+            var firstItem = renderedComponent.Find("[data-testid=element-node]");
 
             Assert.Multiple(() =>
             {
                 Assert.That(firstItem, Is.Not.Null);
                 Assert.That(firstItem.InnerHtml, Contains.Substring("Test1"));
-                Assert.That(firstItem.Attributes.Length, Is.EqualTo(10));
+                Assert.That(firstItem.Attributes.Length, Is.EqualTo(11));
             });
         }
     }

--- a/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
@@ -24,6 +24,10 @@ namespace COMETwebapp.Tests.Components.Tabs
 {
     using Bunit;
 
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Model;
     using COMET.Web.Common.Services.StringTableService;
     using COMET.Web.Common.Test.Helpers;
     using COMET.Web.Common.ViewModels.Components;
@@ -93,6 +97,51 @@ namespace COMETwebapp.Tests.Components.Tabs
         {
             var form = this.renderer.Find("#open-tab-form");
             Assert.That(form.GetAttribute("data-app-ready"), Is.EqualTo("true"));
+        }
+
+        [Test]
+        public void VerifyComboItemTemplatesExposeTheTestId()
+        {
+            var application = Applications.ExistingApplications.OfType<TabbedApplication>().First();
+            var modelSetup = new EngineeringModelSetup { Name = "Model" };
+            var domain = new DomainOfExpertise { Name = "Domain" };
+            var iterationData = new IterationData(new IterationSetup { IterationNumber = 1 });
+
+            // The view, model and domain combos render while no application is selected (the SetUp default). The domain
+            // template's highlighted branch is exercised here because IsCurrentIterationOpened is true in the SetUp.
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.RenderComboItemTemplate<TabbedApplication>("view-selection", application), Is.EqualTo(application.Name));
+                Assert.That(this.RenderComboItemTemplate<EngineeringModelSetup>("model-selection", modelSetup), Is.EqualTo("Model"));
+                Assert.That(this.RenderComboItemTemplate<DomainOfExpertise>("domain-selection", domain), Is.EqualTo("Domain"));
+            });
+
+            // The plain branch of the domain template.
+            this.viewModel.Setup(x => x.IsCurrentIterationOpened).Returns(false);
+            this.renderer.Render();
+            Assert.That(this.RenderComboItemTemplate<DomainOfExpertise>("domain-selection", domain), Is.EqualTo("Domain"));
+
+            // The iteration combo only renders for an iteration view.
+            var iterationApplication = Applications.ExistingApplications.OfType<TabbedApplication>().First(x => x.ThingTypeOfInterest == typeof(Iteration));
+            this.viewModel.Setup(x => x.SelectedApplication).Returns(iterationApplication);
+            this.renderer.Render();
+            Assert.That(this.RenderComboItemTemplate<IterationData>("iteration-selection", iterationData), Is.EqualTo(iterationData.IterationName));
+        }
+
+        /// <summary>
+        /// Renders a combo box's <c>ItemTemplate</c> for the given item and returns the text of its application-owned
+        /// <c>data-testid</c> marker. bunit does not render the DevExpress drop-down list itself, so the template render
+        /// fragment is invoked directly.
+        /// </summary>
+        /// <typeparam name="T">The combo box data type.</typeparam>
+        /// <param name="comboId">The combo box component id.</param>
+        /// <param name="item">The item to render the template for.</param>
+        /// <returns>The trimmed text of the rendered item's marker element.</returns>
+        private string RenderComboItemTemplate<T>(string comboId, T item)
+        {
+            var combo = this.renderer.FindComponents<DxComboBox<T, T>>().First(x => x.Instance.Id == comboId);
+            var renderedItem = this.context.Render(combo.Instance.ItemTemplate(item));
+            return renderedItem.Find("[data-testid=combo-item]").TextContent.Trim();
         }
 
         [Test]

--- a/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
@@ -89,6 +89,13 @@ namespace COMETwebapp.Tests.Components.Tabs
         }
 
         [Test]
+        public void VerifyReadinessMarkerIsPublished()
+        {
+            var form = this.renderer.Find("#open-tab-form");
+            Assert.That(form.GetAttribute("data-app-ready"), Is.EqualTo("true"));
+        }
+
+        [Test]
         public void VerifyOnInitialized()
         {
             Assert.Multiple(() =>

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/BookEditorPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/BookEditorPageModel.cs
@@ -66,9 +66,9 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator AddBookButton => this.Page.Locator("#books-column .add-item-button");
 
         /// <summary>
-        /// Gets the create/edit popup.
+        /// Gets the create/edit popup, targeted by the application-owned <c>book-editor-popup</c> class set on it. 
         /// </summary>
-        public ILocator EditorPopup => this.Page.Locator(".dxbl-popup");
+        public ILocator EditorPopup => this.Page.Locator(".book-editor-popup");
 
         /// <summary>
         /// Opens the "add book" editor dialog.

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/LoginPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/LoginPageModel.cs
@@ -107,17 +107,18 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         }
 
         /// <summary>
-        /// Types a value into a DevExpress login text box deterministically. It first waits for DevExpress to attach the
-        /// editor (its <c>data-qa-dxbl-loaded</c> marker), because on a cold Blazor circuit the field re-renders as it
-        /// wires up and wipes anything typed too early, so Connect ends up posting an empty value; then it types at a
+        /// Types a value into a login text box deterministically. It first waits for the login form's application-owned
+        /// <c>data-app-ready</c> marker, which the form publishes once its editors have rendered and DevExpress has had a
+        /// render cycle to attach their client-side scripts - because on a cold Blazor circuit the field re-renders as it
+        /// wires up and wipes anything typed too early, so Connect ends up posting an empty value. It then types at a
         /// cadence the on-input binding can keep up with and confirms the field holds the full value.
         /// </summary>
-        /// <param name="id">The DevExpress text box component id.</param>
+        /// <param name="id">The text box component id.</param>
         /// <param name="value">The value to type.</param>
         /// <returns>A <see cref="Task" />.</returns>
         private async Task TypeCredentialAsync(string id, string value)
         {
-            await Expect(this.page.Locator($"#{id}[data-qa-dxbl-loaded]"))
+            await Expect(this.page.Locator("#login-form[data-app-ready]"))
                 .ToBeAttachedAsync(new LocatorAssertionsToBeAttachedOptions { Timeout = E2ETestBase.ServerRoundTripTimeoutMilliseconds });
 
             var input = this.TextInput(id);

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ModelDashboardPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ModelDashboardPageModel.cs
@@ -49,8 +49,9 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator Body => this.Page.Locator("#modeldashboard-body");
 
         /// <summary>
-        /// Gets the dashboard charts (parameter/element progress widgets).
+        /// Gets the dashboard charts (parameter/element progress widgets), targeted by the application-owned
+        /// <c>data-testid</c> attribute set on each chart's container rather than a DevExpress internal class.
         /// </summary>
-        public ILocator Charts => this.Page.Locator("#modeldashboard-body .dx-chart-root");
+        public ILocator Charts => this.Page.Locator("#modeldashboard-body [data-testid=dashboard-chart]");
     }
 }

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ModelEditorPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ModelEditorPageModel.cs
@@ -66,9 +66,10 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator SearchBox => this.Page.Locator("#search-textbox");
 
         /// <summary>
-        /// Gets the element rows of the source model tree.
+        /// Gets the element rows of the source model tree, targeted by the application-owned <c>data-testid</c> attribute
+        /// set on each tree item rather than a DevExpress internal class.
         /// </summary>
-        public ILocator SourceElements => this.Page.Locator("#sourcePanel .dxbl-treeview-item");
+        public ILocator SourceElements => this.Page.Locator("#sourcePanel [data-testid=element-node]");
 
         /// <summary>
         /// Selects the first element in the source model tree, which opens it in the details panel.

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ParameterEditorPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ParameterEditorPageModel.cs
@@ -62,9 +62,12 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator OwnedParametersToggle => this.Page.Locator("#only-owned-parameters-toggle");
 
         /// <summary>
-        /// Gets the expand/collapse buttons of the element group rows.
+        /// Gets the element group rows. Each group row is located through the application-owned
+        /// <c>data-testid="parameter-group-row"</c> attribute set on its group cell (rather than a DevExpress internal
+        /// class), then widened to the whole table row so its expand/collapse button - which lives in a sibling cell -
+        /// can be reached.
         /// </summary>
-        public ILocator GroupExpandButtons => this.Page.Locator("#parameter-table .dxbl-grid-expand-button");
+        public ILocator GroupRows => this.Page.Locator("#parameter-table tr:has(td[data-testid=parameter-group-row])");
 
         /// <summary>
         /// Gets the rows currently rendered in the parameter table (collapsing a group hides its rows).
@@ -72,12 +75,13 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator Rows => this.Page.Locator("#parameter-table tr");
 
         /// <summary>
-        /// Clicks the first element group's expand/collapse button.
+        /// Clicks the first element group's expand/collapse button (the single button in the group row), which expands or
+        /// collapses that group.
         /// </summary>
         /// <returns>A <see cref="Task" />.</returns>
         public Task ToggleFirstGroupAsync()
         {
-            return this.GroupExpandButtons.First.ClickAsync();
+            return this.GroupRows.First.Locator("button").First.ClickAsync();
         }
     }
 }

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/TabsPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/TabsPageModel.cs
@@ -60,10 +60,13 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator BlazorError => this.page.Locator("#blazor-error-ui");
 
         /// <summary>
-        /// Gets the list items of the currently open DevExpress drop-down. Scoping to the shown drop-down avoids
-        /// matching the fading-out items of a drop-down that was just closed.
+        /// Gets the items of the currently open combo drop-down. Each item's content carries the application-owned
+        /// <c>data-testid="combo-item"</c> attribute (set by every combo's <c>ItemTemplate</c>), so this does not depend
+        /// on a DevExpress internal class. Only the open combo renders its items, and <see cref="OpenComboAsync" /> waits
+        /// for the previous drop-down to close before opening the next, so this never matches the fading-out items of a
+        /// just-closed one.
         /// </summary>
-        private ILocator OpenDropdownItems => this.page.Locator(".dxbl-edit-dropdown-shown .dxbl-listbox-item");
+        private ILocator OpenDropdownItems => this.page.Locator("[data-testid=combo-item]");
 
         /// <summary>
         /// Opens the given application as a tab from the home "Open Tab" card. Selects it as the View, then the
@@ -163,16 +166,52 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         }
 
         /// <summary>
-        /// Clicks a DevExpress combo box open and waits for its list to appear. The combo is targeted through its
-        /// <c>data-qa-dxbl-loaded</c> marker, so the click waits for DevExpress to attach its client-side scripts —
-        /// a click before that silently fails to open the drop-down.
+        /// Clicks a combo box open and waits for its list to appear. It first waits for the open-tab form's
+        /// application-owned <c>data-app-ready</c> marker and for any previous drop-down to have fully closed (so no stale
+        /// item is matched). The application-owned marker signals the combos have rendered but cannot prove DevExpress has
+        /// finished attaching their client-side scripts, so on a cold or heavily loaded circuit a first click can land
+        /// before the handler is wired and silently fail to open the drop-down; the click is therefore retried until the
+        /// items appear, re-clicking only while nothing is open so an already-open drop-down is never toggled shut.
         /// </summary>
         /// <param name="comboId">The combo box component id.</param>
         /// <returns>A <see cref="Task" />.</returns>
         private async Task OpenComboAsync(string comboId)
         {
-            await this.page.Locator($"#{comboId}[data-qa-dxbl-loaded]").ClickAsync();
-            await Expect(this.OpenDropdownItems.First).ToBeVisibleAsync();
+            await Expect(this.page.Locator("#open-tab-form[data-app-ready]")).ToBeAttachedAsync(new LocatorAssertionsToBeAttachedOptions { Timeout = E2ETestBase.ServerRoundTripTimeoutMilliseconds });
+            await Expect(this.OpenDropdownItems).ToHaveCountAsync(0);
+
+            var combo = this.page.Locator($"#{comboId}");
+
+            for (var attempt = 0; attempt < ComboOpenAttempts; attempt++)
+            {
+                if (await this.OpenDropdownItems.CountAsync() == 0)
+                {
+                    await combo.ClickAsync();
+                }
+
+                try
+                {
+                    await Expect(this.OpenDropdownItems.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = ComboOpenAttemptTimeoutMilliseconds });
+                    return;
+                }
+                catch (PlaywrightException) when (attempt < ComboOpenAttempts - 1)
+                {
+                    // The DevExpress client script had not attached when the click landed, so the drop-down did not open;
+                    // retry on the next iteration.
+                }
+            }
         }
+
+        /// <summary>
+        /// The number of times <see cref="OpenComboAsync" /> retries opening a combo box before giving up, to absorb the
+        /// gap between the form's readiness marker and DevExpress attaching the combo's client-side click handler.
+        /// </summary>
+        private const int ComboOpenAttempts = 5;
+
+        /// <summary>
+        /// The per-attempt timeout, in milliseconds, that <see cref="OpenComboAsync" /> waits for a combo's items to
+        /// appear before re-clicking. Kept short so a click that missed the handler is retried quickly.
+        /// </summary>
+        private const int ComboOpenAttemptTimeoutMilliseconds = 3_000;
     }
 }

--- a/COMETwebapp/Components/ModelDashboard/Elements/UnreferencedElements.razor
+++ b/COMETwebapp/Components/ModelDashboard/Elements/UnreferencedElements.razor
@@ -23,7 +23,7 @@
 
 @if (this.Elements != null && this.UnreferencedElementDefinitions != null)
 {
-    <div>
+    <div data-testid="dashboard-chart">
         <div class="row">
             <div class="col-9">
                 <h3 class="text-align-end">Unreferenced Elements</h3>
@@ -35,7 +35,7 @@
             </div>
         </div>
 
-            <DxChart Data="@this.Elements"  CustomizeSeriesPoint="@PreparePointLabel">
+            <DxChart Data="@this.Elements" CustomizeSeriesPoint="@PreparePointLabel">
                 <DxChartFullStackedBarSeries Color="System.Drawing.Color.MediumPurple" Name="@WebAppConstantValues.ReferencedElements" Filter="@((ElementDefinition e) => this.UnreferencedElementDefinitions.All(x => x.Iid != e.Iid))"
                                     ArgumentField="@(e => e.Owner.ShortName)" ValueField="@(e => 1)"
                                     AggregationMethod="Enumerable.Sum">

--- a/COMETwebapp/Components/ModelDashboard/Elements/UnusedElements.razor
+++ b/COMETwebapp/Components/ModelDashboard/Elements/UnusedElements.razor
@@ -23,7 +23,7 @@
 
 @if(this.Elements != null && this.UnusedElementDefinitions != null)
 {
-    <div>
+    <div data-testid="dashboard-chart">
         <div class="row">
             <div class="col-9">
                 <h3 class="text-align-end">Unused Elements</h3>
@@ -34,7 +34,7 @@
                 </Tooltip>
             </div>
        
-            <DxChart Data="@this.Elements"  CustomizeSeriesPoint="@PreparePointLabel">
+            <DxChart Data="@this.Elements" CustomizeSeriesPoint="@PreparePointLabel">
                 <DxChartFullStackedBarSeries Color="System.Drawing.Color.IndianRed" Name="@WebAppConstantValues.UsedElements" Filter="@((ElementDefinition e) => this.UnusedElementDefinitions.All(x => x.Iid != e.Iid))"
                                             ArgumentField="@(e => e.Owner.ShortName)" ValueField="@(e => 1)"
                                             AggregationMethod="Enumerable.Sum">

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/DefaultValues.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/DefaultValues.razor
@@ -22,7 +22,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 @using COMETwebapp.Utilities
 @inherits HaveValueSetsChartData
 
-<div class="width-100">
+<div class="width-100" data-testid="dashboard-chart">
 	<div class="row">
 		<div class="col-8">
 			<h3 class="text-align-end">Missing Values</h3>

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/DonutDashboard.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/DonutDashboard.razor
@@ -20,7 +20,7 @@
 @using COMETwebapp.Model
 @using Orientation = DevExpress.Blazor.Orientation
 
-<div class="col col-xxl-8">
+<div class="col col-xxl-8" data-testid="dashboard-chart">
     <DxPieChart Data="@(this.dataCharts)" CustomizeSeriesPoint="@CustomizeSeriesPoint"
                 InnerDiameter="0.5">
         <DxPieChartSeries Filter="@((DataChart d) => d.Argument != null && (d.Argument.Equals("Missing Values") || d.Argument.Equals("Complete Values")))"

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/PublishedParameters.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/PublishedParameters.razor
@@ -22,7 +22,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 @using COMETwebapp.Utilities
 @inherits HaveValueSetsChartData
 
-<div class="width-100">
+<div class="width-100" data-testid="dashboard-chart">
     <div class="row">
         <div class="col-9">
             <h3 class="text-align-end">Published Parameters</h3>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
@@ -19,7 +19,7 @@
 ------------------------------------------------------------------------------->
 @using COMETwebapp.Extensions
 
-<div class="@this.CssClass" style="display: flex; justify-content: space-between; align-items: center;" @attributes="this.AdditionalAttributes">
+<div data-testid="element-node" class="@this.CssClass" style="display: flex; justify-content: space-between; align-items: center;" @attributes="this.AdditionalAttributes">
     <span>
         <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="ElementName" />
     </span>

--- a/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterTable.razor.cs
@@ -111,6 +111,8 @@ namespace COMETwebapp.Components.ParameterEditor
                 var elementBaseName = (string)e.Grid.GetRowValue(e.VisibleIndex, nameof(ParameterBaseRowViewModel.ElementBaseName));
                 var isPublishableParameterInGroup = this.sortedCollection.Any(x => x.IsPublishable && x.ElementBaseName == elementBaseName);
 
+                e.Attributes["data-testid"] = "parameter-group-row";
+
                 if (isPublishableParameterInGroup)
                 {
                     e.CssClass = "font-weight-bold";

--- a/COMETwebapp/Components/Tabs/OpenTab.razor
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor
@@ -22,6 +22,7 @@
 @using COMET.Web.Common.Model
 @inherits OpenModel
 
+<div id="open-tab-form" data-app-ready="@(this.formReady ? "true" : null)">
 <DxFormLayout CaptionPosition="CaptionPosition.Vertical" CssClass="py-5 px-4">
     <DxFormLayoutItem ColSpanLg="12">
         <div style="display:flex; flex-direction: column; align-items: center;">
@@ -37,7 +38,11 @@
                     Data="@(Applications.ExistingApplications.OfType<TabbedApplication>())"
                     TextFieldName="@nameof(Application.Name)"
                     @bind-Value="@(this.ViewModel.SelectedApplication)"
-                    NullText="Select a View"/>
+                    NullText="Select a View">
+            <ItemTemplate Context="application">
+                <span data-testid="combo-item">@(application.Name)</span>
+            </ItemTemplate>
+        </DxComboBox>
     </DxFormLayoutItem>
 
     @if (this.IsEngineeringModelView || this.IsIterationView || this.ViewModel.SelectedApplication is null)
@@ -48,7 +53,11 @@
                         TextFieldName="@nameof(EngineeringModelSetup.Name)"
                         @bind-Value="@(this.ViewModel.SelectedEngineeringModel)"
                         NullText="Select an Engineering Model"
-                        Enabled="@(this.ModelId == Guid.Empty)" />
+                        Enabled="@(this.ModelId == Guid.Empty)">
+                <ItemTemplate Context="engineeringModelSetup">
+                    <span data-testid="combo-item">@(engineeringModelSetup.Name)</span>
+                </ItemTemplate>
+            </DxComboBox>
         </DxFormLayoutItem>
 
         <DxFormLayoutItem Caption="Domain" ColSpanLg="12">
@@ -61,11 +70,11 @@
                 <ItemTemplate Context="ctx">
                     @if (this.ViewModel.IsCurrentIterationOpened)
                     {
-                        <span class="@(this.ViewModel.SelectedIterationDomainOfExpertise == ctx ? "font-weight-bold" : "")">@(ctx.Name)</span>
+                        <span data-testid="combo-item" class="@(this.ViewModel.SelectedIterationDomainOfExpertise == ctx ? "font-weight-bold" : "")">@(ctx.Name)</span>
                     }
                     else
                     {
-                        <span>@(ctx.Name)</span>
+                        <span data-testid="combo-item">@(ctx.Name)</span>
                     }
                 </ItemTemplate>
             </DxComboBox>
@@ -79,7 +88,11 @@
                             TextFieldName="@nameof(IterationData.IterationName)"
                             @bind-Value="@(this.ViewModel.SelectedIterationSetup)"
                             NullText="Select an Iteration"
-                            Enabled="@(this.IterationId == Guid.Empty)" />
+                            Enabled="@(this.IterationId == Guid.Empty)">
+                    <ItemTemplate Context="iterationData">
+                        <span data-testid="combo-item">@(iterationData.IterationName)</span>
+                    </ItemTemplate>
+                </DxComboBox>
             </DxFormLayoutItem>
         }
 
@@ -108,3 +121,4 @@
         }
     </DxFormLayoutItem>
 </DxFormLayout>
+</div>

--- a/COMETwebapp/Components/Tabs/OpenTab.razor.cs
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor.cs
@@ -74,6 +74,13 @@ namespace COMETwebapp.Components.Tabs
         private bool IsIterationView => this.ViewModel.SelectedApplication?.ThingTypeOfInterest == typeof(Iteration);
 
         /// <summary>
+        /// Asserts that the open-tab form has rendered and its combo boxes are interactive. Exposed to the DOM as the
+        /// application-owned <c>data-app-ready</c> readiness marker the end-to-end tests wait on before opening a combo,
+        /// so the tests no longer depend on a third-party "editor loaded" attribute.
+        /// </summary>
+        private bool formReady;
+
+        /// <summary>
         /// Method invoked when the component is ready to start, having received its
         /// initial parameters from its parent in the render tree.
         /// </summary>
@@ -81,6 +88,24 @@ namespace COMETwebapp.Components.Tabs
         {
             this.Initialize(this.ViewModel);
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.SelectedApplication).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+        }
+
+        /// <summary>
+        /// Method invoked after each time the component has been rendered interactively. Publishes the application-owned
+        /// <c>data-app-ready</c> readiness marker once the combo boxes have rendered at least once (so DevExpress has had
+        /// a render cycle to attach their client-side scripts).
+        /// </summary>
+        /// <param name="firstRender">Set to <c>true</c> if this is the first time the method has been invoked.</param>
+        /// <returns>A <see cref="Task" /></returns>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (firstRender)
+            {
+                this.formReady = true;
+                await this.InvokeAsync(this.StateHasChanged);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
## Fix #842  Decouple e2e/bunit selectors from third-party DevExpress CSS classes

Playwright page models (and one bunit fixture) located elements via DevExpress-internal classes (`.dxbl-*`, `.dx-chart-root`, `[data-qa-dxbl-loaded]`). A routine component-library upgrade renames these and breaks the whole suite for reasons unrelated to the app. This adds app-owned `data-testid` markers to the production components and re-points every selector at them.

### Selectors replaced
| Was | Now | Marker location |
|---|---|---|
| `.dxbl-popup` | `.book-editor-popup` | `DxPopup.CssClass` |
| `.dx-chart-root` | `[data-testid=dashboard-chart]` | chart wrapper `<div>` |
| `.dxbl-treeview-item` / `.dxbl-text` | `[data-testid=element-node]` | tree-item root div |
| `.dxbl-grid-expand-button` | `tr:has(td[data-testid=parameter-group-row]) button` | grid `CustomizeElement` |
| `.dxbl-edit-dropdown-shown .dxbl-listbox-item` | `[data-testid=combo-item]` | combo `ItemTemplate` |
| `[data-qa-dxbl-loaded]` | `#…[data-app-ready]` | app-owned readiness attribute |

### Notes
- `data-app-ready` is published by the login and open-tab forms one render after their editors exist; combo opening additionally retries (the marker proves render, not DevExpress JS hydration).
- Two deliberate exceptions: the popup keeps `CssClass` (`DxPopup.Attributes` lands on the hidden modal host), and charts use a wrapper div (`DxChart` exposes no attribute splat).
- Also fixes an obsolete `DxPopup.<Content>` (CS0618) → `<BodyContentTemplate>`.

### Verification
- No `dx`-prefixed selector remains under `IntegrationTests`.
- Affected bunit fixtures green; added `data-app-ready` regression tests.
- Full `TestCategory=EndToEnd` suite: **28/28**, run twice, against a live app + COMET server.


