### PR TITLE
Feat #851 Convert DefinitionsTable to the SelectedDataItemForm edit pattern

### DIFF
--- a/COMETwebapp.Tests/Components/Common/DefinitionFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Common/DefinitionFormTestFixture.cs
@@ -1,0 +1,111 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DefinitionFormTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//   --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Common
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Common;
+
+    using Microsoft.AspNetCore.Components.Forms;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for the <see cref="DefinitionForm" /> component.
+    /// </summary>
+    [TestFixture]
+    public class DefinitionFormTestFixture
+    {
+        private BunitContext context;
+        private IRenderedComponent<DefinitionForm> renderer;
+        private Definition definition;
+        private bool isSaved;
+        private bool isCanceled;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.definition = new Definition
+            {
+                Iid = Guid.NewGuid(),
+                Content = "Sample content",
+                LanguageCode = "en-GB"
+            };
+
+            this.isSaved = false;
+            this.isCanceled = false;
+
+            var availableLanguages = new List<NaturalLanguage>
+            {
+                new() { LanguageCode = "en-GB", Name = "English", NativeName = "English" },
+                new() { LanguageCode = "fr", Name = "French", NativeName = "Français" }
+            };
+
+            this.renderer = this.context.Render<DefinitionForm>(parameters => parameters
+                .Add(p => p.Item, this.definition)
+                .Add(p => p.AvailableLanguages, availableLanguages)
+                .Add(p => p.OnSaved, () => Task.FromResult(this.isSaved = true))
+                .Add(p => p.OnCanceled, () => Task.FromResult(this.isCanceled = true)));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+            this.context.Dispose();
+        }
+
+        [Test]
+        public void VerifyDefinitionFormRendering()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.renderer.Instance.Item, Is.SameAs(this.definition));
+                Assert.That(this.renderer.Instance.AvailableLanguages.ToList(), Has.Count.EqualTo(2));
+                Assert.That(this.renderer.Markup, Does.Contain("Sample content"));
+            }
+        }
+
+        [Test]
+        public async Task VerifyFormSubmissionAndCancellation()
+        {
+            var editForm = this.renderer.FindComponent<EditForm>();
+            await this.renderer.InvokeAsync(editForm.Instance.OnValidSubmit.InvokeAsync);
+
+            Assert.That(this.isSaved, Is.True);
+
+            var formButtons = this.renderer.FindComponent<FormButtons>();
+            await this.renderer.InvokeAsync(formButtons.Instance.OnCancel.InvokeAsync);
+
+            Assert.That(this.isCanceled, Is.True);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/Common/DefinitionsTableTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Common/DefinitionsTableTestFixture.cs
@@ -1,24 +1,24 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="DefinitionsTableTestFixture.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
-//
-//     This file is part of COMET WEB Community Edition
-//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//
-//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
-//
-//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//    Affero General Public License for more details.
-//
+//     Affero General Public License for more details.
+// 
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //  </copyright>
-//  --------------------------------------------------------------------------------------------------------------------
+//   --------------------------------------------------------------------------------------------------------------------
 
 namespace COMETwebapp.Tests.Components.Common
 {
@@ -30,9 +30,10 @@ namespace COMETwebapp.Tests.Components.Common
     using COMET.Web.Common.Test.Helpers;
 
     using COMETwebapp.Components.Common;
-    using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
 
     using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components.Forms;
 
     using NUnit.Framework;
 
@@ -76,17 +77,6 @@ namespace COMETwebapp.Tests.Components.Common
         }
 
         [Test]
-        public void VerifyExistingDefinitionIsRendered()
-        {
-            Assert.Multiple(() =>
-            {
-                Assert.That(this.renderer.Instance.Thing, Is.SameAs(this.parameterType));
-                Assert.That(this.renderer.Markup, Does.Contain("Existing definition"));
-                Assert.That(this.renderer.Markup, Does.Contain("en-GB"));
-            });
-        }
-
-        [Test]
         public async Task VerifyAddDefinition()
         {
             var addButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
@@ -99,6 +89,34 @@ namespace COMETwebapp.Tests.Components.Common
                 Assert.That(this.renderer.Instance.Item.LanguageCode, Is.EqualTo("en-GB"));
                 Assert.That(this.parameterType.Definition, Has.Count.EqualTo(1));
             });
+        }
+
+        [Test]
+        public void VerifyExistingDefinitionIsRendered()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.Thing, Is.SameAs(this.parameterType));
+                Assert.That(this.renderer.Markup, Does.Contain("Existing definition"));
+                Assert.That(this.renderer.Markup, Does.Contain("en-GB"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyGetSelectableLanguagesExcludesUsedLanguages()
+        {
+            var english = new NaturalLanguage { LanguageCode = "en-GB", Name = "English" };
+            var french = new NaturalLanguage { LanguageCode = "fr", Name = "French" };
+
+            var languageRenderer = this.context.Render<DefinitionsTable>(parameters => parameters
+                .Add(p => p.Thing, this.parameterType)
+                .Add(p => p.AvailableLanguages, [english, french]));
+
+            var addButton = languageRenderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
+            await languageRenderer.InvokeAsync(addButton.Instance.Click.InvokeAsync);
+
+            // The parent already holds an en-GB definition, so only the unused French language may be selected for the new one.
+            Assert.That(languageRenderer.Instance.GetSelectableLanguages().Select(x => x.LanguageCode), Is.EqualTo(FrenchLanguageCode));
         }
 
         [Test]
@@ -134,20 +152,52 @@ namespace COMETwebapp.Tests.Components.Common
         }
 
         [Test]
-        public async Task VerifyGetSelectableLanguagesExcludesUsedLanguages()
+        public async Task VerifyStartEditAndFormSaveCancel()
         {
-            var english = new NaturalLanguage { LanguageCode = "en-GB", Name = "English" };
-            var french = new NaturalLanguage { LanguageCode = "fr", Name = "French" };
+            this.renderer.Instance.StartEdit(null);
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
 
-            var languageRenderer = this.context.Render<DefinitionsTable>(parameters => parameters
-                .Add(p => p.Thing, this.parameterType)
-                .Add(p => p.AvailableLanguages, new[] { english, french }));
+            var editButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "editDefinitionButton");
+            await this.renderer.InvokeAsync(editButton.Instance.Click.InvokeAsync);
 
-            var addButton = languageRenderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
-            await languageRenderer.InvokeAsync(addButton.Instance.Click.InvokeAsync);
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.ShouldCreate, Is.False);
+                Assert.That(this.renderer.Instance.IsOnEditMode, Is.True);
+                Assert.That(this.renderer.Instance.Item.Content, Is.EqualTo("Existing definition"));
+            });
 
-            // The parent already holds an en-GB definition, so only the unused French language may be selected for the new one.
-            Assert.That(languageRenderer.Instance.GetSelectableLanguages().Select(x => x.LanguageCode), Is.EqualTo(FrenchLanguageCode));
+            this.renderer.Instance.Item.Content = "Updated definition";
+            var form = this.renderer.FindComponent<EditForm>();
+            await this.renderer.InvokeAsync(form.Instance.OnValidSubmit.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
+                Assert.That(this.parameterType.Definition.First().Content, Is.EqualTo("Updated definition"));
+            });
+
+            var addButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
+            await this.renderer.InvokeAsync(addButton.Instance.Click.InvokeAsync);
+            this.renderer.Instance.Item.Content = "New definition";
+            this.renderer.Instance.Item.LanguageCode = "fr";
+
+            form = this.renderer.FindComponent<EditForm>();
+            await this.renderer.InvokeAsync(form.Instance.OnValidSubmit.InvokeAsync);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
+                Assert.That(this.parameterType.Definition, Has.Count.EqualTo(2));
+            });
+
+            addButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "addDefinitionButton");
+            await this.renderer.InvokeAsync(addButton.Instance.Click.InvokeAsync);
+
+            var cancelButton = this.renderer.FindComponents<DxButton>().First(x => x.Instance.Id == "cancelItemButton");
+            await this.renderer.InvokeAsync(cancelButton.Instance.Click.InvokeAsync);
+
+            Assert.That(this.renderer.Instance.IsOnEditMode, Is.False);
         }
     }
 }

--- a/COMETwebapp.Tests/Extensions/SessionServiceExtensionsTestFixture.cs
+++ b/COMETwebapp.Tests/Extensions/SessionServiceExtensionsTestFixture.cs
@@ -1,0 +1,80 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SessionServiceExtensionsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//   --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Extensions
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.Extensions;
+    using COMETwebapp.Utilities;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="SessionServiceExtensions" />.
+    /// </summary>
+    [TestFixture]
+    public class SessionServiceExtensionsTestFixture
+    {
+        private Mock<ISessionService> sessionService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.sessionService = new Mock<ISessionService>();
+        }
+
+        [Test]
+        public void VerifyGetAvailableNaturalLanguages()
+        {
+            var siteDirectory = new SiteDirectory();
+            siteDirectory.NaturalLanguage.Add(new NaturalLanguage { LanguageCode = "custom", Name = "Custom Language" });
+
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+
+            var languages = this.sessionService.Object.GetAvailableNaturalLanguages();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(languages, Is.Not.Empty);
+                Assert.That(languages.Any(x => x.LanguageCode == "custom"), Is.True);
+            });
+        }
+
+        [Test]
+        public void VerifyGetAvailableNaturalLanguagesWithNullSiteDirectory()
+        {
+            this.sessionService.Setup(x => x.GetSiteDirectory()).Returns((SiteDirectory)null);
+            var languages = this.sessionService.Object.GetAvailableNaturalLanguages();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(languages, Is.Not.Empty);
+                Assert.That(languages, Has.Count.EqualTo(DefaultNaturalLanguages.All.Count));
+            });
+        }
+    }
+}

--- a/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementDefinitionViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelEditor/EditElementDefinitionViewModelTestFixture.cs
@@ -148,6 +148,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelEditor
                 Assert.That(this.viewModel.SelectedCategories, Is.EquivalentTo(new[] { this.structureCategory }));
                 Assert.That(this.viewModel.IsTopElement, Is.False, "The seeded ED is not the iteration's top element.");
                 Assert.That(this.viewModel.AvailableCategories, Does.Contain(this.structureCategory));
+                Assert.That(this.viewModel.AvailableLanguages, Is.Not.Empty);
                 Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise, Is.EquivalentTo(new[] { this.domain, this.otherDomain }));
                 Assert.That(this.viewModel.DomainOfExpertiseSelectorViewModel.SelectedDomainOfExpertise, Is.EqualTo(this.domain));
             });

--- a/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ReferenceData/ParameterTypesTableViewModelTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="ParameterTypesTableViewModelTestFixture.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -140,6 +140,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ReferenceData
                 Assert.That(this.viewModel.Rows.Items.First().Thing, Is.EqualTo(this.parameterType));
                 Assert.That(this.viewModel.ReferenceDataLibraries, Is.EqualTo(this.siteDirectory.SiteReferenceDataLibrary));
                 Assert.That(this.viewModel.MeasurementScales.Count(), Is.EqualTo(1));
+                Assert.That(this.viewModel.AvailableLanguages, Is.Not.Empty);
             });
 
             this.viewModel.CurrentThing = new SpecializedQuantityKind

--- a/COMETwebapp/Components/Common/DefinitionForm.razor
+++ b/COMETwebapp/Components/Common/DefinitionForm.razor
@@ -1,0 +1,56 @@
+<!------------------------------------------------------------------------------
+Copyright (c) 2023-2026 Starion Group S.A.
+
+    This file is part of COMET WEB Community Edition
+    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+
+    The COMET WEB Community Edition is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------------->
+@inherits SelectedDataItemForm
+
+<EditForm Context="editFormContext"
+          Model="@(this.Item)"
+          OnValidSubmit="@(this.OnValidSubmit)">
+    <FluentValidationValidator/>
+    <DxFormLayout CssClass="w-100">
+        <DxFormLayoutItem Caption="Language Code:"
+                          ColSpanMd="10">
+            @if (this.AvailableLanguages.Any())
+            {
+                <DxComboBox Id="definitionLanguageCodeInput"
+                            Data="@(this.AvailableLanguages)"
+                            @bind-Value="@(this.Item.LanguageCode)"
+                            ValueFieldName="@nameof(NaturalLanguage.LanguageCode)"
+                            TextFieldName="@nameof(NaturalLanguage.NativeName)"
+                            AllowUserInput="true"
+                            FilteringMode="DataGridFilteringMode.Contains"
+                            NullText="Select a language..."/>
+            }
+            else
+            {
+                <DxTextBox Id="definitionLanguageCodeInput"
+                           @bind-Text="@(this.Item.LanguageCode)"/>
+            }
+        </DxFormLayoutItem>
+        <DxFormLayoutItem Caption="Content:"
+                          ColSpanMd="10">
+            <DxMemo Id="definitionContentInput"
+                    @bind-Text="@(this.Item.Content)"
+                    Rows="5"/>
+        </DxFormLayoutItem>
+    </DxFormLayout>
+    <FormButtons SaveButtonEnabled="@(this.IsSaveButtonEnabled(editFormContext))"
+                 OnCancel="@(this.OnCancel)"
+                 ValidationMessages="@(this.MapOfValidationMessages.SelectMany(x => x.Value))"/>
+</EditForm>

--- a/COMETwebapp/Components/Common/DefinitionForm.razor.cs
+++ b/COMETwebapp/Components/Common/DefinitionForm.razor.cs
@@ -1,0 +1,47 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DefinitionForm.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Common
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Support class for the <see cref="DefinitionForm" /> component.
+    /// </summary>
+    public partial class DefinitionForm : SelectedDataItemForm
+    {
+        /// <summary>
+        /// The <see cref="Definition" /> being created or edited.
+        /// </summary>
+        [Parameter]
+        public Definition Item { get; set; }
+
+        /// <summary>
+        /// The <see cref="NaturalLanguage" />s available for selection.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<NaturalLanguage> AvailableLanguages { get; set; } = [];
+    }
+}

--- a/COMETwebapp/Components/Common/DefinitionsTable.razor
+++ b/COMETwebapp/Components/Common/DefinitionsTable.razor
@@ -19,18 +19,16 @@ Copyright (c) 2023-2026 Starion Group S.A.
 ------------------------------------------------------------------------------->
 @inherits DisposableComponent
 
-<DxGrid @ref="this.Grid"
-        Data="this.GetRows()"
-        EditMode="GridEditMode.PopupEditForm"
-        PopupEditFormHeaderText="Definition"
-        EditModelSaving="@(() => this.OnEditItemSaving())"
-        CustomizeEditModel="this.CustomizeEditDefinition">
+<DxGrid Data="this.GetRows()">
     <Columns>
         <DxGridDataColumn FieldName="@nameof(DefinitionRowViewModel.LanguageCode)" Caption="Language" MinWidth="80" />
         <DxGridDataColumn FieldName="@nameof(DefinitionRowViewModel.Content)" Caption="Content" MinWidth="200" />
-        <DxGridCommandColumn Width="100px" EditButtonVisible="false">
+        <DxGridCommandColumn Width="100px">
             <HeaderTemplate>
-                <DxButton Id="addDefinitionButton" Text="Add" IconCssClass="oi oi-plus" Click="() => this.Grid.StartEditNewRowAsync()"/>
+                <DxButton Id="addDefinitionButton"
+                          Text="Add"
+                          IconCssClass="oi oi-plus"
+                          Click="this.StartCreate"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -38,7 +36,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editDefinitionButton"
                               IconCssClass="oi oi-pencil"
-                              Click="@(() => this.Grid.StartEditRowAsync(context.VisibleIndex))"/>
+                              Click="@(() => this.StartEdit(row))"/>
 
                     <DxButton Id="removeDefinitionButton"
                               IconCssClass="oi oi-trash"
@@ -47,38 +45,24 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </CellDisplayTemplate>
         </DxGridCommandColumn>
     </Columns>
-
-    <EditFormTemplate Context="EditFormContext">
-        <FluentValidationValidator/>
-        <DxFormLayout CssClass="w-100">
-            <DxFormLayoutItem Caption="Language Code:" ColSpanMd="10">
-                @if (this.AvailableLanguages.Any())
-                {
-                    <DxComboBox Id="definitionLanguageCodeInput"
-                                Data="@this.GetSelectableLanguages()"
-                                @bind-Value="@this.Item.LanguageCode"
-                                ValueFieldName="@nameof(CDP4Common.SiteDirectoryData.NaturalLanguage.LanguageCode)"
-                                TextFieldName="@nameof(CDP4Common.SiteDirectoryData.NaturalLanguage.NativeName)"
-                                AllowUserInput="true"
-                                FilteringMode="DataGridFilteringMode.Contains"
-                                NullText="Select a language..."/>
-                }
-                else
-                {
-                    <DxTextBox Id="definitionLanguageCodeInput" @bind-Text="@(this.Item.LanguageCode)"/>
-                }
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Content:" ColSpanMd="10">
-                <DxMemo Id="definitionContentInput" @bind-Text="@(this.Item.Content)" Rows="5"/>
-            </DxFormLayoutItem>
-        </DxFormLayout>
-        <div class="pt-3"></div>
-        <ValidationSummary/>
-    </EditFormTemplate>
 </DxGrid>
+
+<DxPopup HeaderText="Definition"
+         @bind-Visible="@this.IsOnEditMode"
+         CloseOnOutsideClick="false">
+    <BodyContentTemplate Context="popupContext">
+        <DefinitionForm Item="@this.Item"
+                        AvailableLanguages="@this.GetSelectableLanguages()"
+                        ShouldCreate="@this.ShouldCreate"
+                        IsVisible="@this.IsOnEditMode"
+                        IsVisibleChanged="@(visible => this.IsOnEditMode = visible)"
+                        OnSaved="@this.OnSaved"
+                        OnCanceled="@this.OnCanceled"/>
+    </BodyContentTemplate>
+</DxPopup>
 
 <ConfirmRemovalPopup TItem="DefinitionRowViewModel"
                      @ref="this.RemovalPopup"
                      HeaderText="Delete definition"
                      ContentText="Are you sure you want to delete this definition?"
-                     OnRemove="@(row => this.RemoveItem(row))"/>
+                     OnRemove="@(this.RemoveItem)"/>

--- a/COMETwebapp/Components/Common/DefinitionsTable.razor.cs
+++ b/COMETwebapp/Components/Common/DefinitionsTable.razor.cs
@@ -1,24 +1,24 @@
 // --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="DefinitionsTable.razor.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
-//
-//     This file is part of COMET WEB Community Edition
-//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//
-//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
 //     modify it under the terms of the GNU Affero General Public
 //     License as published by the Free Software Foundation; either
 //     version 3 of the License, or (at your option) any later version.
-//
-//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
 //     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//    Affero General Public License for more details.
-//
+//     Affero General Public License for more details.
+// 
 //    You should have received a copy of the GNU Affero General Public License
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //  </copyright>
-//  --------------------------------------------------------------------------------------------------------------------
+//   --------------------------------------------------------------------------------------------------------------------
 
 namespace COMETwebapp.Components.Common
 {
@@ -29,8 +29,6 @@ namespace COMETwebapp.Components.Common
 
     using COMETwebapp.Services.RowViewModelFactoryService;
     using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
-
-    using DevExpress.Blazor;
 
     using Microsoft.AspNetCore.Components;
 
@@ -53,12 +51,6 @@ namespace COMETwebapp.Components.Common
         public ConfirmRemovalPopup<DefinitionRowViewModel> RemovalPopup { get; private set; }
 
         /// <summary>
-        /// Notifies the surrounding form that the parent <see cref="DefinedThing" />'s definition collection has changed.
-        /// </summary>
-        [Parameter]
-        public EventCallback<DefinedThing> ThingChanged { get; set; }
-
-        /// <summary>
         /// The <see cref="NaturalLanguage" />s the user may pick from. When empty, the language is edited as free text
         /// (backward-compatible); when provided, the language is a dropdown that excludes languages already used by the
         /// parent so a <see cref="DefinedThing" /> keeps at most one <see cref="Definition" /> per language.
@@ -72,49 +64,46 @@ namespace COMETwebapp.Components.Common
         public bool ShouldCreate { get; private set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the form popup is visible for editing or creating.
+        /// </summary>
+        public bool IsOnEditMode { get; set; }
+
+        /// <summary>
         /// The <see cref="Definition" /> currently bound to the popup edit form.
         /// </summary>
         public Definition Item { get; private set; }
 
         /// <summary>
-        /// The <see cref="DxGrid" /> hosting the table — kept so that the toolbar buttons can drive its edit state.
+        /// Starts the creation flow for a new <see cref="Definition" /> item.
         /// </summary>
-        public IGrid Grid { get; private set; }
-
-        /// <summary>
-        /// Builds the row view models displayed by the grid from the parent's current <see cref="Definition" /> list.
-        /// </summary>
-        /// <returns>Rows for the grid, ordered by language code.</returns>
-        protected List<DefinitionRowViewModel> GetRows()
+        public void StartCreate()
         {
-            return this.Thing?.Definition
-                .Select(x => (DefinitionRowViewModel)RowViewModelFactory.CreateRow(x))
-                .OrderBy(x => x.LanguageCode, StringComparer.InvariantCultureIgnoreCase)
-                .ToList();
+            this.ShouldCreate = true;
+            this.Item = new Definition { Iid = Guid.NewGuid(), LanguageCode = "en-GB" };
+            this.IsOnEditMode = true;
         }
 
         /// <summary>
-        /// Adds a freshly-created <see cref="Definition" /> when the grid asks for the popup edit form's bound item, or
-        /// hands it a clone of the selected row's underlying <see cref="Definition" /> when editing an existing one.
+        /// Starts the edit flow for the specified <paramref name="row" />.
         /// </summary>
-        /// <param name="e">The grid customize-edit-model event.</param>
-        protected void CustomizeEditDefinition(GridCustomizeEditModelEventArgs e)
+        /// <param name="row">The selected row to edit.</param>
+        public void StartEdit(DefinitionRowViewModel row)
         {
-            var dataItem = (DefinitionRowViewModel)e.DataItem;
-            this.ShouldCreate = e.IsNew;
+            if (row == null)
+            {
+                return;
+            }
 
-            this.Item = dataItem == null
-                ? new Definition { Iid = Guid.NewGuid(), LanguageCode = "en-GB" }
-                : dataItem.Thing.Clone(true);
-
-            e.EditModel = this.Item;
+            this.ShouldCreate = false;
+            this.Item = row.Thing.Clone(true);
+            this.IsOnEditMode = true;
         }
 
         /// <summary>
         /// Persists the popup edit form's <see cref="Item" /> back onto the parent's <see cref="Definition" /> collection,
         /// either appending it (create) or replacing the matching existing entry in place (edit).
         /// </summary>
-        protected void OnEditItemSaving()
+        public void OnSaved()
         {
             if (this.ShouldCreate)
             {
@@ -126,7 +115,15 @@ namespace COMETwebapp.Components.Common
                 this.Thing.Definition[indexToUpdate] = this.Item;
             }
 
-            this.ThingChanged.InvokeAsync(this.Thing);
+            this.IsOnEditMode = false;
+        }
+
+        /// <summary>
+        /// Handles cancellation of the form popup.
+        /// </summary>
+        public void OnCanceled()
+        {
+            this.IsOnEditMode = false;
         }
 
         /// <summary>
@@ -146,15 +143,25 @@ namespace COMETwebapp.Components.Common
         }
 
         /// <summary>
+        /// Builds the row view models displayed by the grid from the parent's current <see cref="Definition" /> list.
+        /// </summary>
+        /// <returns>Rows for the grid, ordered by language code.</returns>
+        protected List<DefinitionRowViewModel> GetRows()
+        {
+            return this.Thing?.Definition
+                .Select(x => (DefinitionRowViewModel)RowViewModelFactory.CreateRow(x))
+                .OrderBy(x => x.LanguageCode, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
         /// Removes the underlying <see cref="Definition" /> from the parent's collection, once the user has confirmed the
         /// removal in the <see cref="RemovalPopup" />.
         /// </summary>
         /// <param name="row">The row whose <see cref="Definition" /> should be removed.</param>
-        /// <returns>A <see cref="Task" />.</returns>
-        protected async Task RemoveItem(DefinitionRowViewModel row)
+        protected void RemoveItem(DefinitionRowViewModel row)
         {
             this.Thing.Definition.Remove(row.Thing);
-            await this.ThingChanged.InvokeAsync(this.Thing);
         }
     }
 }

--- a/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
+++ b/COMETwebapp/Components/Common/SelectedDataItemBase.razor.cs
@@ -59,6 +59,7 @@ namespace COMETwebapp.Components.Common
         /// <summary>
         /// Gets or sets the grid control that is being customized.
         /// </summary>
+        [Obsolete("Grid-editing members are obsolete. Use StartCreate() and StartEdit(TRow) instead.")]
         protected IGrid Grid { get; set; }
 
         /// <summary>
@@ -82,6 +83,7 @@ namespace COMETwebapp.Components.Common
         /// Method invoked when creating a new thing
         /// </summary>
         /// <param name="e">A <see cref="GridCustomizeEditModelEventArgs" /></param>
+        [Obsolete("Grid-editing members are obsolete. Use StartCreate() and StartEdit(TRow) instead.")]
         protected virtual void CustomizeEditThing(GridCustomizeEditModelEventArgs e)
         {
         }
@@ -102,6 +104,31 @@ namespace COMETwebapp.Components.Common
         protected virtual void OnSelectedDataItemChanged(TRow row)
         {
             this.IsOnEditMode = true;
+        }
+
+        /// <summary>
+        /// Starts the creation flow for a new <typeparamref name="T"/> item.
+        /// </summary>
+        public virtual void StartCreate()
+        {
+            this.ShouldCreateThing = true;
+            this.IsOnEditMode = true;
+
+            this.InvokeAsync(this.StateHasChanged);
+        }
+
+        /// <summary>
+        /// Starts the edit flow for the specified <paramref name="row"/>.
+        /// </summary>
+        /// <param name="row">The selected row to edit.</param>
+        public virtual void StartEdit(TRow row)
+        {
+            if (row == null)
+            {
+                return;
+            }
+
+            this.OnSelectedDataItemChanged(row);
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
+++ b/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
@@ -52,7 +52,8 @@
                 </DxFormLayoutTabPage>
 
                 <DxFormLayoutTabPage Caption="Definition">
-                    <DefinitionsTable Thing="@this.ViewModel.ElementDefinition"/>
+                    <DefinitionsTable Thing="@this.ViewModel.ElementDefinition"
+                                      AvailableLanguages="@this.ViewModel.AvailableLanguages"/>
                 </DxFormLayoutTabPage>
             </DxFormLayoutTabPages>
         </DxFormLayout>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ParameterTypeForm.razor
@@ -1,4 +1,4 @@
-﻿<!------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------
 Copyright (c) 2023-2026 Starion Group S.A.
 
     This file is part of COMET WEB Community Edition
@@ -186,7 +186,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </DxFormLayoutTabPage>
 
             <DxFormLayoutTabPage Caption="Definitions">
-                <DefinitionsTable Thing="@(this.ViewModel.CurrentThing)"/>
+                <DefinitionsTable Thing="@(this.ViewModel.CurrentThing)"
+                                  AvailableLanguages="@(this.ViewModel.AvailableLanguages)"/>
             </DxFormLayoutTabPage>
         </DxFormLayoutTabPages>
     </DxFormLayout>

--- a/COMETwebapp/Extensions/SessionServiceExtensions.cs
+++ b/COMETwebapp/Extensions/SessionServiceExtensions.cs
@@ -1,0 +1,72 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SessionServiceExtensions.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+// 
+//     This file is part of CDP4-COMET WEB Community Edition
+//     The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//     The CDP4-COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+// 
+//     The CDP4-COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//     Affero General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//   --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Extensions
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Services.SessionManagement;
+
+    using COMETwebapp.Utilities;
+
+    /// <summary>
+    /// Static class containing extension methods for <see cref="ISessionService" />.
+    /// </summary>
+    public static class SessionServiceExtensions
+    {
+        /// <summary>
+        /// Gets the available <see cref="NaturalLanguage" />s offered for a definition: the default IME language set
+        /// (<see cref="DefaultNaturalLanguages.All" />) merged with any languages defined on the model's
+        /// <see cref="SiteDirectory" />,
+        /// the model ones taking precedence, de-duplicated by language code and ordered by name.
+        /// </summary>
+        /// <param name="sessionService">The <see cref="ISessionService" />.</param>
+        /// <returns>A list of available <see cref="NaturalLanguage" />s.</returns>
+        public static List<NaturalLanguage> GetAvailableNaturalLanguages(this ISessionService sessionService)
+        {
+            var languagesByCode = new Dictionary<string, NaturalLanguage>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var language in DefaultNaturalLanguages.All)
+            {
+                languagesByCode[language.LanguageCode] = language;
+            }
+
+            var siteDirectory = sessionService?.GetSiteDirectory();
+
+            if (siteDirectory?.NaturalLanguage == null)
+            {
+                return languagesByCode.Values
+                    .OrderBy(x => string.IsNullOrWhiteSpace(x.NativeName) ? x.Name : x.NativeName, StringComparer.InvariantCultureIgnoreCase)
+                    .ToList();
+            }
+
+            foreach (var language in siteDirectory.NaturalLanguage)
+            {
+                languagesByCode[language.LanguageCode] = language;
+            }
+
+            return languagesByCode.Values
+                .OrderBy(x => string.IsNullOrWhiteSpace(x.NativeName) ? x.Name : x.NativeName, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/EditElementDefinitionViewModel.cs
@@ -28,7 +28,8 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
 
     using CDP4Dal;
 
-    using COMET.Web.Common.Extensions;
+    using COMETwebapp.Extensions;
+
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
@@ -122,6 +123,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         public IEnumerable<Category> AvailableCategories { get; private set; } = new List<Category>();
 
         /// <summary>
+        /// Gets the <see cref="NaturalLanguage" />s available for selection in definition fields.
+        /// </summary>
+        public IEnumerable<NaturalLanguage> AvailableLanguages { get; private set; } = [];
+
+        /// <summary>
         /// Gets or sets a value indicating whether the edited <see cref="ElementDefinition" /> should be
         /// promoted to <see cref="Iteration.TopElement" /> on save. Initialized to the iteration's current
         /// top-element identity.
@@ -173,6 +179,7 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
             this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(elementDefinition.Owner is null, elementDefinition.Owner);
 
             this.AvailableCategories = this.GetAvailableCategories();
+            this.AvailableLanguages = this.sessionService.GetAvailableNaturalLanguages();
         }
 
         /// <summary>

--- a/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/IEditElementDefinitionViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelEditor/EditElementDefinitionViewModel/IEditElementDefinitionViewModel.cs
@@ -63,6 +63,11 @@ namespace COMETwebapp.ViewModels.Components.ModelEditor.EditElementDefinitionVie
         IEnumerable<Category> AvailableCategories { get; }
 
         /// <summary>
+        /// Gets the <see cref="NaturalLanguage" />s available for selection in definition fields.
+        /// </summary>
+        IEnumerable<NaturalLanguage> AvailableLanguages { get; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the edited <see cref="ElementDefinition" /> should be
         /// promoted to <see cref="Iteration.TopElement" /> on save.
         /// </summary>

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/IParameterTypeTableViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="IParameterTypeTableViewModel.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -68,6 +68,11 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// <see cref="ReferenceDataLibrary" />s and filtered by <see cref="Category.PermissibleClass" />.
         /// </summary>
         IEnumerable<Category> Categories { get; }
+
+        /// <summary>
+        /// Gets the available <see cref="NaturalLanguage" />s.
+        /// </summary>
+        IEnumerable<NaturalLanguage> AvailableLanguages { get; }
 
         /// <summary>
         /// Creates or edits a <see cref="ParameterType" />

--- a/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ReferenceData/ParameterTypes/ParameterTypeTableViewModel.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.ViewModels.Components.Applications;
 
+    using COMETwebapp.Extensions;
     using COMETwebapp.Services.ShowHideDeprecatedThingsService;
     using COMETwebapp.ViewModels.Components.Common.DeprecatableDataItemTable;
     using COMETwebapp.ViewModels.Components.ReferenceData.Rows;
@@ -84,6 +85,11 @@ namespace COMETwebapp.ViewModels.Components.ReferenceData.ParameterTypes
         /// Gets the available <see cref="ReferenceDataLibrary" />s
         /// </summary>
         public IEnumerable<ReferenceDataLibrary> ReferenceDataLibraries { get; private set; } = [];
+
+        /// <summary>
+        /// Gets the available <see cref="NaturalLanguage" />s.
+        /// </summary>
+        public IEnumerable<NaturalLanguage> AvailableLanguages => this.SessionService.GetAvailableNaturalLanguages();
 
         /// <summary>
         /// Gets the possible available <see cref="MeasurementScale" />s

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/EditRequirementThingViewModel.cs
@@ -33,6 +33,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
     using COMET.Web.Common.Utilities.DisposableObject;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
+    using COMETwebapp.Extensions;
     using COMETwebapp.Utilities;
 
     using Microsoft.AspNetCore.Components;
@@ -244,7 +245,7 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             this.Thing = thing;
             this.AvailableGroups = availableGroups ?? [];
             this.AvailableCategories = this.GetAvailableCategories(thing.ClassKind);
-            this.AvailableLanguages = this.GetAvailableLanguages();
+            this.AvailableLanguages = this.sessionService.GetAvailableNaturalLanguages();
 
             this.selectedLanguageCode = this.DefinedThing.Definition.FirstOrDefault()?.LanguageCode ?? this.GetDirectoryDefaultLanguageCode();
 
@@ -260,31 +261,6 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
             this.DomainOfExpertiseSelectorViewModel.CurrentIteration = iteration;
             this.DomainOfExpertiseSelectorViewModel.AvailableDomainsOfExpertise = ((EngineeringModel)iteration.Container).EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
             this.DomainOfExpertiseSelectorViewModel.SetSelectedDomainOfExpertiseOrReset(owner is null, owner);
-        }
-
-        /// <summary>
-        /// Builds the languages offered for a definition: the default IME language set (<see cref="DefaultNaturalLanguages" />)
-        /// merged with any languages defined on the model's <see cref="SiteDirectory" />, the model ones taking precedence,
-        /// de-duplicated by language code and ordered by name.
-        /// </summary>
-        /// <returns>The available languages.</returns>
-        private List<NaturalLanguage> GetAvailableLanguages()
-        {
-            var languagesByCode = new Dictionary<string, NaturalLanguage>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var language in DefaultNaturalLanguages.All)
-            {
-                languagesByCode[language.LanguageCode] = language;
-            }
-
-            foreach (var language in this.sessionService.GetSiteDirectory().NaturalLanguage)
-            {
-                languagesByCode[language.LanguageCode] = language;
-            }
-
-            return languagesByCode.Values
-                .OrderBy(x => string.IsNullOrWhiteSpace(x.NativeName) ? x.Name : x.NativeName, StringComparer.InvariantCultureIgnoreCase)
-                .ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Closes #851 Convert DefinitionsTable to the SelectedDataItemForm edit pattern
<!-- Thanks for contributing to COMET-WEB! -->

**NOTE**: This PR also fixes a bug where the available languages were not passed to the table component, making the app display a textbox instead of a combobox

