### PR TITLE
Feat/gh812 harmonize filter settings and 887 button coloring

### DIFF
--- a/COMET.Web.Common.Tests/Components/ParameterTypeEditors/CompoundParameterTypeEditorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/ParameterTypeEditors/CompoundParameterTypeEditorTestFixture.cs
@@ -154,6 +154,18 @@ namespace COMET.Web.Common.Tests.Components.ParameterTypeEditors
                 Assert.That(this.editor, Is.Not.Null);
                 Assert.That(this.editor.ViewModel, Is.Not.Null);
             });
+
+            var editButton = this.renderedComponent.FindComponent<DxButton>();
+            Assert.That(editButton.Instance.Text, Is.EqualTo("Edit"));
+        }
+
+        [Test]
+        public async Task VerifyEditButtonClickTriggersComponentSelection()
+        {
+            var editButton = this.renderedComponent.FindComponent<DxButton>();
+            await this.renderedComponent.InvokeAsync(editButton.Instance.Click.InvokeAsync);
+
+            this.viewModelMock.As<ICompoundParameterTypeEditorViewModel>().Verify(x => x.OnComponentSelected(), Times.Once);
         }
 
         [Test]

--- a/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/ParameterTypeEditors/TextParameterTypeEditorTestFixture.cs
@@ -105,6 +105,20 @@ namespace COMET.Web.Common.Tests.Components.ParameterTypeEditors
         }
 
         [Test]
+        public async Task VerifyMultilineOkButtonClosesEditMode()
+        {
+            var textboxButton = this.renderedComponent.FindComponent<DxEditorButton>();
+            await this.renderedComponent.InvokeAsync(() => textboxButton.Instance.Click.InvokeAsync(null));
+
+            Assert.That(this.editor.IsOnEditMode, Is.True);
+
+            var okButton = this.renderedComponent.FindComponents<DxButton>().Single(b => b.Instance.Text == "OK");
+            await this.renderedComponent.InvokeAsync(okButton.Instance.Click.InvokeAsync);
+
+            Assert.That(this.editor.IsOnEditMode, Is.False);
+        }
+
+        [Test]
         public async Task VerifyParameterValueChanged()
         {
             var textbox = this.renderedComponent.FindComponent<DxTextBox>();

--- a/COMET.Web.Common.Tests/Components/Selectors/ElementBaseSelectorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/ElementBaseSelectorTestFixture.cs
@@ -1,0 +1,96 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ElementBaseSelectorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using DevExpress.Blazor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ElementBaseSelectorTestFixture
+    {
+        private BunitContext context;
+        private Mock<IElementBaseSelectorViewModel> viewModel;
+        private List<ElementBase> availableElements;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.availableElements = new List<ElementBase>
+            {
+                new ElementDefinition { Iid = Guid.NewGuid(), Name = "Element A" },
+                new ElementDefinition { Iid = Guid.NewGuid(), Name = "Element B" }
+            };
+
+            this.viewModel = new Mock<IElementBaseSelectorViewModel>();
+            this.viewModel.Setup(x => x.AvailableElements).Returns(this.availableElements);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public void VerifyElementBaseSelectorComponent()
+        {
+            var renderer = this.context.Render<ElementBaseSelector>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            Assert.That(renderer.FindComponents<DxComboBox<ElementBase, ElementBase>>(), Is.Empty,
+                "without a CurrentIteration the selector must not render.");
+
+            this.viewModel.Setup(x => x.CurrentIteration).Returns(new Iteration { Iid = Guid.NewGuid() });
+            renderer.Render();
+
+            // The DxComboBox is asserted by presence only: DevExpress echoes neither Data nor ValueChanged back
+            // onto its own instance under bunit.
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Find("h6").TextContent, Is.EqualTo("Filter on Element:"));
+                Assert.That(renderer.FindComponent<DxComboBox<ElementBase, ElementBase>>(), Is.Not.Null);
+            });
+
+            renderer.Render(parameters => parameters.Add(p => p.DisplayText, string.Empty));
+
+            Assert.That(renderer.FindAll("h6"), Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/Selectors/FilterTagBoxTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/FilterTagBoxTestFixture.cs
@@ -1,0 +1,105 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="FilterTagBoxTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Test.Helpers;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class FilterTagBoxTestFixture
+    {
+        private BunitContext context;
+        private List<Category> availableCategories;
+        private List<Category> selectedCategories;
+        private IEnumerable<Category> valuesChangedResult;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.availableCategories = new List<Category>
+            {
+                new() { Iid = Guid.NewGuid(), Name = "Category A" },
+                new() { Iid = Guid.NewGuid(), Name = "Category B" }
+            };
+
+            this.selectedCategories = new List<Category> { this.availableCategories[0] };
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifyFilterTagBoxComponent()
+        {
+            var valuesChanged = new EventCallbackFactory().Create<IEnumerable<Category>>(this, values => this.valuesChangedResult = values);
+
+            var renderer = this.context.Render<FilterTagBox<Category>>(parameters =>
+            {
+                parameters.Add(p => p.Data, this.availableCategories);
+                parameters.Add(p => p.Values, this.selectedCategories);
+                parameters.Add(p => p.ValuesChanged, valuesChanged);
+                parameters.Add(p => p.TextFieldName, nameof(Category.Name));
+                parameters.Add(p => p.NullText, "Filter by category...");
+            });
+
+            var tagBox = renderer.FindComponent<DxTagBox<Category, Category>>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tagBox.Instance.Data, Is.EqualTo(this.availableCategories));
+                Assert.That(tagBox.Instance.Values, Is.EqualTo(this.selectedCategories));
+                Assert.That(tagBox.Instance.TextFieldName, Is.EqualTo(nameof(Category.Name)));
+                Assert.That(tagBox.Instance.NullText, Is.EqualTo("Filter by category..."));
+                Assert.That(renderer.Instance.AdditionalAttributes, Is.Empty, "With no unmatched attributes, nothing extra is splatted onto the tag box.");
+            });
+
+            // Invoked on FilterTagBox's own ValuesChanged rather than the nested DxTagBox: DevExpress does not
+            // echo the bound EventCallback back onto its own instance under bunit.
+            var newValues = new List<Category> { this.availableCategories[1] };
+            await renderer.InvokeAsync(() => renderer.Instance.ValuesChanged.InvokeAsync(newValues));
+
+            Assert.That(this.valuesChangedResult, Is.EqualTo(newValues));
+
+            renderer.Render(parameters => parameters.AddUnmatched("id", "categoryFilter"));
+
+            Assert.That(renderer.Instance.AdditionalAttributes["id"], Is.EqualTo("categoryFilter"));
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/Selectors/IterationSelectorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/IterationSelectorTestFixture.cs
@@ -1,0 +1,102 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IterationSelectorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Model;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using DevExpress.Blazor;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class IterationSelectorTestFixture
+    {
+        private BunitContext context;
+        private Mock<IIterationSelectorViewModel> viewModel;
+        private List<IterationData> iterations;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            var modelSetup = new EngineeringModelSetup { Iid = Guid.NewGuid(), Name = "model" };
+            var iterationSetupA = new IterationSetup { Iid = Guid.NewGuid(), IterationNumber = 1, Container = modelSetup };
+            var iterationSetupB = new IterationSetup { Iid = Guid.NewGuid(), IterationNumber = 2, Container = modelSetup };
+
+            this.iterations = new List<IterationData>
+            {
+                new(iterationSetupA),
+                new(iterationSetupB)
+            };
+
+            this.viewModel = new Mock<IIterationSelectorViewModel>();
+            this.viewModel.Setup(x => x.AvailableIterations).Returns(this.iterations);
+            this.viewModel.Setup(x => x.Submit()).Returns(Task.CompletedTask);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifyIterationSelectorComponent()
+        {
+            var renderer = this.context.Render<IterationSelector>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            var listBox = renderer.FindComponent<DxListBox<IterationData, IterationData>>();
+            var submitButton = renderer.FindComponent<DxButton>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(listBox.Instance.Data.Count(), Is.EqualTo(2));
+                Assert.That(submitButton.Instance.Enabled, Is.False);
+            });
+
+            this.viewModel.Setup(x => x.SelectedIteration).Returns(this.iterations[^1]);
+            renderer.Render();
+
+            Assert.That(submitButton.Instance.Enabled, Is.True);
+
+            await renderer.InvokeAsync(submitButton.Instance.Click.InvokeAsync);
+            this.viewModel.Verify(x => x.Submit(), Times.Once);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/Selectors/MultiElementBaseSelectorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/MultiElementBaseSelectorTestFixture.cs
@@ -1,0 +1,102 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiElementBaseSelectorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MultiElementBaseSelectorTestFixture
+    {
+        private BunitContext context;
+        private Mock<IMultiElementBaseSelectorViewModel> viewModel;
+        private List<ElementBase> availableElements;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.availableElements = new List<ElementBase>
+            {
+                new ElementDefinition { Iid = Guid.NewGuid(), Name = "Element A" },
+                new ElementDefinition { Iid = Guid.NewGuid(), Name = "Element B" }
+            };
+
+            this.viewModel = new Mock<IMultiElementBaseSelectorViewModel>();
+            this.viewModel.Setup(x => x.AvailableElements).Returns(this.availableElements);
+            this.viewModel.SetupProperty(x => x.SelectedElementBases, Enumerable.Empty<ElementBase>());
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifyMultiElementBaseSelectorComponent()
+        {
+            var renderer = this.context.Render<MultiElementBaseSelector>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            Assert.That(renderer.FindComponents<FilterTagBox<ElementBase>>(), Is.Empty,
+                "without a CurrentIteration the selector must not render.");
+
+            this.viewModel.Setup(x => x.CurrentIteration).Returns(new Iteration { Iid = Guid.NewGuid() });
+            renderer.Render();
+
+            var filterTagBox = renderer.FindComponent<FilterTagBox<ElementBase>>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Find("h6").TextContent, Is.EqualTo("Filter on Element:"));
+                Assert.That(filterTagBox.Instance.Data, Is.EqualTo(this.availableElements));
+            });
+
+            // Invoked on FilterTagBox rather than the nested DxTagBox: DevExpress does not echo the bound
+            // EventCallback back onto its own instance under bunit.
+            var newSelection = new List<ElementBase> { this.availableElements[0] };
+            await renderer.InvokeAsync(() => filterTagBox.Instance.ValuesChanged.InvokeAsync(newSelection));
+
+            Assert.That(this.viewModel.Object.SelectedElementBases, Is.EqualTo(newSelection));
+
+            renderer.Render(parameters => parameters.Add(p => p.DisplayText, string.Empty));
+
+            Assert.That(renderer.FindAll("h6"), Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/Selectors/MultiFiniteStateSelectorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/MultiFiniteStateSelectorTestFixture.cs
@@ -1,0 +1,114 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiFiniteStateSelectorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MultiFiniteStateSelectorTestFixture
+    {
+        private BunitContext context;
+        private Mock<IMultiFiniteStateSelectorViewModel> viewModel;
+        private List<ActualFiniteState> availableFiniteStates;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            var possibleFiniteStateList = new PossibleFiniteStateList { Iid = Guid.NewGuid() };
+            possibleFiniteStateList.PossibleState.Add(new PossibleFiniteState { Iid = Guid.NewGuid(), Name = "State A" });
+            possibleFiniteStateList.PossibleState.Add(new PossibleFiniteState { Iid = Guid.NewGuid(), Name = "State B" });
+
+            var actualFiniteStateList = new ActualFiniteStateList { Iid = Guid.NewGuid() };
+            actualFiniteStateList.PossibleFiniteStateList.Add(possibleFiniteStateList);
+
+            foreach (PossibleFiniteState possibleState in possibleFiniteStateList.PossibleState)
+            {
+                actualFiniteStateList.ActualState.Add(new ActualFiniteState
+                {
+                    Iid = Guid.NewGuid(),
+                    PossibleState = new List<PossibleFiniteState> { possibleState }
+                });
+            }
+
+            this.availableFiniteStates = actualFiniteStateList.ActualState.ToList();
+
+            this.viewModel = new Mock<IMultiFiniteStateSelectorViewModel>();
+            this.viewModel.Setup(x => x.AvailableFiniteStates).Returns(this.availableFiniteStates);
+            this.viewModel.SetupProperty(x => x.SelectedActualFiniteStates, Enumerable.Empty<ActualFiniteState>());
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifyMultiFiniteStateSelectorComponent()
+        {
+            var renderer = this.context.Render<MultiFiniteStateSelector>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            Assert.That(renderer.FindComponents<FilterTagBox<ActualFiniteState>>(), Is.Empty,
+                "without a CurrentIteration the selector must not render.");
+
+            this.viewModel.Setup(x => x.CurrentIteration).Returns(new Iteration { Iid = Guid.NewGuid() });
+            renderer.Render();
+
+            var filterTagBox = renderer.FindComponent<FilterTagBox<ActualFiniteState>>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Find("h6").TextContent, Is.EqualTo("Filter on State:"));
+                Assert.That(filterTagBox.Instance.Data, Is.EqualTo(this.availableFiniteStates));
+            });
+
+            // Invoked on FilterTagBox rather than the nested DxTagBox: DevExpress does not echo the bound
+            // EventCallback back onto its own instance under bunit.
+            var newSelection = new List<ActualFiniteState> { this.availableFiniteStates[0] };
+            await renderer.InvokeAsync(() => filterTagBox.Instance.ValuesChanged.InvokeAsync(newSelection));
+
+            Assert.That(this.viewModel.Object.SelectedActualFiniteStates, Is.EqualTo(newSelection));
+
+            renderer.Render(parameters => parameters.Add(p => p.DisplayText, string.Empty));
+
+            Assert.That(renderer.FindAll("h6"), Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/Selectors/MultiOptionSelectorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/Selectors/MultiOptionSelectorTestFixture.cs
@@ -1,0 +1,102 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiOptionSelectorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components.Selectors
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components.Selectors;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MultiOptionSelectorTestFixture
+    {
+        private BunitContext context;
+        private Mock<IMultiOptionSelectorViewModel> viewModel;
+        private List<Option> availableOptions;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.availableOptions = new List<Option>
+            {
+                new() { Iid = Guid.NewGuid(), Name = "Option A" },
+                new() { Iid = Guid.NewGuid(), Name = "Option B" }
+            };
+
+            this.viewModel = new Mock<IMultiOptionSelectorViewModel>();
+            this.viewModel.Setup(x => x.AvailableOptions).Returns(this.availableOptions);
+            this.viewModel.SetupProperty(x => x.SelectedOptions, Enumerable.Empty<Option>());
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifyMultiOptionSelectorComponent()
+        {
+            var renderer = this.context.Render<MultiOptionSelector>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            Assert.That(renderer.FindComponents<FilterTagBox<Option>>(), Is.Empty,
+                "without a CurrentIteration the selector must not render.");
+
+            this.viewModel.Setup(x => x.CurrentIteration).Returns(new Iteration { Iid = Guid.NewGuid() });
+            renderer.Render();
+
+            var filterTagBox = renderer.FindComponent<FilterTagBox<Option>>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Find("h6").TextContent, Is.EqualTo("Filter on Option:"));
+                Assert.That(filterTagBox.Instance.Data, Is.EqualTo(this.availableOptions));
+            });
+
+            // Invoked on FilterTagBox rather than the nested DxTagBox: DevExpress does not echo the bound
+            // EventCallback back onto its own instance under bunit.
+            var newSelection = new List<Option> { this.availableOptions[0] };
+            await renderer.InvokeAsync(() => filterTagBox.Instance.ValuesChanged.InvokeAsync(newSelection));
+
+            Assert.That(this.viewModel.Object.SelectedOptions, Is.EqualTo(newSelection));
+
+            renderer.Render(parameters => parameters.Add(p => p.DisplayText, string.Empty));
+
+            Assert.That(renderer.FindAll("h6"), Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/SwitchDomainTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/SwitchDomainTestFixture.cs
@@ -1,0 +1,92 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SwitchDomainTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components
+{
+    using Bunit;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.ViewModels.Components;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SwitchDomainTestFixture
+    {
+        private BunitContext context;
+        private Mock<ISwitchDomainViewModel> viewModel;
+        private List<DomainOfExpertise> availableDomains;
+        private DomainOfExpertise submittedDomain;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+
+            this.availableDomains = new List<DomainOfExpertise>
+            {
+                new() { Iid = Guid.NewGuid(), Name = "Domain A" },
+                new() { Iid = Guid.NewGuid(), Name = "Domain B" }
+            };
+
+            this.viewModel = new Mock<ISwitchDomainViewModel>();
+            this.viewModel.Setup(x => x.AvailableDomains).Returns(this.availableDomains);
+            this.viewModel.Setup(x => x.SelectedDomainOfExpertise).Returns(this.availableDomains[0]);
+            this.viewModel.Setup(x => x.OnSubmit).Returns(new EventCallbackFactory().Create<DomainOfExpertise>(this, domain => this.submittedDomain = domain));
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public async Task VerifySwitchDomainComponent()
+        {
+            var renderer = this.context.Render<SwitchDomain>(parameters =>
+            {
+                parameters.Add(p => p.ViewModel, this.viewModel.Object);
+            });
+
+            // The DxComboBox is asserted by presence only: DevExpress echoes neither Data nor ValueChanged back
+            // onto its own instance under bunit, so behaviour is verified through the switch button instead.
+            Assert.That(renderer.FindComponent<DxComboBox<DomainOfExpertise, DomainOfExpertise>>(), Is.Not.Null);
+
+            var switchButton = renderer.FindComponent<DxButton>();
+            await renderer.InvokeAsync(switchButton.Instance.Click.InvokeAsync);
+
+            Assert.That(this.submittedDomain, Is.EqualTo(this.availableDomains[0]));
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Components/ViewOptionsMenuTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/ViewOptionsMenuTestFixture.cs
@@ -1,0 +1,105 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ViewOptionsMenuTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Components
+{
+    using Bunit;
+
+    using COMET.Web.Common.Components;
+    using COMET.Web.Common.Enumerations;
+    using COMET.Web.Common.Extensions;
+    using COMET.Web.Common.Test.Helpers;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for the <see cref="ViewOptionsMenu" /> shared component.
+    /// </summary>
+    [TestFixture]
+    public class ViewOptionsMenuTestFixture
+    {
+        private BunitContext context;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new BunitContext();
+            this.context.ConfigureDevExpressBlazor();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Verifies that the trigger button is rendered with the caller-supplied id, the default "View" text and
+        /// the shared settings icon.
+        /// </summary>
+        [Test]
+        public void VerifyTriggerButtonIsRendered()
+        {
+            var renderer = this.context.Render<ViewOptionsMenu>(parameters => parameters
+                .Add(p => p.ButtonId, "testViewMenuButton")
+                .Add(p => p.ChildContent, "<span id=\"option-marker\">option</span>"));
+
+            var button = renderer.FindComponent<DxButton>();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => renderer.Find("#testViewMenuButton"), Throws.Nothing);
+                Assert.That(button.Instance.Text, Is.EqualTo("View"));
+                Assert.That(button.Instance.IconCssClass, Is.EqualTo(IconName.Settings.GetCssClass()));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that clicking the trigger button toggles the dropdown open and closed.
+        /// </summary>
+        /// <returns>A <see cref="Task" />.</returns>
+        [Test]
+        public async Task VerifyClickTogglesDropdown()
+        {
+            var renderer = this.context.Render<ViewOptionsMenu>(parameters => parameters
+                .Add(p => p.ButtonId, "testViewMenuButton")
+                .Add(p => p.ChildContent, "<span>option</span>"));
+
+            var button = renderer.FindComponent<DxButton>();
+            var dropDown = renderer.FindComponent<DxDropDown>();
+
+            Assert.That(dropDown.Instance.IsOpen, Is.False);
+
+            await renderer.InvokeAsync(() => button.Instance.Click.InvokeAsync(new MouseEventArgs()));
+            Assert.That(dropDown.Instance.IsOpen, Is.True);
+
+            await renderer.InvokeAsync(() => button.Instance.Click.InvokeAsync(new MouseEventArgs()));
+            Assert.That(dropDown.Instance.IsOpen, Is.False);
+        }
+    }
+}

--- a/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
+++ b/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
@@ -49,6 +49,7 @@ namespace COMET.Web.Common.Tests.Extensions
                 Assert.That(CometButtonStyle.Light.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Light));
                 Assert.That(CometButtonStyle.Dark.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Dark));
                 Assert.That(CometButtonStyle.Link.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Link));
+                Assert.That(CometButtonStyle.Edit.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Info));
                 Assert.That(((CometButtonStyle)99).ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Primary));
             }
         }

--- a/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
+++ b/COMET.Web.Common.Tests/Extensions/CometButtonStyleExtensionsTestFixture.cs
@@ -50,6 +50,7 @@ namespace COMET.Web.Common.Tests.Extensions
                 Assert.That(CometButtonStyle.Dark.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Dark));
                 Assert.That(CometButtonStyle.Link.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Link));
                 Assert.That(CometButtonStyle.Edit.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Info));
+                Assert.That(CometButtonStyle.None.ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.None));
                 Assert.That(((CometButtonStyle)99).ToButtonRenderStyle(), Is.EqualTo(ButtonRenderStyle.Primary));
             }
         }

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
@@ -33,7 +33,7 @@
     <FooterTemplate>
         <div class="modal-footer">
             <DxButton CssClass="ok-button" Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(async () => await this.OnConfirmClick())" />
-            <DxButton CssClass="cancel-button" Text="Cancel" RenderStyle="ButtonRenderStyle.Danger" Click="@(async () => await this.ViewModel.OnCancelClick.InvokeAsync())" />
+            <DxButton CssClass="cancel-button" Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(async () => await this.ViewModel.OnCancelClick.InvokeAsync())" />
         </div>
     </FooterTemplate>
 </DxPopup>

--- a/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
+++ b/COMET.Web.Common/Components/BookEditor/EditorPopup.razor
@@ -32,7 +32,7 @@
     </BodyContentTemplate>
     <FooterTemplate>
         <div class="modal-footer">
-            <DxButton CssClass="ok-button" Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(async () => await this.OnConfirmClick())" />
+            <DxButton CssClass="ok-button" Text="OK" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(async () => await this.OnConfirmClick())" />
             <DxButton CssClass="cancel-button" Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(async () => await this.ViewModel.OnCancelClick.InvokeAsync())" />
         </div>
     </FooterTemplate>

--- a/COMET.Web.Common/Components/OpenModel.razor
+++ b/COMET.Web.Common/Components/OpenModel.razor
@@ -58,5 +58,6 @@
 <ValidationMessageComponent ValidationMessage="@this.ErrorMessage" />
 <div class="modal-footer">
 	<DxButton Id="openmodel__button" CssClass="btn btn-connect"
+	          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
 	          Text="@this.ButtonText" Enabled="@this.ButtonEnabled" Click="@this.OpenSessionAsync" />
 </div>

--- a/COMET.Web.Common/Components/ParameterTypeEditors/CompoundParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/CompoundParameterTypeEditor.razor
@@ -59,7 +59,7 @@ else if (this.ViewModel.ValueSet is not null)
                         <div>[@componentLabels]</div>
                     }
                 </div>
-                <DxButton Id="openPopup" Text="Edit" RenderStyleMode="@ButtonRenderStyleMode.Outline" IconCssClass="@IconName.Edit.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> compoundParameterTypeEditorViewModel.OnComponentSelected())" />
+                <DxButton Id="openPopup" Text="Edit" RenderStyleMode="@ButtonRenderStyleMode.Outline" RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" IconCssClass="@IconName.Edit.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> compoundParameterTypeEditorViewModel.OnComponentSelected())" />
             </div>
         }
     }

--- a/COMET.Web.Common/Components/ParameterTypeEditors/EnumerationParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/EnumerationParameterTypeEditor.razor
@@ -55,8 +55,8 @@
                            ShowCheckboxes="true"/>
             </BodyTemplate>
             <FooterTextTemplate>
-                <DxButton Id="confirmButton" RenderStyle="ButtonRenderStyle.Primary" Text="Ok" Click="enumerationParameterTypeEditorViewModel.OnConfirmButtonClick"/>
-                <DxButton Id="cancelButton" RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="enumerationParameterTypeEditorViewModel.OnCancelButtonClick"/>
+                <DxButton Id="confirmButton" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Ok" Click="enumerationParameterTypeEditorViewModel.OnConfirmButtonClick"/>
+                <DxButton Id="cancelButton" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Cancel" Click="enumerationParameterTypeEditorViewModel.OnCancelButtonClick"/>
             </FooterTextTemplate>
         </DxDropDown>
     }

--- a/COMET.Web.Common/Components/ParameterTypeEditors/SampledFunctionParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/SampledFunctionParameterTypeEditor.razor
@@ -29,8 +29,8 @@
         @if (!this.ViewModel.IsReadOnly)
         {
             <div class="sfpt-header">
-                <DxButton RenderStyleMode="@ButtonRenderStyleMode.Outline" IconCssClass="@IconName.Add.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> sfptViewModel.AddRow())" Text="Add row"/>
-                <DxButton RenderStyleMode="@ButtonRenderStyleMode.Outline" IconCssClass="@IconName.Remove.GetCssClass()" SizeMode="SizeMode.Small" 
+                <DxButton RenderStyleMode="@ButtonRenderStyleMode.Outline" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> sfptViewModel.AddRow())" Text="Add row"/>
+                <DxButton RenderStyleMode="@ButtonRenderStyleMode.Outline" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" IconCssClass="@IconName.Remove.GetCssClass()" SizeMode="SizeMode.Small"
                           Click="@(()=> sfptViewModel.RemoveRow())" Text="Delete row" Enabled="@sfptViewModel.CanRemoveRow"/>
             </div>
         }
@@ -59,8 +59,8 @@
             </tbody>
         </table>
         <div class="modal-footer">
-            <DxButton Click="@this.UpdateValues" Text="Confirm" Enabled="@(!this.ViewModel.IsReadOnly)" />
-            <DxButton Click="@this.CancelUpdate" Text="Close" />
+            <DxButton Click="@this.UpdateValues" Text="Confirm" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Enabled="@(!this.ViewModel.IsReadOnly)" />
+            <DxButton Click="@this.CancelUpdate" Text="Close" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" />
         </div>
         }
     else
@@ -70,7 +70,7 @@
                 <div>@this.ViewModel.ParameterType.QueryValuesRepresentation(this.ViewModel.ValueArray)</div>
             </div>
             <span class="align-right">
-                <DxButton Id="openPopup" Text="Edit" RenderStyleMode="@ButtonRenderStyleMode.Outline" IconCssClass="@IconName.Edit.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> sfptViewModel.OnComponentSelected())" />
+                <DxButton Id="openPopup" Text="Edit" RenderStyleMode="@ButtonRenderStyleMode.Outline" RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" IconCssClass="@IconName.Edit.GetCssClass()" SizeMode="SizeMode.Small" Click="@(()=> sfptViewModel.OnComponentSelected())" />
             </span>
         </div>
     }

--- a/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
+++ b/COMET.Web.Common/Components/ParameterTypeEditors/TextParameterTypeEditor.razor
@@ -71,7 +71,7 @@ else
         </Content>
         <FooterTemplate>
             <div class="modal-footer">
-                <DxButton Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(() => this.IsOnEditMode = false)"/>
+                <DxButton Text="OK" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.IsOnEditMode = false)"/>
             </div>
         </FooterTemplate>
     </DxPopup>

--- a/COMET.Web.Common/Components/Publications.razor
+++ b/COMET.Web.Common/Components/Publications.razor
@@ -24,6 +24,7 @@
 <div>
     <div>
         <DxButton IconCssClass="@IconName.UploadCloud.GetCssClass()"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                   Enabled="@this.ViewModel.CanPublish"
                   Click="() => { this.ViewModel.ExecutePublish(); }"/>
     </div>

--- a/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor
@@ -24,12 +24,15 @@
 
 @if (this.ViewModel.CurrentIteration != null)
 {
-    <h6>Filter on Element:</h6>
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
     <DxComboBox Data="@this.ViewModel.AvailableElements"
                 AllowUserInput="true"
                 @bind-Value="@this.ViewModel.SelectedElementBase"
                 FilteringMode="DataGridFilteringMode.Contains"
                 TextFieldName="@nameof(ActualFiniteState.Name)"
                 ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-                NullText="Select an Element"/>
+                NullText="Filter by element..."/>
 }

--- a/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor
@@ -34,5 +34,5 @@
                 FilteringMode="DataGridFilteringMode.Contains"
                 TextFieldName="@nameof(ActualFiniteState.Name)"
                 ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-                NullText="Filter by element..."/>
+                NullText="@this.NullText"/>
 }

--- a/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor.cs
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ElementBaseSelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select an <see cref="CDP4Common.EngineeringModelData.ElementBase" />.
+    /// </summary>
+    public partial class ElementBaseSelector
+    {
+        /// <summary>
+        /// The label shown above the selector. Set to an empty string to hide the label (for instance when the
+        /// selector already sits in a toolbar whose placeholder text is self-explanatory).
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Element:";
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/ElementBaseSelector.razor.cs
@@ -36,5 +36,12 @@ namespace COMET.Web.Common.Components.Selectors
         /// </summary>
         [Parameter]
         public string DisplayText { get; set; } = "Filter on Element:";
+
+        /// <summary>
+        /// The placeholder text shown when nothing is selected. Defaults to a "Select ..." wording since the
+        /// selector is a general-purpose selector; pass a "Filter by ..." value when it is used as a page filter.
+        /// </summary>
+        [Parameter]
+        public string NullText { get; set; } = "Select an element...";
     }
 }

--- a/COMET.Web.Common/Components/Selectors/EngineeringModelSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/EngineeringModelSelector.razor
@@ -28,5 +28,5 @@
     </DxFormLayoutItem>
 </DxFormLayout>
 <div class="modal-footer">
-    <DxButton Text="Select" CssClass="btn btn-connect" Click="@this.ViewModel.Submit" Enabled="@(this.ViewModel.SelectedEngineeringModelSetup != null)" />
+    <DxButton Text="Select" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@this.ViewModel.Submit" Enabled="@(this.ViewModel.SelectedEngineeringModelSetup != null)" />
 </div>

--- a/COMET.Web.Common/Components/Selectors/FilterTagBox.razor
+++ b/COMET.Web.Common/Components/Selectors/FilterTagBox.razor
@@ -30,4 +30,4 @@
           TextFieldName="@this.TextFieldName"
           NullText="@this.NullText"
           CssClass="filter-tag-box"
-          @attributes="@this.IdAttribute" />
+          @attributes="@this.AdditionalAttributes" />

--- a/COMET.Web.Common/Components/Selectors/FilterTagBox.razor
+++ b/COMET.Web.Common/Components/Selectors/FilterTagBox.razor
@@ -1,0 +1,33 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@typeparam TItem
+
+<DxTagBox TData="TItem"
+          TValue="TItem"
+          Data="@this.Data"
+          Values="@this.Values"
+          ValuesChanged="@this.ValuesChanged"
+          FilteringMode="DataGridFilteringMode.Contains"
+          ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+          TextFieldName="@this.TextFieldName"
+          NullText="@this.NullText"
+          CssClass="filter-tag-box"
+          @attributes="@this.IdAttribute" />

--- a/COMET.Web.Common/Components/Selectors/FilterTagBox.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/FilterTagBox.razor.cs
@@ -64,22 +64,11 @@ namespace COMET.Web.Common.Components.Selectors
         public string NullText { get; set; }
 
         /// <summary>
-        /// Gets or sets the optional DOM id assigned to the underlying tag box.
+        /// Gets or sets any additional attributes (for example an <c>id</c>) splatted onto the underlying tag box.
+        /// Only attributes the caller actually supplies are forwarded, so no empty or null <c>id</c> is ever set on
+        /// the DxTagBox (which would make DevExpress build the invalid drop-down selector "#" and throw).
         /// </summary>
-        [Parameter]
-        public string Id { get; set; }
-
-        /// <summary>
-        /// An empty attribute set, reused when no id is supplied so no allocation happens on every render.
-        /// </summary>
-        private static readonly IReadOnlyDictionary<string, object> EmptyAttributes = new Dictionary<string, object>();
-
-        /// <summary>
-        /// Gets the splatted <c>id</c> attribute, present only when <see cref="Id" /> is set. Setting an empty or
-        /// null <c>Id</c> directly on the DxTagBox makes DevExpress build the invalid drop-down selector "#" and
-        /// throw a JS exception that kills the circuit, so the attribute is omitted entirely when there is no id.
-        /// </summary>
-        public IReadOnlyDictionary<string, object> IdAttribute
-            => string.IsNullOrEmpty(this.Id) ? EmptyAttributes : new Dictionary<string, object> { ["id"] = this.Id };
+        [Parameter(CaptureUnmatchedValues = true)]
+        public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
     }
 }

--- a/COMET.Web.Common/Components/Selectors/FilterTagBox.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/FilterTagBox.razor.cs
@@ -1,0 +1,85 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="FilterTagBox.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// The single reusable multi-select filter tag box used by every filter bar (dashboards, Parameter Editor,
+    /// Requirements). It bakes in the shared behaviour (contains-filtering, a clear-all button, full-name display)
+    /// so all filters look and behave identically. Wrap it in a <c>filter-bar-item</c> element to size it.
+    /// </summary>
+    /// <typeparam name="TItem">The type of the items presented and selected.</typeparam>
+    public partial class FilterTagBox<TItem>
+    {
+        /// <summary>
+        /// Gets or sets the collection of items available for selection.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<TItem> Data { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of currently selected items.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<TItem> Values { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback invoked when the selected items change.
+        /// </summary>
+        [Parameter]
+        public EventCallback<IEnumerable<TItem>> ValuesChanged { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the item property shown as each tag's text.
+        /// </summary>
+        [Parameter]
+        public string TextFieldName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the placeholder text shown when nothing is selected.
+        /// </summary>
+        [Parameter]
+        public string NullText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional DOM id assigned to the underlying tag box.
+        /// </summary>
+        [Parameter]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// An empty attribute set, reused when no id is supplied so no allocation happens on every render.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<string, object> EmptyAttributes = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets the splatted <c>id</c> attribute, present only when <see cref="Id" /> is set. Setting an empty or
+        /// null <c>Id</c> directly on the DxTagBox makes DevExpress build the invalid drop-down selector "#" and
+        /// throw a JS exception that kills the circuit, so the attribute is omitted entirely when there is no id.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> IdAttribute
+            => string.IsNullOrEmpty(this.Id) ? EmptyAttributes : new Dictionary<string, object> { ["id"] = this.Id };
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor
@@ -34,5 +34,5 @@
 			FilteringMode="DataGridFilteringMode.Contains"
 			TextFieldName="@nameof(ActualFiniteState.Name)"
 			ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-			NullText="Filter by state..." />
+			NullText="@this.NullText" />
 }

--- a/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor
@@ -34,5 +34,5 @@
 			FilteringMode="DataGridFilteringMode.Contains"
 			TextFieldName="@nameof(ActualFiniteState.Name)"
 			ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-			NullText="Select a State" />
+			NullText="Filter by state..." />
 }

--- a/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor.cs
@@ -1,22 +1,23 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="FiniteStateSelector.razor.cs" company="Starion Group S.A.">
-//     Copyright (c) 2023-2026 Starion Group S.A.
+//    Copyright (c) 2023-2026 Starion Group S.A.
 //
-//     This file is part of COMET WEB Community Edition
-//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-// 
-//     The COMET WEB Community Edition is free software; you can redistribute it and/or
-//     modify it under the terms of the GNU Affero General Public
-//     License as published by the Free Software Foundation; either
-//     version 3 of the License, or (at your option) any later version.
-// 
-//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
-//     but WITHOUT ANY WARRANTY; without even the implied warranty of
-//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//    Affero General Public License for more details.
-// 
-//    You should have received a copy of the GNU Affero General Public License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 

--- a/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/FiniteStateSelector.razor.cs
@@ -35,5 +35,12 @@ namespace COMET.Web.Common.Components.Selectors
         /// </summary>
         [Parameter]
         public string DisplayText { get; set; } = "Filter on State:";
+
+        /// <summary>
+        /// The placeholder text shown when nothing is selected. Defaults to a "Select ..." wording since the
+        /// selector is a general-purpose selector; pass a "Filter by ..." value when it is used as a page filter.
+        /// </summary>
+        [Parameter]
+        public string NullText { get; set; } = "Select a state...";
     }
 }

--- a/COMET.Web.Common/Components/Selectors/IterationSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/IterationSelector.razor
@@ -28,5 +28,5 @@
 	</DxFormLayoutItem>
 </DxFormLayout>
 <div class="modal-footer">
-    <DxButton Text="Select" CssClass="btn btn-connect" Click="@this.ViewModel.Submit" Enabled="@(this.ViewModel.SelectedIteration != null)"/>
+    <DxButton Text="Select" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@this.ViewModel.Submit" Enabled="@(this.ViewModel.SelectedIteration != null)"/>
 </div>

--- a/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiCategorySelector.razor
@@ -28,13 +28,10 @@
         <h6>@(this.DisplayText)</h6>
     }
 
-    <DxTagBox Data="@(this.ViewModel.AvailableCategories)"
-              TData="Category"
-              TValue="Category"
-              Values="@(this.ViewModel.SelectedCategories)"
-              ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values)"
-              FilteringMode="DataGridFilteringMode.Contains"
-              ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-              TextFieldName="@(nameof(Category.Name))"
-              NullText="Select Categories"/>
+    <FilterTagBox TItem="Category"
+                  Data="@(this.ViewModel.AvailableCategories)"
+                  Values="@(this.ViewModel.SelectedCategories)"
+                  ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values)"
+                  TextFieldName="@(nameof(Category.Name))"
+                  NullText="Filter by category..."/>
 }

--- a/COMET.Web.Common/Components/Selectors/MultiElementBaseSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiElementBaseSelector.razor
@@ -1,0 +1,37 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@using CDP4Common.EngineeringModelData
+@inherits BelongsToIterationSelector<COMET.Web.Common.ViewModels.Components.Selectors.IMultiElementBaseSelectorViewModel>
+
+@if (this.ViewModel.CurrentIteration != null)
+{
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
+
+    <FilterTagBox TItem="ElementBase"
+                  Data="@(this.ViewModel.AvailableElements)"
+                  Values="@(this.ViewModel.SelectedElementBases)"
+                  ValuesChanged="@((IEnumerable<ElementBase> values) => this.ViewModel.SelectedElementBases = values)"
+                  TextFieldName="@(nameof(ElementBase.Name))"
+                  NullText="Filter by element..."/>
+}

--- a/COMET.Web.Common/Components/Selectors/MultiElementBaseSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/MultiElementBaseSelector.razor.cs
@@ -1,0 +1,39 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiElementBaseSelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select one or more <see cref="CDP4Common.EngineeringModelData.ElementBase" />s.
+    /// </summary>
+    public partial class MultiElementBaseSelector
+    {
+        /// <summary>
+        /// Gets or sets the heading rendered above the selector. Set to an empty string to hide the heading.
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Element:";
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/MultiFiniteStateSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiFiniteStateSelector.razor
@@ -1,0 +1,37 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@using CDP4Common.EngineeringModelData
+@inherits BelongsToIterationSelector<COMET.Web.Common.ViewModels.Components.Selectors.IMultiFiniteStateSelectorViewModel>
+
+@if (this.ViewModel.CurrentIteration != null)
+{
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
+
+    <FilterTagBox TItem="ActualFiniteState"
+                  Data="@(this.ViewModel.AvailableFiniteStates)"
+                  Values="@(this.ViewModel.SelectedActualFiniteStates)"
+                  ValuesChanged="@((IEnumerable<ActualFiniteState> values) => this.ViewModel.SelectedActualFiniteStates = values)"
+                  TextFieldName="@(nameof(ActualFiniteState.Name))"
+                  NullText="Filter by state..."/>
+}

--- a/COMET.Web.Common/Components/Selectors/MultiFiniteStateSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/MultiFiniteStateSelector.razor.cs
@@ -1,0 +1,39 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiFiniteStateSelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select one or more <see cref="CDP4Common.EngineeringModelData.ActualFiniteState" />s.
+    /// </summary>
+    public partial class MultiFiniteStateSelector
+    {
+        /// <summary>
+        /// Gets or sets the heading rendered above the selector. Set to an empty string to hide the heading.
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on State:";
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/MultiOptionSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiOptionSelector.razor
@@ -1,0 +1,37 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//   This file is part of CDP4-COMET WEB Community Edition
+//   The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//   Annex A and Annex C.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components.Selectors
+@using CDP4Common.EngineeringModelData
+@inherits BelongsToIterationSelector<COMET.Web.Common.ViewModels.Components.Selectors.IMultiOptionSelectorViewModel>
+
+@if (this.ViewModel.CurrentIteration != null)
+{
+    if (!string.IsNullOrWhiteSpace(this.DisplayText))
+    {
+        <h6>@(this.DisplayText)</h6>
+    }
+
+    <FilterTagBox TItem="Option"
+                  Data="@(this.ViewModel.AvailableOptions)"
+                  Values="@(this.ViewModel.SelectedOptions)"
+                  ValuesChanged="@((IEnumerable<Option> values) => this.ViewModel.SelectedOptions = values)"
+                  TextFieldName="@(nameof(Option.Name))"
+                  NullText="Filter by option..."/>
+}

--- a/COMET.Web.Common/Components/Selectors/MultiOptionSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/MultiOptionSelector.razor.cs
@@ -1,0 +1,39 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiOptionSelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select one or more <see cref="CDP4Common.EngineeringModelData.Option" />s.
+    /// </summary>
+    public partial class MultiOptionSelector
+    {
+        /// <summary>
+        /// Gets or sets the heading rendered above the selector. Set to an empty string to hide the heading.
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Option:";
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/MultiParameterTypeSelector.razor
@@ -28,13 +28,10 @@
         <h6>@(this.DisplayText)</h6>
     }
 
-    <DxTagBox Data="@(this.ViewModel.AvailableParameterTypes)"
-              TData="ParameterType"
-              TValue="ParameterType"
-              Values="@(this.ViewModel.SelectedParameterTypes)"
-              ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypes = values)"
-              FilteringMode="DataGridFilteringMode.Contains"
-              ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-              TextFieldName="@(nameof(ParameterType.Name))"
-              NullText="Select Parameter Types"/>
+    <FilterTagBox TItem="ParameterType"
+                  Data="@(this.ViewModel.AvailableParameterTypes)"
+                  Values="@(this.ViewModel.SelectedParameterTypes)"
+                  ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypes = values)"
+                  TextFieldName="@(nameof(ParameterType.Name))"
+                  NullText="Filter by parameter type..."/>
 }

--- a/COMET.Web.Common/Components/Selectors/OptionSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/OptionSelector.razor
@@ -34,5 +34,5 @@
 	            FilteringMode="DataGridFilteringMode.Contains"
 	            TextFieldName="@nameof(Option.Name)"
 	            ClearButtonDisplayMode="@(this.ViewModel.AllowNullOption ? DataEditorClearButtonDisplayMode.Auto : DataEditorClearButtonDisplayMode.Never)"
-	            NullText="Filter by option..."/>
+	            NullText="@this.NullText"/>
 }

--- a/COMET.Web.Common/Components/Selectors/OptionSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/OptionSelector.razor
@@ -24,12 +24,15 @@
 
 @if(this.ViewModel.CurrentIteration != null)
 {
-	<h6>Filter on Option:</h6>
+	if (!string.IsNullOrWhiteSpace(this.DisplayText))
+	{
+		<h6>@(this.DisplayText)</h6>
+	}
 	<DxComboBox Data="@this.ViewModel.AvailableOptions"
 	            AllowUserInput="true"
 	            @bind-Value="@this.ViewModel.SelectedOption"
 	            FilteringMode="DataGridFilteringMode.Contains"
 	            TextFieldName="@nameof(Option.Name)"
 	            ClearButtonDisplayMode="@(this.ViewModel.AllowNullOption ? DataEditorClearButtonDisplayMode.Auto : DataEditorClearButtonDisplayMode.Never)"
-	            NullText="Select an Option"/>
+	            NullText="Filter by option..."/>
 }

--- a/COMET.Web.Common/Components/Selectors/OptionSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/OptionSelector.razor.cs
@@ -36,5 +36,12 @@ namespace COMET.Web.Common.Components.Selectors
         /// </summary>
         [Parameter]
         public string DisplayText { get; set; } = "Filter on Option:";
+
+        /// <summary>
+        /// The placeholder text shown when nothing is selected. Defaults to a "Select ..." wording since the
+        /// selector is a general-purpose selector; pass a "Filter by ..." value when it is used as a page filter.
+        /// </summary>
+        [Parameter]
+        public string NullText { get; set; } = "Select an option...";
     }
 }

--- a/COMET.Web.Common/Components/Selectors/OptionSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/OptionSelector.razor.cs
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="OptionSelector.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components.Selectors
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Component used to select an <see cref="CDP4Common.EngineeringModelData.Option" />.
+    /// </summary>
+    public partial class OptionSelector
+    {
+        /// <summary>
+        /// The label shown above the selector. Set to an empty string to hide the label (for instance when the
+        /// selector already sits in a toolbar whose placeholder text is self-explanatory).
+        /// </summary>
+        [Parameter]
+        public string DisplayText { get; set; } = "Filter on Option:";
+    }
+}

--- a/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor
@@ -38,5 +38,5 @@
                 ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
                 TextFieldName="@(nameof(SelectorModelBaseWrapper<ParameterType>.DisplayText))"
                 ValueFieldName="@(nameof(SelectorModelBaseWrapper<ParameterType>.WrappedThing))"
-                NullText="Select a Parameter Type"/>
+                NullText="Filter by parameter type..."/>
 }

--- a/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor
+++ b/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor
@@ -38,5 +38,5 @@
                 ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
                 TextFieldName="@(nameof(SelectorModelBaseWrapper<ParameterType>.DisplayText))"
                 ValueFieldName="@(nameof(SelectorModelBaseWrapper<ParameterType>.WrappedThing))"
-                NullText="Filter by parameter type..."/>
+                NullText="@this.NullText"/>
 }

--- a/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor.cs
+++ b/COMET.Web.Common/Components/Selectors/ParameterTypeSelector.razor.cs
@@ -38,6 +38,13 @@ namespace COMET.Web.Common.Components.Selectors
         public string DisplayText { get; set; } = "Filter on Parameter Type:";
 
         /// <summary>
+        /// The placeholder text shown when nothing is selected. Defaults to a "Select ..." wording since the
+        /// selector is a general-purpose selector; pass a "Filter by ..." value when it is used as a page filter.
+        /// </summary>
+        [Parameter]
+        public string NullText { get; set; } = "Select a parameter type...";
+
+        /// <summary>
         /// Condition to check if name and shortname shall be displayed in the selector. If false, only the name is displayed
         /// </summary>
         [Parameter]

--- a/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
+++ b/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
@@ -72,6 +72,7 @@
                     <DxButton Id="addEmailButton"
                               Text="Add e-mail"
                               IconCssClass="@IconName.Add.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                               Click="@(this.ViewModel.AddEmail)"/>
                 </DxFormLayoutItem>
             </DxFormLayoutTabPage>
@@ -101,6 +102,7 @@
                     <DxButton Id="addTelephoneButton"
                               Text="Add telephone"
                               IconCssClass="@IconName.Add.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                               Click="@(this.ViewModel.AddTelephone)"/>
                 </DxFormLayoutItem>
             </DxFormLayoutTabPage>

--- a/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
+++ b/COMET.Web.Common/Components/Shared/PersonEdit/PersonEditForm.razor
@@ -62,7 +62,7 @@
                     </DxFormLayoutItem>
                     <DxFormLayoutItem ColSpanMd="1">
                         <DxButton IconCssClass="@IconName.Delete.GetCssClass()"
-                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                                   RenderStyleMode="ButtonRenderStyleMode.Text"
                                   Click="@(() => this.ViewModel.RemoveEmail(email))"
                                   title="Remove this e-mail"/>
@@ -92,7 +92,7 @@
                     </DxFormLayoutItem>
                     <DxFormLayoutItem ColSpanMd="1">
                         <DxButton IconCssClass="@IconName.Delete.GetCssClass()"
-                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                                   RenderStyleMode="ButtonRenderStyleMode.Text"
                                   Click="@(() => this.ViewModel.RemoveTelephone(telephone))"
                                   title="Remove this telephone"/>
@@ -134,12 +134,12 @@
     <div class="modal-footer">
         <DxButton Id="cancelPersonEdit"
                   Text="Cancel"
-                  RenderStyle="ButtonRenderStyle.Secondary"
+                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())"
                   Click="@(this.OnCancel)"
                   Enabled="@(!this.ViewModel.IsLoading)"/>
         <DxButton Id="savePersonEdit"
                   Text="Save"
-                  RenderStyle="ButtonRenderStyle.Primary"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                   Click="@(this.ViewModel.SaveAsync)"
                   Enabled="@(this.ViewModel.IsValid && !this.ViewModel.IsLoading)"/>
     </div>

--- a/COMET.Web.Common/Components/SwitchDomain.razor
+++ b/COMET.Web.Common/Components/SwitchDomain.razor
@@ -29,6 +29,6 @@
         </DxFormLayoutItem>
     </DxFormLayout>
     <div class="modal-footer">
-        <DxButton id="switch-domain-button" Text="Switch" RenderStyle="ButtonRenderStyle.Primary" Click="@(() => this.ViewModel.OnSubmit.InvokeAsync(this.ViewModel.SelectedDomainOfExpertise))"/>
+        <DxButton id="switch-domain-button" Text="Switch" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(() => this.ViewModel.OnSubmit.InvokeAsync(this.ViewModel.SelectedDomainOfExpertise))"/>
     </div> 
 </span>

--- a/COMET.Web.Common/Components/ViewOptionsMenu.razor
+++ b/COMET.Web.Common/Components/ViewOptionsMenu.razor
@@ -1,0 +1,40 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+------------------------------------------------------------------------------->
+@namespace COMET.Web.Common.Components
+
+<DxButton Id="@this.ButtonId"
+          CssClass="view-options-button"
+          RenderStyle="ButtonRenderStyle.Light"
+          IconCssClass="@IconName.Settings.GetCssClass()"
+          Text="@this.ButtonText"
+          title="@this.ButtonTitle"
+          Click="@(() => this.IsOpen = !this.IsOpen)" />
+
+<DxDropDown @bind-IsOpen="@this.IsOpen"
+            PositionMode="DropDownPositionMode.Bottom"
+            PositionTarget="@($"#{this.ButtonId}")"
+            CloseMode="DropDownCloseMode.Close"
+            HeaderVisible="false"
+            FooterVisible="false">
+    <BodyTemplate>
+        <div class="view-options-menu">
+            @this.ChildContent
+        </div>
+    </BodyTemplate>
+</DxDropDown>

--- a/COMET.Web.Common/Components/ViewOptionsMenu.razor
+++ b/COMET.Web.Common/Components/ViewOptionsMenu.razor
@@ -20,7 +20,7 @@
 
 <DxButton Id="@this.ButtonId"
           CssClass="view-options-button"
-          RenderStyle="ButtonRenderStyle.Light"
+          RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"
           IconCssClass="@IconName.Settings.GetCssClass()"
           Text="@this.ButtonText"
           title="@this.ButtonTitle"

--- a/COMET.Web.Common/Components/ViewOptionsMenu.razor.cs
+++ b/COMET.Web.Common/Components/ViewOptionsMenu.razor.cs
@@ -1,0 +1,68 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ViewOptionsMenu.razor.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Components
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// A reusable "View" cog: a light button carrying the settings icon that opens a dropdown holding the
+    /// display and filter options of a page. Gives every application page the same, predictable place - the
+    /// upper-right corner of its toolbar - to reach its view settings. Callers supply the option controls
+    /// through <see cref="ChildContent" />.
+    /// </summary>
+    public partial class ViewOptionsMenu
+    {
+        /// <summary>
+        /// Gets or sets the id given to the trigger button, also used as the dropdown's position target. Must be
+        /// unique per page so several menus can coexist.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public string ButtonId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the option controls rendered inside the dropdown.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text shown on the trigger button.
+        /// </summary>
+        [Parameter]
+        public string ButtonText { get; set; } = "View";
+
+        /// <summary>
+        /// Gets or sets the tooltip shown on the trigger button.
+        /// </summary>
+        [Parameter]
+        public string ButtonTitle { get; set; } = "Display and filter options";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the dropdown is currently open.
+        /// </summary>
+        private bool IsOpen { get; set; }
+    }
+}

--- a/COMET.Web.Common/Components/ViewOptionsMenu.razor.css
+++ b/COMET.Web.Common/Components/ViewOptionsMenu.razor.css
@@ -1,0 +1,7 @@
+.view-options-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    min-width: 200px;
+}

--- a/COMET.Web.Common/Enumerations/CometButtonStyle.cs
+++ b/COMET.Web.Common/Enumerations/CometButtonStyle.cs
@@ -71,6 +71,13 @@ namespace COMET.Web.Common.Enumerations
         /// <summary>
         /// Link button style intent. Used for inline navigation, hyperlink-style actions, or minimal footprint triggers.
         /// </summary>
-        Link = 8
+        Link = 8,
+
+        /// <summary>
+        /// Edit button style intent. Used for edit, subscribe, override and other "modify" actions. Rendered in a
+        /// distinct, clearly visible accessible teal so these actions stand apart from create (Primary) and delete
+        /// (Danger) and are never as faint as <see cref="Light" />.
+        /// </summary>
+        Edit = 9
     }
 }

--- a/COMET.Web.Common/Enumerations/CometButtonStyle.cs
+++ b/COMET.Web.Common/Enumerations/CometButtonStyle.cs
@@ -78,6 +78,13 @@ namespace COMET.Web.Common.Enumerations
         /// distinct, clearly visible accessible teal so these actions stand apart from create (Primary) and delete
         /// (Danger) and are never as faint as <see cref="Light" />.
         /// </summary>
-        Edit = 9
+        Edit = 9,
+
+        /// <summary>
+        /// No button chrome. Used for controls that are styled entirely by their own CSS (for example tab and
+        /// side-bar triggers), so that even these route through <see cref="CometButtonStyle" /> and the mapping
+        /// stays the single source of truth for every button.
+        /// </summary>
+        None = 10
     }
 }

--- a/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
+++ b/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
@@ -47,6 +47,7 @@ namespace COMET.Web.Common.Extensions
                 CometButtonStyle.Success => ButtonRenderStyle.Success,
                 CometButtonStyle.Warning => ButtonRenderStyle.Warning,
                 CometButtonStyle.Info => ButtonRenderStyle.Info,
+                CometButtonStyle.Edit => ButtonRenderStyle.Info,
                 CometButtonStyle.Light => ButtonRenderStyle.Light,
                 CometButtonStyle.Dark => ButtonRenderStyle.Dark,
                 CometButtonStyle.Link => ButtonRenderStyle.Link,

--- a/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
+++ b/COMET.Web.Common/Extensions/CometButtonStyleExtensions.cs
@@ -51,6 +51,7 @@ namespace COMET.Web.Common.Extensions
                 CometButtonStyle.Light => ButtonRenderStyle.Light,
                 CometButtonStyle.Dark => ButtonRenderStyle.Dark,
                 CometButtonStyle.Link => ButtonRenderStyle.Link,
+                CometButtonStyle.None => ButtonRenderStyle.None,
                 _ => ButtonRenderStyle.Primary
             };
         }

--- a/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
+++ b/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
@@ -61,12 +61,12 @@
                 sec
             </div>
             <div class="session__buttons">
-                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" Click="@(this.OnEditProfileClick)"/>
+                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" Click="@(this.OnEditProfileClick)"/>
             </div>
 
             <div class="session__buttons session__buttons--secondary">
-                <DxButton Id="refresh-button" CssClass="btn btn-connect" Text="@this.RefreshButtonText" IconCssClass="@IconName.Refresh.GetCssClass()" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
-                <DxButton Id="logout-button" CssClass="btn btn-connect" Text="Log out" IconCssClass="@IconName.LogOut.GetCssClass()" Click="@this.Logout"/>
+                <DxButton Id="refresh-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Text="@this.RefreshButtonText" IconCssClass="@IconName.Refresh.GetCssClass()" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
+                <DxButton Id="logout-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Log out" IconCssClass="@IconName.LogOut.GetCssClass()" Click="@this.Logout"/>
             </div>
         </div>
     </SubMenuTemplate>

--- a/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
+++ b/COMET.Web.Common/Shared/TopMenuEntry/SessionMenu.razor
@@ -61,11 +61,11 @@
                 sec
             </div>
             <div class="session__buttons">
-                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" Click="@(this.OnEditProfileClick)"/>
+                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" Click="@(this.OnEditProfileClick)"/>
             </div>
 
             <div class="session__buttons session__buttons--secondary">
-                <DxButton Id="refresh-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Text="@this.RefreshButtonText" IconCssClass="@IconName.Refresh.GetCssClass()" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
+                <DxButton Id="refresh-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="@this.RefreshButtonText" IconCssClass="@IconName.Refresh.GetCssClass()" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
                 <DxButton Id="logout-button" CssClass="btn btn-connect" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Log out" IconCssClass="@IconName.LogOut.GetCssClass()" Click="@this.Logout"/>
             </div>
         </div>

--- a/COMET.Web.Common/Utilities/QueryKeys.cs
+++ b/COMET.Web.Common/Utilities/QueryKeys.cs
@@ -77,5 +77,23 @@ namespace COMET.Web.Common.Utilities
         /// Parameter Editor's category filter.
         /// </summary>
         public const string CategoriesKey = "categories";
+
+        /// <summary>
+        /// The query key for a comma-delimited list of <see cref="Option" /> short-form GUIDs, used by
+        /// multi-select option filters.
+        /// </summary>
+        public const string OptionsKey = "options";
+
+        /// <summary>
+        /// The query key for a comma-delimited list of <see cref="ElementBase" /> short-form GUIDs, used by the
+        /// Parameter Editor's element filter.
+        /// </summary>
+        public const string ElementsKey = "elements";
+
+        /// <summary>
+        /// The query key for a comma-delimited list of <see cref="ActualFiniteState" /> short-form GUIDs, used by
+        /// multi-select finite state filters.
+        /// </summary>
+        public const string StatesKey = "states";
     }
 }

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiElementBaseSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiElementBaseSelectorViewModel.cs
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IMultiElementBaseSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// ViewModel used to select one or more <see cref="ElementBase" />s through a collection of existing <see cref="ElementBase" />
+    /// </summary>
+    public interface IMultiElementBaseSelectorViewModel : IBelongsToIterationSelectorViewModel
+    {
+        /// <summary>
+        /// A collection of available <see cref="ElementBase" />
+        /// </summary>
+        IEnumerable<ElementBase> AvailableElements { get; }
+
+        /// <summary>
+        /// The currently selected <see cref="ElementBase" />s
+        /// </summary>
+        IEnumerable<ElementBase> SelectedElementBases { get; set; }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiFiniteStateSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiFiniteStateSelectorViewModel.cs
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IMultiFiniteStateSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// View Model that enables the user to select one or more <see cref="ActualFiniteState" />s
+    /// </summary>
+    public interface IMultiFiniteStateSelectorViewModel : IBelongsToIterationSelectorViewModel
+    {
+        /// <summary>
+        /// A collection of available <see cref="ActualFiniteState" />
+        /// </summary>
+        IEnumerable<ActualFiniteState> AvailableFiniteStates { get; }
+
+        /// <summary>
+        /// The currently selected <see cref="ActualFiniteState" />s
+        /// </summary>
+        IEnumerable<ActualFiniteState> SelectedActualFiniteStates { get; set; }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/IMultiOptionSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/IMultiOptionSelectorViewModel.cs
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="IMultiOptionSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// View Model that provide capability to select one or more <see cref="Option" />s
+    /// </summary>
+    public interface IMultiOptionSelectorViewModel : IBelongsToIterationSelectorViewModel
+    {
+        /// <summary>
+        /// The currently selected <see cref="Option" />s
+        /// </summary>
+        IEnumerable<Option> SelectedOptions { get; set; }
+
+        /// <summary>
+        /// A collection of available <see cref="Option" />
+        /// </summary>
+        IEnumerable<Option> AvailableOptions { get; }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiElementBaseSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiElementBaseSelectorViewModel.cs
@@ -1,0 +1,66 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiElementBaseSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    using COMET.Web.Common.Extensions;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// ViewModel used to select one or more <see cref="ElementBase" />s through a collection of existing <see cref="ElementBase" />
+    /// </summary>
+    public class MultiElementBaseSelectorViewModel : BelongsToIterationSelectorViewModel, IMultiElementBaseSelectorViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedElementBases" />
+        /// </summary>
+        private IEnumerable<ElementBase> selectedElementBases = new List<ElementBase>();
+
+        /// <summary>
+        /// A collection of available <see cref="ElementBase" />
+        /// </summary>
+        public IEnumerable<ElementBase> AvailableElements { get; private set; } = Enumerable.Empty<ElementBase>();
+
+        /// <summary>
+        /// The currently selected <see cref="ElementBase" />s
+        /// </summary>
+        public IEnumerable<ElementBase> SelectedElementBases
+        {
+            get => this.selectedElementBases;
+            set => this.RaiseAndSetIfChanged(ref this.selectedElementBases, value ?? new List<ElementBase>());
+        }
+
+        /// <summary>
+        /// Updates this view model properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            this.SelectedElementBases = new List<ElementBase>();
+
+            this.AvailableElements = this.CurrentIteration?.QueryUsedElementDefinitions().OrderBy(x => x.Name) ?? Enumerable.Empty<ElementBase>();
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiFiniteStateSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiFiniteStateSelectorViewModel.cs
@@ -1,0 +1,65 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiFiniteStateSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View Model that enables the user to select one or more <see cref="ActualFiniteState" />s
+    /// </summary>
+    public class MultiFiniteStateSelectorViewModel : BelongsToIterationSelectorViewModel, IMultiFiniteStateSelectorViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedActualFiniteStates" />
+        /// </summary>
+        private IEnumerable<ActualFiniteState> selectedActualFiniteStates = new List<ActualFiniteState>();
+
+        /// <summary>
+        /// A collection of available <see cref="ActualFiniteState" />
+        /// </summary>
+        public IEnumerable<ActualFiniteState> AvailableFiniteStates { get; private set; } = Enumerable.Empty<ActualFiniteState>();
+
+        /// <summary>
+        /// The currently selected <see cref="ActualFiniteState" />s
+        /// </summary>
+        public IEnumerable<ActualFiniteState> SelectedActualFiniteStates
+        {
+            get => this.selectedActualFiniteStates;
+            set => this.RaiseAndSetIfChanged(ref this.selectedActualFiniteStates, value ?? new List<ActualFiniteState>());
+        }
+
+        /// <summary>
+        /// Updates this view model properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            this.SelectedActualFiniteStates = new List<ActualFiniteState>();
+
+            this.AvailableFiniteStates = this.CurrentIteration?.ActualFiniteStateList.OrderBy(x => x.Name).SelectMany(x => x.ActualState)
+                                         ?? Enumerable.Empty<ActualFiniteState>();
+        }
+    }
+}

--- a/COMET.Web.Common/ViewModels/Components/Selectors/MultiOptionSelectorViewModel.cs
+++ b/COMET.Web.Common/ViewModels/Components/Selectors/MultiOptionSelectorViewModel.cs
@@ -1,0 +1,64 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="MultiOptionSelectorViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.ViewModels.Components.Selectors
+{
+    using CDP4Common.EngineeringModelData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View Model that provide capability to select one or more <see cref="Option" />s
+    /// </summary>
+    public class MultiOptionSelectorViewModel : BelongsToIterationSelectorViewModel, IMultiOptionSelectorViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedOptions" />
+        /// </summary>
+        private IEnumerable<Option> selectedOptions = new List<Option>();
+
+        /// <summary>
+        /// The currently selected <see cref="Option" />s
+        /// </summary>
+        public IEnumerable<Option> SelectedOptions
+        {
+            get => this.selectedOptions;
+            set => this.RaiseAndSetIfChanged(ref this.selectedOptions, value ?? new List<Option>());
+        }
+
+        /// <summary>
+        /// A collection of available <see cref="Option" />
+        /// </summary>
+        public IEnumerable<Option> AvailableOptions { get; private set; } = Enumerable.Empty<Option>();
+
+        /// <summary>
+        /// Updates this view model properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            this.SelectedOptions = new List<Option>();
+
+            this.AvailableOptions = this.CurrentIteration?.Option.OrderBy(x => x.Name) ?? Enumerable.Empty<Option>();
+        }
+    }
+}

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -60,7 +60,7 @@
 }
 
 .color-title {
-    color: #008bd2;
+    color: var(--colors-gray-800);
 }
 
 .font-weight-100 {
@@ -80,6 +80,24 @@
 
 .font-size-small {
     font-size: small;
+}
+
+/* The shared "View" display-options trigger (ViewOptionsMenu). A minimum width lets it be sized to match a
+   sibling "Add" button, and the down-caret signals that it opens a dropdown of options. Kept global (not in the
+   component's scoped css) because the DxButton is that component's root element, leaving ::deep nothing to anchor to. */
+.view-options-button {
+    min-width: 88px;
+    height: 34px;
+}
+
+.view-options-button::after {
+    content: "";
+    display: inline-block;
+    margin-left: 6px;
+    vertical-align: middle;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid currentColor;
 }
 
 .card-btn {
@@ -561,12 +579,15 @@
     }
 
 .treeview-drag-over {
-    background-color: burlywood;
+    background-color: #ebf8ff;
+    outline: 2px dashed #3182ce;
+    outline-offset: -2px;
 }
 
 .treeview-item-drag-over {
-    background-color: burlywood !important;
-    box-shadow: 0px 0px 2px 10px burlywood !important;
+    background-color: #ebf8ff !important;
+    outline: 2px dashed #3182ce !important;
+    outline-offset: -2px;
 }
 
 .treeview-scrollarea {

--- a/COMETwebapp.Tests/Components/ModelDashboard/ModelDashboardBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelDashboard/ModelDashboardBodyTestFixture.cs
@@ -93,6 +93,35 @@ namespace COMETwebapp.Tests.Components.ModelDashboard
             this.messageBus.ClearSubscriptions();
         }
 
+        /// <summary>
+        /// Verifies that <c>InitializeValues</c> reads the options/states/parameters URL keys on first
+        /// render, applying them (as an empty selection, since nothing is yet available) instead of
+        /// skipping the branch entirely.
+        /// </summary>
+        [Test]
+        public void VerifyInitializeValuesAppliesUrlFilters()
+        {
+            var navigation = this.context.Services.GetRequiredService<NavigationManager>();
+
+            var urlOptions = new Dictionary<string, string>
+            {
+                [QueryKeys.OptionsKey] = Guid.NewGuid().ToShortGuid(),
+                [QueryKeys.StatesKey] = Guid.NewGuid().ToShortGuid(),
+                [QueryKeys.ParametersKey] = Guid.NewGuid().ToShortGuid()
+            };
+
+            navigation.NavigateTo(QueryHelpers.AddQueryString("http://localhost/", urlOptions));
+
+            var rendered = this.context.Render<ModelDashboardBody>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rendered.Instance.ViewModel.OptionSelector.SelectedOptions, Is.Not.Null);
+                Assert.That(rendered.Instance.ViewModel.FiniteStateSelector.SelectedActualFiniteStates, Is.Not.Null);
+                Assert.That(rendered.Instance.ViewModel.ParameterTypeSelector.SelectedParameterTypes, Is.Not.Null);
+            });
+        }
+
         [Test]
         public async Task VerifyModelDashboardComponent()
         {

--- a/COMETwebapp.Tests/Components/ModelDashboard/ModelDashboardBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelDashboard/ModelDashboardBodyTestFixture.cs
@@ -340,14 +340,14 @@ namespace COMETwebapp.Tests.Components.ModelDashboard
                 Assert.That(() => parameterDashboard.Instance.OnAccessData(("Referenced", "THE")), Throws.Nothing);  
             });
 
-            this.viewModel.OptionSelector.SelectedOption = this.viewModel.OptionSelector.AvailableOptions.First();
-            Assert.That(navigation.Uri, Does.Contain("option="));
+            this.viewModel.OptionSelector.SelectedOptions = [this.viewModel.OptionSelector.AvailableOptions.First()];
+            Assert.That(navigation.Uri, Does.Contain("options="));
 
-            this.viewModel.FiniteStateSelector.SelectedActualFiniteState = this.viewModel.FiniteStateSelector.AvailableFiniteStates.First();
-            Assert.That(navigation.Uri, Does.Contain("state="));
+            this.viewModel.FiniteStateSelector.SelectedActualFiniteStates = [this.viewModel.FiniteStateSelector.AvailableFiniteStates.First()];
+            Assert.That(navigation.Uri, Does.Contain("states="));
 
-            this.viewModel.ParameterTypeSelector.SelectedParameterType = this.viewModel.ParameterTypeSelector.AvailableParameterTypes.First();
-            Assert.That(navigation.Uri, Does.Contain("parameter="));
+            this.viewModel.ParameterTypeSelector.SelectedParameterTypes = [this.viewModel.ParameterTypeSelector.AvailableParameterTypes.First()];
+            Assert.That(navigation.Uri, Does.Contain("parameters="));
 
             Assert.That(() => this.messageBus.SendMessage(new SessionEvent(null, SessionStatus.EndUpdate)), Throws.Nothing);
         }

--- a/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/DetailsPanelEditorTestFixture.cs
@@ -120,7 +120,6 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 Assert.That(markup, Does.Contain("SYS"), "Owner ShortName must appear in the summary card.");
                 Assert.That(markup, Does.Contain("EdCategory"), "First category name must appear.");
                 Assert.That(markup, Does.Contain("AnotherEdCategory"), "Second category name must appear.");
-                Assert.That(markup, Does.Contain("An element definition used for testing."), "Definition content must appear.");
             });
         }
 
@@ -403,11 +402,12 @@ namespace COMETwebapp.Tests.Components.ModelEditor
         }
 
         [Test]
-        public void VerifyElementUsageInheritsCategoriesFromDefinition()
+        public void VerifyElementShowsItsDisplayCategories()
         {
             var owner = new DomainOfExpertise { ShortName = "SYS", Name = "System" };
 
             var inheritedCategory = new Category { ShortName = "edCat", Name = "InheritedCategory", PermissibleClass = { ClassKind.ElementDefinition } };
+            var directCategory = new Category { ShortName = "euCat", Name = "DirectCategory", PermissibleClass = { ClassKind.ElementUsage } };
 
             var elementDefinition = new ElementDefinition { Name = "BatteryDef", ShortName = "BATDEF", Owner = owner };
             elementDefinition.Category.Add(inheritedCategory);
@@ -420,6 +420,8 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 ElementDefinition = elementDefinition
             };
 
+            elementUsage.Category.Add(directCategory);
+
             this.viewModel.Setup(x => x.SelectedSystemNode).Returns(elementUsage);
 
             var rendered = this.context.Render<DetailsPanelEditor>(parameters => parameters.Add(p => p.ViewModel, this.viewModel.Object));
@@ -429,8 +431,9 @@ namespace COMETwebapp.Tests.Components.ModelEditor
             {
                 Assert.That(markup, Does.Contain("BatteryUsage"), "ElementUsage Name must appear.");
                 Assert.That(markup, Does.Contain("BATU"), "ElementUsage ShortName must appear.");
+                Assert.That(markup, Does.Contain("DirectCategory"), "The usage's own category must appear.");
                 Assert.That(markup, Does.Contain("InheritedCategory"),
-                    "ElementUsage must surface the referenced ElementDefinition's categories via GetAllCategories().");
+                    "The summary card shows the same display categories as the tree, so a usage also surfaces its ElementDefinition's categories.");
             });
         }
 

--- a/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ElementDefinitionTreeTestFixture.cs
@@ -237,6 +237,25 @@ namespace COMETwebapp.Tests.Components.ModelEditor
             Assert.That(renderedComponent.FindAll(".starion-pill"), Is.Empty, "Unchecking both options must hide every pill.");
         }
 
+        /// <summary>
+        /// Verifies that unchecking <see cref="ElementDefinitionTree.ShowName" /> renders the node's short
+        /// name instead of the <see cref="CardField" />-driven full name.
+        /// </summary>
+        [Test]
+        public void VerifyShowNameFalseRendersShortName()
+        {
+            renderedComponent = context.Render<ElementDefinitionTree>(parameters =>
+            {
+                parameters
+                    .Add(p => p.ShowName, false);
+            });
+
+            var firstItem = renderedComponent.Find("[data-testid=element-node]");
+
+            Assert.That(firstItem.TextContent, Does.Not.Contain("Test1"),
+                "With ShowName off, the node must fall back to the ElementBase ShortName instead of the row's full name.");
+        }
+
         [Test]
         public void VerifyDragIsNotAllowed()
         {

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -372,7 +372,7 @@ namespace COMETwebapp.Tests.Components.ModelEditor
             });
 
             // Collapse the details panel: only the details panel is affected.
-            renderedComponent.Find("#collapseDetailsPanel").Click();
+            renderedComponent.Find("#collapseDetailsPanelEmpty").Click();
 
             renderedComponent.WaitForAssertion(() =>
             {
@@ -407,7 +407,7 @@ namespace COMETwebapp.Tests.Components.ModelEditor
 
             Assert.That(renderedComponent.Find("#targetPanel").ClassList, Does.Not.Contain(GrowPanelClass));
 
-            renderedComponent.Find("#collapseDetailsPanel").Click();
+            renderedComponent.Find("#collapseDetailsPanelEmpty").Click();
 
             renderedComponent.WaitForAssertion(() =>
             {

--- a/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ModelEditor/ModelEditorTestFixture.cs
@@ -22,15 +22,20 @@
 
 namespace COMETwebapp.Tests.Components.ModelEditor
 {
+    using System.Reflection;
+
     using Bunit;
 
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using CDP4Dal;
+
     using CDP4DalCommon.Protocol.Operations;
 
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
+    using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
 
     using COMETwebapp.ViewModels.Components.Common;
@@ -38,14 +43,18 @@ namespace COMETwebapp.Tests.Components.ModelEditor
     using COMETwebapp.ViewModels.Components.ModelEditor.CopySettings;
     using COMETwebapp.ViewModels.Components.ModelEditor.Rows;
 
+    using DynamicData;
+
     using Microsoft.AspNetCore.Components.Web;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
 
     using Moq;
 
     using NUnit.Framework;
 
     using ElementDefinitionTree = COMETwebapp.Components.ModelEditor.ElementDefinitionTree;
+    using ElementDetailsPanel = COMETwebapp.Components.Common.ElementDetailsPanel;
     using ModelEditorComponent = COMETwebapp.Components.ModelEditor.ModelEditor;
 
     /// <summary>
@@ -442,6 +451,93 @@ namespace COMETwebapp.Tests.Components.ModelEditor
                 Assert.That(renderedComponent.FindComponents<ElementDefinitionTree>(), Has.Count.EqualTo(2),
                     "A collapsed source panel must stay mounted, so that its ViewModel's subscriptions are not leaked.");
             });
+        }
+
+        /// <summary>
+        /// Verifies that selecting an <see cref="ElementDefinition" /> mounts the nested
+        /// <see cref="ElementDetailsPanel" /> (only rendered by <c>DataItemDetailsComponent</c> once a
+        /// selection exists) and that its "Add" button opens the new-item menu.
+        /// </summary>
+        [Test]
+        public void VerifyElementDetailsPanelRendersAddButtonWhenElementSelected()
+        {
+            var realDetailsPanelViewModel = this.BuildRealElementDetailsPanelViewModel(out var elementDefinition);
+            this.viewModel.Setup(x => x.DetailsPanelViewModel).Returns(realDetailsPanelViewModel);
+
+            var renderedComponent = this.RenderModelEditor();
+
+            var detailsPanel = renderedComponent.FindComponent<ElementDetailsPanel>();
+            Assert.That(detailsPanel, Is.Not.Null, "The details panel must mount once an ElementDefinition is selected.");
+
+            var addButton = renderedComponent.Find("#element-details-new-button");
+            addButton.Click();
+
+            renderedComponent.WaitForAssertion(() =>
+                Assert.That(detailsPanel.Instance, Is.Not.Null, "The details panel must stay mounted after opening the new-item menu."));
+
+            // The DxDropDown BodyTemplate holding the menu items never renders in bunit, so the item click
+            // handler is invoked directly through the private method it is bound to.
+            var onNewMenuItemClicked = typeof(ElementDetailsPanel).GetMethod("OnNewMenuItemClicked", BindingFlags.NonPublic | BindingFlags.Instance);
+            var wasInvoked = false;
+
+            renderedComponent.InvokeAsync(() => onNewMenuItemClicked.Invoke(detailsPanel.Instance, [new Action(() => wasInvoked = true)]));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(wasInvoked, Is.True, "OnNewMenuItemClicked must invoke the supplied action.");
+                Assert.That(elementDefinition, Is.Not.Null);
+            });
+
+            realDetailsPanelViewModel.Dispose();
+        }
+
+        /// <summary>
+        /// Builds a real (non-mocked) <see cref="ElementDetailsPanelViewModel" /> against a minimal domain
+        /// graph, with an <see cref="ElementDefinition" /> already selected, so the nested
+        /// <see cref="ElementDetailsPanel" /> renders its populated state instead of relying on a mock that
+        /// would otherwise return null for every child popup view model.
+        /// </summary>
+        /// <param name="selectedElementDefinition">The <see cref="ElementDefinition" /> selected on the returned view model.</param>
+        /// <returns>The built <see cref="ElementDetailsPanelViewModel" />.</returns>
+        private ElementDetailsPanelViewModel BuildRealElementDetailsPanelViewModel(out ElementDefinition selectedElementDefinition)
+        {
+            var messageBus = new CDPMessageBus();
+            var sessionService = new Mock<ISessionService>();
+            var session = new Mock<ISession>();
+            sessionService.Setup(x => x.Session).Returns(session.Object);
+            sessionService.Setup(x => x.OpenIterations).Returns(new SourceList<Iteration>());
+
+            var domain = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "SYS", Name = "System" };
+            sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(domain);
+
+            var rdl = new SiteReferenceDataLibrary { ShortName = "siteRdl", Name = "Site RDL" };
+            var siteDirectory = new SiteDirectory { Domain = { domain }, SiteReferenceDataLibrary = { rdl } };
+            var modelSetup = new EngineeringModelSetup { Name = "ModelName", ShortName = "ModelShortName", ActiveDomain = { domain }, RequiredRdl = { new ModelReferenceDataLibrary { RequiredRdl = rdl } } };
+            siteDirectory.Model.Add(modelSetup);
+            var iterationSetup = new IterationSetup { IterationNumber = 1 };
+            modelSetup.IterationSetup.Add(iterationSetup);
+            sessionService.Setup(x => x.GetSiteDirectory()).Returns(siteDirectory);
+            session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
+
+            selectedElementDefinition = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Selected", ShortName = "SEL", Owner = domain };
+
+            var detailsIteration = new Iteration
+            {
+                Iid = Guid.NewGuid(),
+                Element = { selectedElementDefinition },
+                TopElement = selectedElementDefinition,
+                IterationSetup = iterationSetup,
+                Container = new EngineeringModel { EngineeringModelSetup = modelSetup }
+            };
+
+            var logger = new Mock<ILogger<ElementDetailsPanelViewModel>>();
+
+            var realDetailsPanelViewModel = new ElementDetailsPanelViewModel(sessionService.Object, messageBus, logger.Object);
+            realDetailsPanelViewModel.Initialize(detailsIteration);
+            realDetailsPanelViewModel.CurrentDomain = domain;
+            realDetailsPanelViewModel.SelectElement(selectedElementDefinition);
+
+            return realDetailsPanelViewModel;
         }
     }
 }

--- a/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
@@ -32,10 +32,12 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
     using CDP4Dal.Permission;
 
     using COMET.Web.Common.Components.Selectors;
+    using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Model.Configuration;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
     using COMET.Web.Common.Test.Helpers;
+    using COMET.Web.Common.Utilities;
     using COMET.Web.Common.ViewModels.Components.Selectors;
 
     using COMETwebapp.Components.ParameterEditor;
@@ -47,6 +49,8 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
 
     using DynamicData;
 
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.WebUtilities;
     using Microsoft.Extensions.DependencyInjection;
 
     using Moq;
@@ -61,6 +65,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
         private IRenderedComponent<ParameterEditorBody> renderedComponent;
         private ParameterEditorBody editor;
         private CDPMessageBus messageBus;
+        private Mock<IParameterEditorBodyViewModel> parameterEditorViewModel;
 
         [SetUp]
         public void SetUp()
@@ -76,7 +81,8 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             session.Setup(x => x.PermissionService).Returns(permissionService.Object);
             sessionService.Setup(x => x.Session).Returns(session.Object);
-            var parameterEditorViewModel = new Mock<IParameterEditorBodyViewModel>();
+            this.parameterEditorViewModel = new Mock<IParameterEditorBodyViewModel>();
+            var parameterEditorViewModel = this.parameterEditorViewModel;
 
             var elements = new SourceList<ElementBase>();
             elements.Add(new ElementDefinition { Name = "Element1" });
@@ -158,6 +164,57 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
                 Assert.That(this.editor.ViewModel, Is.Not.Null);
                 Assert.That(this.renderedComponent, Is.Not.Null);
             });
+        }
+
+        /// <summary>
+        /// Verifies that <c>InitializeValues</c> reads the option/element/parameter/category filters found
+        /// in the URL on first render, and that changing a selector afterward exercises
+        /// <c>UpdateUrl</c> without throwing.
+        /// </summary>
+        [Test]
+        public void VerifyInitializeValuesAndUpdateUrl()
+        {
+            var navigation = this.context.Services.GetRequiredService<NavigationManager>();
+
+            var urlOptions = new Dictionary<string, string>
+            {
+                [QueryKeys.OptionsKey] = Guid.NewGuid().ToShortGuid(),
+                [QueryKeys.ElementsKey] = Guid.NewGuid().ToShortGuid(),
+                [QueryKeys.ParametersKey] = Guid.NewGuid().ToShortGuid(),
+                [QueryKeys.CategoriesKey] = Guid.NewGuid().ToShortGuid()
+            };
+
+            navigation.NavigateTo(QueryHelpers.AddQueryString("http://localhost/", urlOptions));
+
+            var rendered = this.context.Render<ParameterEditorBody>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rendered.Instance.ViewModel.OptionSelector.SelectedOptions, Is.Not.Null);
+                Assert.That(rendered.Instance.ViewModel.ElementSelector.SelectedElementBases, Is.Not.Null);
+                Assert.That(rendered.Instance.ViewModel.ParameterTypeSelector.SelectedParameterTypes, Is.Not.Null);
+                Assert.That(rendered.Instance.ViewModel.CategorySelector.SelectedCategories, Is.Not.Null);
+            });
+
+            var elementSelector = (MultiElementBaseSelectorViewModel)rendered.Instance.ViewModel.ElementSelector;
+            var optionSelector = (MultiOptionSelectorViewModel)rendered.Instance.ViewModel.OptionSelector;
+            var parameterTypeSelector = (MultiParameterTypeSelectorViewModel)rendered.Instance.ViewModel.ParameterTypeSelector;
+            var categorySelector = (MultiCategorySelectorViewModel)rendered.Instance.ViewModel.CategorySelector;
+
+            var element = new ElementDefinition { Iid = Guid.NewGuid(), Name = "Selected element" };
+            var option = new Option { Iid = Guid.NewGuid(), Name = "Selected option" };
+            var parameterType = new SimpleQuantityKind { Iid = Guid.NewGuid(), Name = "Selected type" };
+            var category = new Category { Iid = Guid.NewGuid(), Name = "Selected category" };
+
+            this.parameterEditorViewModel.SetupProperty(x => x.IsOwnedParameters, true);
+
+            Assert.That(() =>
+            {
+                elementSelector.SelectedElementBases = [element];
+                optionSelector.SelectedOptions = [option];
+                parameterTypeSelector.SelectedParameterTypes = [parameterType];
+                categorySelector.SelectedCategories = [category];
+            }, Throws.Nothing, "Changing a selector must exercise UpdateUrl without throwing.");
         }
 
         [Test]

--- a/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ParameterEditor/ParameterEditorBodyTestFixture.cs
@@ -83,8 +83,8 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
             elements.Add(new ElementDefinition { Name = "Element2" });
             elements.Add(new ElementDefinition { Name = "Element3" });
 
-            parameterEditorViewModel.Setup(x => x.ElementSelector).Returns(new ElementBaseSelectorViewModel());
-            parameterEditorViewModel.Setup(x => x.OptionSelector).Returns(new OptionSelectorViewModel());
+            parameterEditorViewModel.Setup(x => x.ElementSelector).Returns(new MultiElementBaseSelectorViewModel());
+            parameterEditorViewModel.Setup(x => x.OptionSelector).Returns(new MultiOptionSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.ParameterTypeSelector).Returns(new MultiParameterTypeSelectorViewModel());
             parameterEditorViewModel.Setup(x => x.CategorySelector).Returns(new MultiCategorySelectorViewModel());
             parameterEditorViewModel.Setup(x => x.ParameterTableViewModel).Returns(new ParameterTableViewModel(sessionService.Object, this.messageBus));
@@ -163,12 +163,11 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
         [Test]
         public void VerifyComponentUi()
         {
-            var elementFilterCombo = this.renderedComponent.FindComponent<ElementBaseSelector>();
+            var elementFilterCombo = this.renderedComponent.FindComponent<MultiElementBaseSelector>();
             var parameterFilterCombo = this.renderedComponent.FindComponent<MultiParameterTypeSelector>();
             var categoryFilterCombo = this.renderedComponent.FindComponent<MultiCategorySelector>();
-            var optionFilterCombo = this.renderedComponent.FindComponent<OptionSelector>();
+            var optionFilterCombo = this.renderedComponent.FindComponent<MultiOptionSelector>();
 
-            var isOwnedCheckbox = this.renderedComponent.FindComponent<DxCheckBox<bool>>();
             var parameterTable = this.renderedComponent.FindComponent<ParameterTable>();
             var batchParameterEditor = this.renderedComponent.FindComponent<BatchParameterEditor>();
 
@@ -178,7 +177,7 @@ namespace COMETwebapp.Tests.Components.ParameterEditor
                 Assert.That(parameterFilterCombo, Is.Not.Null);
                 Assert.That(categoryFilterCombo, Is.Not.Null);
                 Assert.That(optionFilterCombo, Is.Not.Null);
-                Assert.That(isOwnedCheckbox, Is.Not.Null);
+                Assert.That(() => this.renderedComponent.Find("#parameterEditorViewMenuButton"), Throws.Nothing);
                 Assert.That(parameterTable, Is.Not.Null);
                 Assert.That(batchParameterEditor, Is.Not.Null);
             });

--- a/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
+++ b/COMETwebapp.Tests/Components/ReferenceData/ParameterTypes/ParameterTypeFormTestFixture.cs
@@ -60,6 +60,14 @@ namespace COMETwebapp.Tests.Components.ReferenceData.ParameterTypes
         {
             this.context = new BunitContext();
             this.context.ConfigureDevExpressBlazor();
+            this.context.JSInterop.SetupVoid("DxBlazor.AdaptiveDropDown.init").SetVoidResult();
+
+            // The ArrayParameterType / numeric branches render DevExpress input editors (DxSpinEdit/DxComboBox)
+            // whose DxInputDataEditorBase.InitClientSideCore awaits JS module-load calls from OnAfterRenderAsync.
+            // ConfigureDevExpressBlazor does not complete them, so the awaited call otherwise throws
+            // JSRuntimeInvocationNotSetException; complete them here (same pattern as AdaptiveDropDown.init).
+            this.context.JSInterop.SetupVoid("DxBlazor.Input.loadModule").SetVoidResult();
+            this.context.JSInterop.SetupVoid("DxBlazor.UiHandlersBridge.loadModule").SetVoidResult();
 
             this.viewModel = new Mock<IParameterTypeTableViewModel>();
             this.viewModel.Setup(x => x.ParameterTypes).Returns([new ClassKindWrapper(ClassKind.BooleanParameterType)]);

--- a/COMETwebapp.Tests/Components/RelationshipMatrix/RelationshipMatrixBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/RelationshipMatrix/RelationshipMatrixBodyTestFixture.cs
@@ -291,7 +291,7 @@ namespace COMETwebapp.Tests.Components.RelationshipMatrix
             await renderedComponent.InvokeAsync(() => renderedComponent.FindAll("button").Single(x => x.TextContent.Contains("Swap")).ClickAsync(new MouseEventArgs()));
             await renderedComponent.InvokeAsync(() => renderedComponent.FindAll("button").Single(x => x.TextContent.Contains("Export to Excel")).ClickAsync(new MouseEventArgs()));
             await renderedComponent.InvokeAsync(() => renderedComponent.FindAll("button").Single(x => x.TextContent.Contains("Configuration")).ClickAsync(new MouseEventArgs()));
-            await renderedComponent.InvokeAsync(() => renderedComponent.Find(".matrix-config-panel-header button").ClickAsync(new MouseEventArgs()));
+            await renderedComponent.InvokeAsync(() => renderedComponent.Find("#matrix-config-minimize").ClickAsync(new MouseEventArgs()));
 
             Assert.Multiple(() =>
             {

--- a/COMETwebapp.Tests/Components/Shared/CategoryPillsTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Shared/CategoryPillsTestFixture.cs
@@ -1,0 +1,148 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CategoryPillsTestFixture.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Tests.Components.Shared
+{
+    using Bunit;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using COMET.Web.Common.Test.Helpers;
+
+    using COMETwebapp.Components.Shared;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for <see cref="CategoryPills" />.
+    /// </summary>
+    [TestFixture]
+    public class CategoryPillsTestFixture
+    {
+        private BunitContext context;
+
+        /// <summary>
+        /// Set up the test run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this.context = new BunitContext();
+        }
+
+        /// <summary>
+        /// Tears down the test run.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.context.CleanContext();
+        }
+
+        /// <summary>
+        /// Verifies that fewer categories than <see cref="CategoryPills.MaxVisible" /> render one pill per
+        /// category and no overflow pill.
+        /// </summary>
+        [Test]
+        public void VerifyFewCategoriesRenderNoOverflowPill()
+        {
+            var categories = new List<Category>
+            {
+                new() { Iid = Guid.NewGuid(), ShortName = "CAT1", Name = "Category One", PermissibleClass = { ClassKind.ElementDefinition } }
+            };
+
+            var rendered = this.context.Render<CategoryPills>(parameters => parameters.Add(p => p.Categories, categories));
+
+            var pills = rendered.FindAll("span.starion-pill");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pills, Has.Count.EqualTo(1));
+                Assert.That(pills[0].TextContent, Is.EqualTo("CAT1"));
+                Assert.That(rendered.Markup, Does.Not.Contain("+1"));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that more categories than <see cref="CategoryPills.MaxVisible" /> render exactly
+        /// <see cref="CategoryPills.MaxVisible" /> individual pills plus a single "+N" overflow pill whose
+        /// tooltip lists the hidden categories.
+        /// </summary>
+        [Test]
+        public void VerifyExcessCategoriesCollapseIntoOverflowPill()
+        {
+            var categories = new List<Category>
+            {
+                new() { Iid = Guid.NewGuid(), ShortName = "CAT1", Name = "Category One", PermissibleClass = { ClassKind.ElementDefinition } },
+                new() { Iid = Guid.NewGuid(), ShortName = "CAT2", Name = "Category Two", PermissibleClass = { ClassKind.ElementDefinition } },
+                new() { Iid = Guid.NewGuid(), ShortName = "CAT3", Name = "Category Three", PermissibleClass = { ClassKind.ElementDefinition } }
+            };
+
+            var rendered = this.context.Render<CategoryPills>(parameters => parameters.Add(p => p.Categories, categories));
+
+            var pills = rendered.FindAll("span.starion-pill");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pills, Has.Count.EqualTo(3), "Two visible pills plus one overflow pill.");
+                Assert.That(pills[0].TextContent, Is.EqualTo("CAT1"));
+                Assert.That(pills[1].TextContent, Is.EqualTo("CAT2"));
+                Assert.That(pills[2].TextContent, Is.EqualTo("+1"));
+                Assert.That(pills[2].GetAttribute("title"), Does.Contain("CAT3"));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="CategoryPills.UseShortName" /> set to <see langword="false" /> labels
+        /// pills with the category's full name rather than its short name.
+        /// </summary>
+        [Test]
+        public void VerifyUseShortNameFalseRendersFullName()
+        {
+            var categories = new List<Category>
+            {
+                new() { Iid = Guid.NewGuid(), ShortName = "CAT1", Name = "Category One", PermissibleClass = { ClassKind.ElementDefinition } }
+            };
+
+            var rendered = this.context.Render<CategoryPills>(parameters => parameters
+                .Add(p => p.Categories, categories)
+                .Add(p => p.UseShortName, false));
+
+            var pill = rendered.Find("span.starion-pill");
+
+            Assert.That(pill.TextContent, Is.EqualTo("Category One"));
+        }
+
+        /// <summary>
+        /// Verifies that a <see langword="null" /> <see cref="CategoryPills.Categories" /> renders no pills
+        /// instead of throwing.
+        /// </summary>
+        [Test]
+        public void VerifyNullCategoriesRendersNoPills()
+        {
+            var rendered = this.context.Render<CategoryPills>(parameters => parameters.Add(p => p.Categories, null));
+
+            Assert.That(rendered.FindAll("span.starion-pill"), Is.Empty);
+        }
+    }
+}

--- a/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
@@ -101,6 +101,60 @@ namespace COMETwebapp.Tests.Components.SubscriptionDashboard
             });
         }
 
+        /// <summary>
+        /// Verifies that the multi-value "parameters" URL key is applied on initialization, that changing
+        /// a selector afterward round-trips the selection through <c>UpdateUrl</c>, and that clicking a
+        /// missing value in the domain-of-expertise table redirects to the Parameter Editor.
+        /// </summary>
+        [Test]
+        public void VerifyMultiValueInitializationAndUpdateUrlRoundTrip()
+        {
+            var thermal = new DomainOfExpertise { Iid = Guid.NewGuid(), Name = "Thermal" };
+            this.sessionService.Setup(x => x.GetDomainOfExpertise(It.IsAny<Iteration>())).Returns(thermal);
+
+            var navigation = this.context.Services.GetService<NavigationManager>();
+
+            var parameterId = Guid.NewGuid();
+            var optionId = Guid.NewGuid();
+
+            var queryParameters = new Dictionary<string, string>
+            {
+                [QueryKeys.OptionsKey] = optionId.ToShortGuid(),
+                [QueryKeys.ParametersKey] = parameterId.ToShortGuid()
+            };
+
+            navigation.NavigateTo(QueryHelpers.AddQueryString("http://localhost", queryParameters));
+
+            var parameterType = new TextParameterType { Iid = parameterId };
+
+            var parameter = new Parameter
+            {
+                ParameterType = parameterType,
+                Owner = thermal,
+                ParameterSubscription = { new ParameterSubscription { Iid = Guid.NewGuid(), Owner = new DomainOfExpertise() } }
+            };
+
+            var iteration = new Iteration { Element = { new ElementDefinition { Parameter = { parameter } } } };
+            iteration.TopElement = iteration.Element[0];
+            iteration.Option.Add(new Option { Iid = optionId });
+
+            var rendered = this.context.Render<SubscriptionDashboardBody>(parameters => parameters.Add(p => p.CurrentThing, iteration));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.OptionSelector.SelectedOptions, Is.Not.Empty, "The multi-value 'parameters' URL key must apply the option filter.");
+                Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterTypes, Is.Not.Empty, "The multi-value 'parameters' URL key must apply the parameter-type filter.");
+            });
+
+            Assert.That(() => this.viewModel.OptionSelector.SelectedOptions = [], Throws.Nothing,
+                "Clearing the selection must exercise UpdateUrl without throwing.");
+
+            var domainTable = rendered.FindComponent<DomainOfExpertiseSubscriptionTable>();
+
+            Assert.That(async () => await rendered.InvokeAsync(() => domainTable.Instance.OnMissingValueClick.InvokeAsync(parameter)), Throws.Nothing,
+                "Clicking a missing value must redirect to the Parameter Editor without throwing.");
+        }
+
         [Test]
         public void VerifyWithValidInitialValuesComponent()
         {

--- a/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SubscriptionDashboard/SubscriptionDashboardBodyTestFixture.cs
@@ -96,8 +96,8 @@ namespace COMETwebapp.Tests.Components.SubscriptionDashboard
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.OptionSelector.SelectedOption, Is.Null);
-                Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterType, Is.Null);
+                Assert.That(this.viewModel.OptionSelector.SelectedOptions, Is.Empty);
+                Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterTypes, Is.Empty);
             });
         }
 
@@ -119,7 +119,7 @@ namespace COMETwebapp.Tests.Components.SubscriptionDashboard
 
             var queryParameters = new Dictionary<string, string>
             {
-                [QueryKeys.OptionKey] = optionId.ToShortGuid(),
+                [QueryKeys.OptionsKey] = optionId.ToShortGuid(),
                 [QueryKeys.ParameterKey] = parameterId.ToShortGuid()
             };
 
@@ -164,8 +164,8 @@ namespace COMETwebapp.Tests.Components.SubscriptionDashboard
 
             Assert.Multiple(() =>
             {
-                Assert.That(this.viewModel.OptionSelector.SelectedOption, Is.Not.Null);
-                Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterType, Is.Not.Null);
+                Assert.That(this.viewModel.OptionSelector.SelectedOptions, Is.Not.Empty);
+                Assert.That(this.viewModel.ParameterTypeSelector.SelectedParameterTypes, Is.Not.Empty);
             });
 
             var mockedViewModel = new Mock<ISubscriptionDashboardBodyViewModel>();

--- a/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
+++ b/COMETwebapp.Tests/Components/SystemRepresentation/SystemRepresentationBodyTestFixture.cs
@@ -331,8 +331,7 @@ namespace COMETwebapp.Tests.Components.SystemRepresentation
             renderer.WaitForAssertion(() =>
             {
                 Assert.That(this.viewModel.DetailsPanelViewModel.SelectedElementDefinition, Is.Not.Null, "Selecting an ElementDefinition must set SelectedElementDefinition.");
-                Assert.That(renderer.Markup, Does.Contain("Parameter Group"), "The renamed add-parameter-group button must render.");
-                Assert.That(renderer.Markup, Does.Contain("Element Definition"), "The renamed add-element-definition button must render.");
+                Assert.That(() => renderer.Find("#element-details-new-button"), Throws.Nothing, "The consolidated 'New' add-actions dropdown button must render (its Parameter / Parameter Group / Element Definition items live in the DxDropDown body, which bunit does not render).");
                 Assert.That(renderer.Markup, Does.Contain("STR"), "The tree node's category pill must render.");
             });
 

--- a/COMETwebapp.Tests/IntegrationTests/ModelEditorTestFixture.cs
+++ b/COMETwebapp.Tests/IntegrationTests/ModelEditorTestFixture.cs
@@ -50,12 +50,24 @@ namespace COMETwebapp.Tests.IntegrationTests
         /// <returns>The page object.</returns>
         protected override ModelEditorPageModel CreatePageModel(IPage page) => new(page);
 
+        /// <summary>
+        /// Verifies that the harmonized "View" display-options cog is shown in the upper-right of the toolbar.
+        /// </summary>
+        /// <returns>A <see cref="Task" />.</returns>
+        [Test]
+        public async Task VerifyViewMenuButtonIsDisplayed()
+        {
+            await Expect(this.PageModel.ViewMenuButton).ToBeVisibleAsync();
+            await Expect(this.Tabs.BlazorError).ToBeHiddenAsync();
+        }
+
         [Test]
         public async Task VerifyOpeningAnElementShowsItsDetails()
         {
             await this.PageModel.SelectFirstSourceElementAsync();
 
-            await Expect(this.PageModel.DetailsPanel).ToContainTextAsync("Element Definition");
+            await Expect(this.PageModel.DetailsPanel.Locator("#element-details-new-button")).ToBeVisibleAsync();
+            await Expect(this.Tabs.BlazorError).ToBeHiddenAsync();
         }
     }
 }

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ModelEditorPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ModelEditorPageModel.cs
@@ -61,6 +61,11 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator DetailsPanel => this.Page.Locator("#detailsPanel");
 
         /// <summary>
+        /// Gets the "View" display-options cog in the upper-right of the toolbar (holds the Owner / Categories toggles).
+        /// </summary>
+        public ILocator ViewMenuButton => this.Page.Locator("#modelEditorViewMenuButton");
+
+        /// <summary>
         /// Gets the element search text box.
         /// </summary>
         public ILocator SearchBox => this.Page.Locator("#search-textbox");

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/ParameterEditorPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/ParameterEditorPageModel.cs
@@ -57,7 +57,13 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator ParameterTable => this.Page.Locator("#parameter-table");
 
         /// <summary>
-        /// Gets the "Only Parameters owned by … domain" toggle.
+        /// Gets the "View" display-and-filter options cog in the upper-right of the toolbar.
+        /// </summary>
+        public ILocator ViewMenuButton => this.Page.Locator("#parameterEditorViewMenuButton");
+
+        /// <summary>
+        /// Gets the "Only Parameters owned by … domain" toggle, which lives inside the <see cref="ViewMenuButton" />
+        /// dropdown (open the cog before interacting with it).
         /// </summary>
         public ILocator OwnedParametersToggle => this.Page.Locator("#only-owned-parameters-toggle");
 

--- a/COMETwebapp.Tests/IntegrationTests/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/IntegrationTests/ParameterEditorTestFixture.cs
@@ -50,6 +50,17 @@ namespace COMETwebapp.Tests.IntegrationTests
         /// <returns>The page object.</returns>
         protected override ParameterEditorPageModel CreatePageModel(IPage page) => new(page);
 
+        /// <summary>
+        /// Verifies that the harmonized "View" display-and-filter options cog is shown in the upper-right of the toolbar.
+        /// </summary>
+        /// <returns>A <see cref="Task" />.</returns>
+        [Test]
+        public async Task VerifyViewMenuButtonIsDisplayed()
+        {
+            await Expect(this.PageModel.ViewMenuButton).ToBeVisibleAsync();
+            await Expect(this.Tabs.BlazorError).ToBeHiddenAsync();
+        }
+
         [Test]
         public async Task VerifyCanExpandAndCollapseAnElement()
         {

--- a/COMETwebapp.Tests/IntegrationTests/SystemRepresentationTestFixture.cs
+++ b/COMETwebapp.Tests/IntegrationTests/SystemRepresentationTestFixture.cs
@@ -61,7 +61,7 @@ namespace COMETwebapp.Tests.IntegrationTests
             await Expect(this.PageModel.TreeNodes).Not.ToHaveCountAsync(initialNodeCount);
 
             await this.PageModel.SelectRootNodeAsync();
-            await Expect(this.PageModel.DetailsPanel).ToContainTextAsync("Element Definition");
+            await Expect(this.PageModel.DetailsPanel.Locator("#element-details-new-button")).ToBeVisibleAsync();
 
             await this.PageModel.CollapseFirstExpandedNodeAsync();
             await Expect(this.PageModel.TreeNodes).ToHaveCountAsync(initialNodeCount);

--- a/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
+++ b/COMETwebapp.Tests/Pages/ParameterEditor/ParameterEditorTestFixture.cs
@@ -127,11 +127,11 @@ namespace COMETwebapp.Tests.Pages.ParameterEditor
             parameterTableViewModel.Setup(x => x.Rows).Returns(new SourceList<ParameterBaseRowViewModel>());
 
             var parameterEditorBodyViewModel = new Mock<IParameterEditorBodyViewModel>();
-            parameterEditorBodyViewModel.Setup(x => x.OptionSelector).Returns(new Mock<IOptionSelectorViewModel>().Object);
+            parameterEditorBodyViewModel.Setup(x => x.OptionSelector).Returns(new Mock<IMultiOptionSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.BatchParameterEditorViewModel).Returns(new Mock<IBatchParameterEditorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ParameterTypeSelector).Returns(new Mock<IMultiParameterTypeSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.CategorySelector).Returns(new Mock<IMultiCategorySelectorViewModel>().Object);
-            parameterEditorBodyViewModel.Setup(x => x.ElementSelector).Returns(new Mock<IElementBaseSelectorViewModel>().Object);
+            parameterEditorBodyViewModel.Setup(x => x.ElementSelector).Returns(new Mock<IMultiElementBaseSelectorViewModel>().Object);
             parameterEditorBodyViewModel.Setup(x => x.ParameterTableViewModel).Returns(parameterTableViewModel.Object);
 
             var configurationService = new Mock<IStringTableService>();

--- a/COMETwebapp.Tests/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModelTestFixture.cs
@@ -135,8 +135,8 @@ namespace COMETwebapp.Tests.ViewModels.Components.ModelDashboard
 
             Assert.Multiple(() =>
             {
-                this.parameterDashboard.Verify(x => x.UpdateProperties(It.IsAny<Iteration>(), It.IsAny<Option>(),
-                        It.IsAny<ActualFiniteState>(), It.IsAny<ParameterType>(), It.IsAny<DomainOfExpertise>(), It.IsAny<IEnumerable<DomainOfExpertise>>()),
+                this.parameterDashboard.Verify(x => x.UpdateProperties(It.IsAny<Iteration>(), It.IsAny<IEnumerable<Option>>(),
+                        It.IsAny<IEnumerable<ActualFiniteState>>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<DomainOfExpertise>(), It.IsAny<IEnumerable<DomainOfExpertise>>()),
                     Times.AtLeastOnce,
                     "ModelDashboardBodyViewModel has no OnEndUpdate override, so a cross-panel write's EndUpdate never " +
                     "reaches OnSessionRefreshed/UpdateDashboards.");

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModelTestFixture.cs
@@ -249,14 +249,14 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         {
             await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
 
-            this.viewModel.ElementSelector.SelectedElementBase = this.viewModel.ElementSelector.AvailableElements.First();
+            this.viewModel.ElementSelector.SelectedElementBases = [this.viewModel.ElementSelector.AvailableElements.First()];
             this.viewModel.ParameterTypeSelector.SelectedParameterTypes = new List<ParameterType> { this.viewModel.ParameterTypeSelector.AvailableParameterTypes.First() };
-            this.viewModel.OptionSelector.SelectedOption = this.viewModel.CurrentThing.Option.Last();
+            this.viewModel.OptionSelector.SelectedOptions = [this.viewModel.CurrentThing.Option.Last()];
             this.viewModel.IsOwnedParameters = false;
 
             this.viewModel.ApplyFilters();
 
-            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<Option>(), It.IsAny<ElementBase>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<IEnumerable<Category>>(), It.IsAny<bool>()), Times.AtLeastOnce);
+            this.tableViewModel.Verify(x => x.ApplyFilters(It.IsAny<IEnumerable<Option>>(), It.IsAny<IEnumerable<ElementBase>>(), It.IsAny<IEnumerable<ParameterType>>(), It.IsAny<IEnumerable<Category>>(), It.IsAny<bool>()), Times.AtLeastOnce);
         }
 
         [Test]
@@ -270,7 +270,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 Assert.That(this.viewModel.CategorySelector, Is.Not.Null);
                 Assert.That(this.viewModel.CategorySelector.CurrentIteration, Is.SameAs(this.viewModel.CurrentThing));
                 Assert.That(this.viewModel.OptionSelector, Is.Not.Null);
-                Assert.That(this.viewModel.OptionSelector.SelectedOption, Is.Not.Null);
+                Assert.That(this.viewModel.OptionSelector.SelectedOptions, Is.Empty);
                 Assert.That(this.viewModel.IsOwnedParameters, Is.True);
             });
         }

--- a/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/ParameterEditor/ParameterTableViewModelTestFixture.cs
@@ -224,7 +224,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         [Test]
         public void VerifyInitializeViewModel()
         {
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
 
             Assert.Multiple(() =>
             {
@@ -235,7 +235,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         [Test]
         public void VerifyParameterRowProperties()
         {
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
             var parameterRow = this.viewModel.Rows.Items.First();
 
             Assert.Multiple(() =>
@@ -252,7 +252,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         [Test]
         public async Task VerifyParameterRowBehavior()
         {
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
             var parameterRow = this.viewModel.Rows.Items.First();
 
             Assert.Multiple(() =>
@@ -269,7 +269,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
             this.permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
 
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
             parameterRow = this.viewModel.Rows.Items.First();
 
             await parameterRow.ParameterSwitchKindSelectorViewModel.OnUpdate.InvokeAsync();
@@ -294,19 +294,19 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
         [Test]
         public void VerifyFiltering()
         {
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.Option.Last(), null, null, null, true);
+            this.viewModel.ApplyFilters([this.iteration.Option.Last()], null, null, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(1));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, this.iteration.Element[^1], null, null, true);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], [this.iteration.Element[^1]], null, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { new ArrayParameterType { Iid = Guid.NewGuid() } }, null, true);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, new[] { new ArrayParameterType { Iid = Guid.NewGuid() } }, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(0));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, new[] { this.iteration.TopElement.Parameter[0].ParameterType }, null, true);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, new[] { this.iteration.TopElement.Parameter[0].ParameterType }, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
             var multipleParameterTypes = new[]
@@ -314,13 +314,13 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
                 this.iteration.TopElement.Parameter[0].ParameterType,
                 new ArrayParameterType { Iid = Guid.NewGuid() }
             };
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, multipleParameterTypes, null, true);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, multipleParameterTypes, null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, Array.Empty<ParameterType>(), null, true);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, Array.Empty<ParameterType>(), null, true);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, null, false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, null, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
         }
 
@@ -347,34 +347,34 @@ namespace COMETwebapp.Tests.ViewModels.Components.ParameterEditor
 
             this.iteration.Element[^1].Category.Add(boxCategory);
 
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
             // Empty/null category set — no filter applied.
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, null, false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, null, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, Array.Empty<Category>(), false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, Array.Empty<Category>(), false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(4));
 
             // Filtering by an unrelated category drops every row.
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { unrelatedCategory }, false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, new[] { unrelatedCategory }, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(0));
 
             // Filtering by the box category retains only the rows whose owning ElementBase carries it directly
             // (parameter1, parameter2 on Box) or inherits it (the override on usage1, which references Box).
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { boxCategory }, false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, new[] { boxCategory }, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
 
             // Multi-select OR semantics: union of matching rows.
-            this.viewModel.ApplyFilters(this.iteration.DefaultOption, null, null, new[] { boxCategory, unrelatedCategory }, false);
+            this.viewModel.ApplyFilters([this.iteration.DefaultOption], null, null, new[] { boxCategory, unrelatedCategory }, false);
             Assert.That(this.viewModel.Rows, Has.Count.EqualTo(3));
         }
 
         [Test]
         public void VerifyUpdateOnCollection()
         {
-            this.viewModel.InitializeViewModel(this.iteration, this.domain, this.option);
+            this.viewModel.InitializeViewModel(this.iteration, this.domain, [this.option]);
 
             var elementDefinition = new ElementDefinition()
             {

--- a/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/DomainOfExpertiseSubscriptionTableViewModeltTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/DomainOfExpertiseSubscriptionTableViewModeltTestFixture.cs
@@ -100,10 +100,10 @@ namespace COMETwebapp.Tests.ViewModels.Components.SubscriptionDashboard
                 Assert.That(row.InterestedDomainsShortNames, Is.EquivalentTo(otherDomain.ShortName));
             });
 
-            this.viewModel.ApplyFilters(null, new BooleanParameterType());
+            this.viewModel.ApplyFilters(null, [new BooleanParameterType()]);
             Assert.That(this.viewModel.Rows, Is.Empty);
 
-            this.viewModel.ApplyFilters(new Option(), null);
+            this.viewModel.ApplyFilters([new Option()], null);
             Assert.That(this.viewModel.Rows, Is.Not.Empty);
         }
     }

--- a/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/SubscribedTableViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/SubscriptionDashboard/SubscribedTableViewModelTestFixture.cs
@@ -206,7 +206,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.SubscriptionDashboard
 
             Assert.That(this.viewModel.DidSubscriptionsChanged, Is.True);
 
-            this.viewModel.ApplyFilters(options[0], heightParameterType);
+            this.viewModel.ApplyFilters([options[0]], [heightParameterType]);
             Assert.That(this.viewModel.Rows, Is.Empty);
 
             this.viewModel.ApplyFilters(null, null);

--- a/COMETwebapp/Components/BookEditor/BookEditorColumn.razor.css
+++ b/COMETwebapp/Components/BookEditor/BookEditorColumn.razor.css
@@ -46,8 +46,17 @@
     background-color: transparent;
 }
 
+.add-item-button {
+    color: var(--colors-primary-600);
+}
+
+.add-item-button:hover:not(.disabled-button) {
+    color: var(--colors-primary-700);
+}
+
 .add-item-button.disabled-button{
-    background-color: #DDD;
+    background-color: transparent;
+    color: #9db8cf;
 }
 
 .column-content {

--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor
@@ -36,7 +36,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                               Text="@(this.ButtonDisplayText)"
                               Click="@(() => this.OnButtonClick.Invoke())"
                               IconCssClass="@IconName.Add.GetCssClass()"
-                              RenderStyle="ButtonRenderStyle.Dark"
+                              RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                               style="width: 200px;"/>
                 }
             </div>

--- a/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.css
+++ b/COMETwebapp/Components/Common/DataItemDetailsComponent.razor.css
@@ -1,7 +1,6 @@
 ﻿.data-item-details-section {
-    padding: 15px;
-    border: 1px dashed;
-    border-radius: 10px;
+    padding: 4px 12px 12px 12px;
+    border: none;
     height: 100%;
     overflow: auto;
 }

--- a/COMETwebapp/Components/Common/DefinitionsTable.razor
+++ b/COMETwebapp/Components/Common/DefinitionsTable.razor
@@ -28,6 +28,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxButton Id="addDefinitionButton"
                           Text="Add"
                           IconCssClass="@IconName.Add.GetCssClass()"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                           Click="this.StartCreate"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
@@ -36,10 +37,12 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editDefinitionButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                               Click="@(() => this.StartEdit(row))"/>
 
                     <DxButton Id="removeDefinitionButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                               Click="() => this.RemovalPopup.Request(row)"/>
                 }
             </CellDisplayTemplate>

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor
@@ -22,19 +22,6 @@
 @using COMETwebapp.Components.ModelEditor
 @inherits DisposableComponent
 
-<div id="panel-action-bar" class="mb-2 d-flex flex-wrap align-items-center justify-content-end" style="gap:8px;">
-    @if (this.ViewModel.SelectedElementDefinition is not null)
-    {
-        <div style="flex:1 1 200px; min-width:0;">
-            <SearchBar @bind-Text="@this.SearchTerm" Placeholder="Search parameters or owner…"/>
-        </div>
-        <DxButton Id="addParameter" Text="Parameter" IconCssClass="@IconName.Add.GetCssClass()" Click="@(this.ViewModel.OpenAddParameterPopup)"/>
-        <DxButton Id="addParameterGroup" Text="Parameter Group" IconCssClass="@IconName.Add.GetCssClass()" Click="@this.ViewModel.OpenCreateParameterGroupPopup"/>
-    }
-
-    <DxButton Id="addElementDefinition" Text="Element Definition" IconCssClass="@IconName.Add.GetCssClass()" Click="@this.ViewModel.OpenCreateElementDefinitionCreationPopup"/>
-</div>
-
 <DetailsPanelEditor ViewModel="this.ViewModel.ElementDefinitionDetailsViewModel"
                     SearchTerm="@this.SearchTerm"
                     OnEditParameter="@(parameter => this.ViewModel.OpenEditParameterPopup(parameter))"
@@ -51,7 +38,46 @@
                     OnAssignParameterGroup="@(args => this.ViewModel.AssignParameterToGroupAsync(args))"
                     OnReassignGroupContaining="@(args => this.ViewModel.ReassignGroupContainingAsync(args))"
                     OnEditParameterGroup="@(g => this.ViewModel.OpenEditParameterGroupPopup(g))"
-                    OnDeleteParameterGroup="@(g => this.ViewModel.OpenDeleteParameterGroupPopup(g))"/>
+                    OnDeleteParameterGroup="@(g => this.ViewModel.OpenDeleteParameterGroupPopup(g))">
+    <HeaderActions>
+        @this.DetailsHeaderActions
+    </HeaderActions>
+    <ActionBar>
+        <div id="panel-action-bar" class="mb-2 d-flex align-items-center" style="gap:8px;">
+            <div style="flex:1 1 200px; min-width:0;">
+                @if (this.ViewModel.SelectedElementDefinition is not null)
+                {
+                    <SearchBar @bind-Text="@this.SearchTerm" Placeholder="Search parameters or owner…"/>
+                }
+            </div>
+
+            <DxButton Id="element-details-new-button"
+                      CssClass="element-details-add-button"
+                      Text="Add"
+                      IconCssClass="@IconName.Add.GetCssClass()"
+                      RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
+                      Click="@(() => this.IsNewMenuOpen = !this.IsNewMenuOpen)"/>
+        </div>
+    </ActionBar>
+</DetailsPanelEditor>
+
+<DxDropDown @bind-IsOpen="@this.IsNewMenuOpen"
+            PositionMode="DropDownPositionMode.Bottom"
+            PositionTarget="#element-details-new-button"
+            CloseMode="DropDownCloseMode.Close"
+            HeaderVisible="false"
+            FooterVisible="false">
+    <BodyTemplate>
+        <div class="element-details-new-menu">
+            @if (this.ViewModel.SelectedElementDefinition is not null)
+            {
+                <DxButton Id="addParameter" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Parameter" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenAddParameterPopup))"/>
+                <DxButton Id="addParameterGroup" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Parameter Group" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateParameterGroupPopup))"/>
+            }
+            <DxButton Id="addElementDefinition" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Element Definition" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateElementDefinitionCreationPopup))"/>
+        </div>
+    </BodyTemplate>
+</DxDropDown>
 
 <DxPopup CloseOnOutsideClick="false" HeaderText="Create Element Definition" @bind-Visible="@this.ViewModel.IsOnCreationMode" Width="40vw">
     <BodyContentTemplate>

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor
@@ -71,10 +71,10 @@
         <div class="element-details-new-menu">
             @if (this.ViewModel.SelectedElementDefinition is not null)
             {
-                <DxButton Id="addParameter" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Parameter" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenAddParameterPopup))"/>
-                <DxButton Id="addParameterGroup" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Parameter Group" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateParameterGroupPopup))"/>
+                <DxButton Id="addParameter" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" CssClass="element-details-new-item" Text="Add Parameter" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenAddParameterPopup))"/>
+                <DxButton Id="addParameterGroup" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" CssClass="element-details-new-item" Text="Add Parameter Group" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateParameterGroupPopup))"/>
             }
-            <DxButton Id="addElementDefinition" RenderStyle="ButtonRenderStyle.Light" CssClass="element-details-new-item" Text="Add Element Definition" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateElementDefinitionCreationPopup))"/>
+            <DxButton Id="addElementDefinition" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" CssClass="element-details-new-item" Text="Add Element Definition" Click="@(() => this.OnNewMenuItemClicked(this.ViewModel.OpenCreateElementDefinitionCreationPopup))"/>
         </div>
     </BodyTemplate>
 </DxDropDown>
@@ -123,10 +123,10 @@
         </div>
         <div class="d-flex justify-content-end" style="gap:8px;">
             <DxButton Text="Cancel"
-                      RenderStyle="ButtonRenderStyle.Secondary"
+                      RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())"
                       Click="@(() => this.ViewModel.IsOnParameterGroupEditMode = false)"/>
             <DxButton Text="Save"
-                      RenderStyle="ButtonRenderStyle.Primary"
+                      RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                       Click="@this.ViewModel.SaveParameterGroupAsync"/>
         </div>
     </BodyContentTemplate>

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
@@ -44,10 +44,22 @@ namespace COMETwebapp.Components.Common
         public IElementDetailsPanelViewModel ViewModel { get; set; }
 
         /// <summary>
+        /// Gets or sets optional content rendered on the element summary header row, next to the edit/delete
+        /// buttons (used by the Model Editor to place the panel-collapse chevron on the same line).
+        /// </summary>
+        [Parameter]
+        public RenderFragment DetailsHeaderActions { get; set; }
+
+        /// <summary>
         /// Gets or sets the current search term used to filter the parameter cards rendered by the
         /// <see cref="COMETwebapp.Components.ModelEditor.DetailsPanelEditor" />. Held here so the search box can share the action-bar row.
         /// </summary>
         private string SearchTerm { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the "New" dropdown menu is currently open.
+        /// </summary>
+        private bool IsNewMenuOpen { get; set; }
 
         /// <summary>
         /// Method invoked when the component is ready to start, having received its initial parameters
@@ -79,6 +91,17 @@ namespace COMETwebapp.Components.Common
                 .SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
 
             return base.OnInitializedAsync();
+        }
+
+        /// <summary>
+        /// Closes the "New" dropdown menu and invokes the supplied action. Bound to each item of the
+        /// dropdown so that choosing an item both triggers its popup and dismisses the menu.
+        /// </summary>
+        /// <param name="action">The action to invoke, e.g. one of the <c>Open*Popup</c> methods on <see cref="ViewModel" />.</param>
+        private void OnNewMenuItemClicked(Action action)
+        {
+            this.IsNewMenuOpen = false;
+            action();
         }
     }
 }

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.cs
@@ -101,7 +101,7 @@ namespace COMETwebapp.Components.Common
         private void OnNewMenuItemClicked(Action action)
         {
             this.IsNewMenuOpen = false;
-            action();
+            action.Invoke();
         }
     }
 }

--- a/COMETwebapp/Components/Common/ElementDetailsPanel.razor.css
+++ b/COMETwebapp/Components/Common/ElementDetailsPanel.razor.css
@@ -1,7 +1,57 @@
-#panel-action-bar {
+#element-details-toolbar {
     position: sticky;
     top: 0;
     z-index: 5;
     background: #fff;
     padding-top: 4px;
+}
+
+.element-details-identity {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.element-details-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-bottom: 0;
+}
+
+.element-details-actions {
+    flex: 0 0 auto;
+    gap: 4px;
+    margin-left: 8px;
+}
+
+.element-details-pills {
+    gap: 4px;
+    margin-top: 4px;
+}
+
+::deep .element-details-add-button {
+    min-width: 88px;
+    height: 34px;
+}
+
+::deep .element-details-add-button::after {
+    content: "";
+    display: inline-block;
+    margin-left: 6px;
+    vertical-align: middle;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid currentColor;
+}
+
+.element-details-new-menu {
+    display: flex;
+    flex-direction: column;
+    min-width: 190px;
+}
+
+.element-details-new-menu ::deep .element-details-new-item {
+    width: 100%;
+    justify-content: flex-start;
+    text-align: left;
 }

--- a/COMETwebapp/Components/Common/FormButtons.razor
+++ b/COMETwebapp/Components/Common/FormButtons.razor
@@ -20,7 +20,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     {
         <DxButton Id="deleteItemButton"
                   Click="@(() => this.OnDelete.InvokeAsync())"
-                  RenderStyle="ButtonRenderStyle.Danger">
+                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())">
             Delete
         </DxButton>
     }
@@ -34,7 +34,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
     <DxButton Id="cancelItemButton"
               Click="@(() => this.OnCancel.InvokeAsync())"
-              RenderStyle="ButtonRenderStyle.Secondary">
+              RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
         Cancel
     </DxButton>
 </div>

--- a/COMETwebapp/Components/Common/FormButtons.razor
+++ b/COMETwebapp/Components/Common/FormButtons.razor
@@ -27,6 +27,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
     <DxButton Id="saveItemButton"
               SubmitFormOnClick="true"
+              RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
               Enabled="@(this.SaveButtonEnabled && !this.IsLoading)">
         @(this.IsLoading ? "Loading" : "Save")
     </DxButton>

--- a/COMETwebapp/Components/Common/ParameterCard.razor
+++ b/COMETwebapp/Components/Common/ParameterCard.razor
@@ -50,7 +50,7 @@
             else if (this.OnDeleteSubscription.HasDelegate && this.Row.HasCurrentDomainSubscription)
             {
                 <DxButton IconCssClass="@IconName.Bell.GetCssClass()"
-                          RenderStyle="ButtonRenderStyle.Danger"
+                          RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnDeleteSubscription.InvokeAsync(this.Row.CurrentDomainSubscription))"
@@ -68,7 +68,7 @@
             else if (this.OnDeleteOverride.HasDelegate && this.Row.HasOverride)
             {
                 <DxButton IconCssClass="@IconName.Branch.GetCssClass()"
-                          RenderStyle="ButtonRenderStyle.Danger"
+                          RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnDeleteOverride.InvokeAsync(this.Row.CurrentOverride))"
@@ -93,7 +93,7 @@
             @if (this.OnDeleteParameter.HasDelegate)
             {
                 <DxButton IconCssClass="@IconName.Delete.GetCssClass()"
-                          RenderStyle="ButtonRenderStyle.Danger"
+                          RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnDeleteParameter.InvokeAsync(this.Row.Parameter))"

--- a/COMETwebapp/Components/Common/ParameterCard.razor
+++ b/COMETwebapp/Components/Common/ParameterCard.razor
@@ -41,6 +41,7 @@
             @if (this.OnCreateSubscription.HasDelegate && this.Row.CanSubscribe)
             {
                 <DxButton IconCssClass="@IconName.Bell.GetCssClass()"
+                          RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnCreateSubscription.InvokeAsync(this.Row.Parameter))"
@@ -58,6 +59,7 @@
             @if (this.OnCreateOverride.HasDelegate && this.Row.CanCreateOverride)
             {
                 <DxButton IconCssClass="@IconName.Branch.GetCssClass()"
+                          RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnCreateOverride.InvokeAsync((this.Row.Parameter, this.Row.HostElementUsage)))"
@@ -82,6 +84,7 @@
             @if (this.OnEditParameter.HasDelegate)
             {
                 <DxButton IconCssClass="@IconName.Edit.GetCssClass()"
+                          RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                           RenderStyleMode="ButtonRenderStyleMode.Text"
                           CssClass="ms-1 flex-shrink-0"
                           Click="@(() => this.OnEditParameter.InvokeAsync(this.Row.HasOverride ? this.Row.CurrentOverride : (ParameterOrOverrideBase)this.Row.Parameter))"

--- a/COMETwebapp/Components/Common/ParameterGroupSection.razor
+++ b/COMETwebapp/Components/Common/ParameterGroupSection.razor
@@ -56,7 +56,7 @@
                 {
                     <span @onclick:stopPropagation="true">
                         <DxButton IconCssClass="@IconName.Delete.GetCssClass()"
-                                  RenderStyle="ButtonRenderStyle.Danger"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                                   RenderStyleMode="ButtonRenderStyleMode.Text"
                                   SizeMode="SizeMode.Small"
                                   CssClass="ms-1"

--- a/COMETwebapp/Components/Common/ParameterGroupSection.razor
+++ b/COMETwebapp/Components/Common/ParameterGroupSection.razor
@@ -44,6 +44,7 @@
                 {
                     <span @onclick:stopPropagation="true">
                         <DxButton IconCssClass="@IconName.Edit.GetCssClass()"
+                                  RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                                   RenderStyleMode="ButtonRenderStyleMode.Text"
                                   SizeMode="SizeMode.Small"
                                   CssClass="ms-1"

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresForm.razor
@@ -38,7 +38,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxFormLayoutTabPage Caption="FolderFile Structure">
                     <DxFormLayoutItem CssClass="w-100">
                         <FolderFileStructure ViewModel="@(this.ViewModel.FolderFileStructureViewModel)"/>
-                        <DxButton Click="@(() => this.IsFolderFileStructureVisible = true)" Text="Open Details"/>
+                        <DxButton Click="@(() => this.IsFolderFileStructureVisible = true)" Text="Open Details" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                     </DxFormLayoutItem>
                 </DxFormLayoutTabPage>
             }

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
@@ -49,7 +49,7 @@ Copyright (c) 2023-2026 Starion Group S.A
 <DxPopup @bind-Visible="@(this.ViewModel.IsOnDeletionMode)" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/CommonFileStoresTable.razor
@@ -50,6 +50,6 @@ Copyright (c) 2023-2026 Starion Group S.A
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresForm.razor
@@ -38,7 +38,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxFormLayoutTabPage Caption="FolderFile Structure">
                     <DxFormLayoutItem CssClass="w-100">
                         <FolderFileStructure ViewModel="@(this.ViewModel.FolderFileStructureViewModel)"/>
-                        <DxButton Click="@(() => this.IsFolderFileStructureVisible = true)" Text="Open Details"/>
+                        <DxButton Click="@(() => this.IsFolderFileStructureVisible = true)" Text="Open Details" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                     </DxFormLayoutItem>
                 </DxFormLayoutTabPage>
             }

--- a/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
@@ -51,6 +51,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/DomainFileStore/DomainFileStoresTable.razor
@@ -50,7 +50,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@(this.ViewModel.IsOnDeletionMode)" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
@@ -75,7 +75,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             Delete
         </DxButton>
         <DxButton SubmitFormOnClick="true"
-                  Enabled="@(this.ViewModel.SelectedFileRevisions.Any())">
+                  Enabled="@(this.ViewModel.SelectedFileRevisions.Any())"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
             Save
         </DxButton>
 
@@ -90,7 +91,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@this.IsDeletePopupVisible" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     You are about to delete the File: @(this.ViewModel.CurrentThing.CurrentFileRevision?.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(() => this.IsDeletePopupVisible = false)" />
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.IsDeletePopupVisible = false)" />
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFilePopupButton" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FileForm.razor
@@ -71,7 +71,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     <div class="dxbl-grid-edit-form-buttons">
         <DxButton Id="deleteFileButton"
                   Click="@(() => this.IsDeletePopupVisible = true)"
-                  RenderStyle="ButtonRenderStyle.Danger">
+                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())">
             Delete
         </DxButton>
         <DxButton SubmitFormOnClick="true"
@@ -82,7 +82,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
         <DxButton Id="cancelFileButton"
                   Click="@(() => this.OnCancel())"
-                  RenderStyle="ButtonRenderStyle.Secondary">
+                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
             Cancel
         </DxButton>
     </div>
@@ -92,6 +92,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     You are about to delete the File: @(this.ViewModel.CurrentThing.CurrentFileRevision?.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.IsDeletePopupVisible = false)" />
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFilePopupButton" />
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(() => this.OnDelete())" Id="deleteFilePopupButton" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FileRevisionsTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FileRevisionsTable.razor
@@ -22,7 +22,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxGridDataColumn FieldName="@nameof(FileRevisionRowViewModel.CreatedOn)" MinWidth="80" SearchEnabled="false" />
         <DxGridCommandColumn Width="160px">
             <HeaderTemplate>
-                <DxButton Id="addFileRevisionButton" Text="Add File Revision" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                <DxButton Id="addFileRevisionButton" Text="Add File Revision" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -30,10 +30,12 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="downloadFileRevisionButton"
                               IconCssClass="@IconName.Download.GetCssClass()"
-                              Click="() => this.ViewModel.DownloadFileRevision(row.Thing)" />
+                              Click="() => this.ViewModel.DownloadFileRevision(row.Thing)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" />
                     <DxButton Id="removeFileRevisionButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="() => this.RemoveFileRevision(row)"/>
+                              Click="() => this.RemoveFileRevision(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FileTypesTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FileTypesTable.razor
@@ -22,11 +22,12 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxGridDataColumn FieldName="@nameof(FileTypeRowViewModel.Extension)" MinWidth="80" SearchEnabled="false" />
         <DxGridCommandColumn Width="160px">
             <HeaderTemplate>
-                <DxButton Id="addFileTypeButton" 
-                          Text="Add File Type" 
-                          IconCssClass="@IconName.Add.GetCssClass()" 
-                          Click="this.StartCreate" 
-                          Enabled="@(this.SelectedFileTypes.Count != this.FileTypes.Count())"/>
+                <DxButton Id="addFileTypeButton"
+                          Text="Add File Type"
+                          IconCssClass="@IconName.Add.GetCssClass()"
+                          Click="this.StartCreate"
+                          Enabled="@(this.SelectedFileTypes.Count != this.FileTypes.Count())"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -34,15 +35,18 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="moveUpButton"
                               IconCssClass="@IconName.ArrowUp.GetCssClass()"
-                              Click="() => this.MoveUp(row)" 
-                              Enabled="@(this.SelectedFileTypes.IndexOf(row.Thing) > 0)"/>
+                              Click="() => this.MoveUp(row)"
+                              Enabled="@(this.SelectedFileTypes.IndexOf(row.Thing) > 0)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                     <DxButton Id="moveDownButton"
                               IconCssClass="@IconName.ArrowDown.GetCssClass()"
                               Click="() => this.MoveDown(row)"
-                              Enabled="@(this.SelectedFileTypes.LastOrDefault() != row.Thing)" />
+                              Enabled="@(this.SelectedFileTypes.LastOrDefault() != row.Thing)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" />
                     <DxButton Id="removeFileTypeButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="() => this.RemoveFileType(row)" />
+                              Click="() => this.RemoveFileType(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" />
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FolderFileStructure.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FolderFileStructure.razor
@@ -17,12 +17,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
 @inherits DisposableComponent
 
 <DxButton Id="createFolderButton"
-          Click="@(() => this.OnEditFolderClick())">
+          Click="@(() => this.OnEditFolderClick())"
+          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
     Create Folder
 </DxButton>
 
 <DxButton Id="createFileButton"
-          Click="@(() => this.OnEditFileClick())">
+          Click="@(() => this.OnEditFileClick())"
+          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
     Create File
 </DxButton>
 
@@ -54,7 +56,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                           Click="@(() => this.OnEditFolderClick(row))"
                           SizeMode="SizeMode.Small"
                           CssClass="float-end"
-                          RenderStyle="ButtonRenderStyle.Dark"/>
+                          RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
             }
         </div>}
     </NodeTextTemplate>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
@@ -49,7 +49,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     <div class="dxbl-grid-edit-form-buttons">
         <DxButton Id="deleteFolderButton"
                   Click="@(() => this.IsDeletePopupVisible = true)"
-                  RenderStyle="ButtonRenderStyle.Danger">
+                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())">
             Delete
         </DxButton>
 
@@ -60,7 +60,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
         <DxButton Id="cancelFolderButton"
                   Click="@(() => this.OnCancel())"
-                  RenderStyle="ButtonRenderStyle.Secondary">
+                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
             Cancel
         </DxButton>
     </div>
@@ -70,6 +70,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     You are about to delete the Folder: @(this.ViewModel.CurrentThing.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.IsDeletePopupVisible = false)" />
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFolderPopupButton" />
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(() => this.OnDelete())" Id="deleteFolderPopupButton" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
+++ b/COMETwebapp/Components/EngineeringModel/FileStore/FolderForm.razor
@@ -53,7 +53,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             Delete
         </DxButton>
 
-        <DxButton SubmitFormOnClick="true">
+        <DxButton SubmitFormOnClick="true"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
             Save
         </DxButton>
 
@@ -68,7 +69,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@this.IsDeletePopupVisible" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     You are about to delete the Folder: @(this.ViewModel.CurrentThing.Name)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(() => this.IsDeletePopupVisible = false)" />
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.IsDeletePopupVisible = false)" />
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(() => this.OnDelete())" Id="deleteFolderPopupButton" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
@@ -51,7 +51,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@(this.ViewModel.IsOnDeletionMode)" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/OptionsTable.razor
@@ -52,6 +52,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/EngineeringModel/PublicationsTable.razor
+++ b/COMETwebapp/Components/EngineeringModel/PublicationsTable.razor
@@ -43,7 +43,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <div class="p-3">
             <DxButton Id="addPublicationButton" 
                       Text="Publish" 
-                      RenderStyle="ButtonRenderStyle.Primary" 
+                      RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" 
                       Click="@this.PublishSelectedParameters"
                       CssClass="float-end"/>
         </div>

--- a/COMETwebapp/Components/ModelDashboard/Elements/UnreferencedElements.razor
+++ b/COMETwebapp/Components/ModelDashboard/Elements/UnreferencedElements.razor
@@ -24,13 +24,13 @@
 @if (this.Elements != null && this.UnreferencedElementDefinitions != null)
 {
     <div data-testid="dashboard-chart">
-        <div class="row">
-            <div class="col-9">
-                <h3 class="text-align-end">Unreferenced Elements</h3>
+        <div class="row align-items-center justify-content-center">
+            <div class="col-auto p-0">
+                <h3 class="m-0">Unreferenced Elements</h3>
             </div>
-            <div class="col text-align-start p-0">
+            <div class="col-auto p-0">
                 <Tooltip MarginBottom="bottom-60" Text="Elements without associated element usage">
-                    <button type="button" class="btn btn-secondary btn-tooltip"><CometIcon Icon="IconName.Info"/></button>
+                    <button type="button" class="btn-tooltip"><CometIcon Icon="IconName.Info" Size="16"/></button>
                 </Tooltip>
             </div>
         </div>

--- a/COMETwebapp/Components/ModelDashboard/Elements/UnusedElements.razor
+++ b/COMETwebapp/Components/ModelDashboard/Elements/UnusedElements.razor
@@ -24,16 +24,17 @@
 @if(this.Elements != null && this.UnusedElementDefinitions != null)
 {
     <div data-testid="dashboard-chart">
-        <div class="row">
-            <div class="col-9">
-                <h3 class="text-align-end">Unused Elements</h3>
+        <div class="row align-items-center justify-content-center">
+            <div class="col-auto p-0">
+                <h3 class="m-0">Unused Elements</h3>
             </div>
-            <div class="col text-align-start p-0">
+            <div class="col-auto p-0">
                 <Tooltip MarginBottom="bottom-25" Text="Elements not used in an option">
-                    <button type="button" class="btn btn-secondary btn-tooltip"><CometIcon Icon="IconName.Info"/></button>
+                    <button type="button" class="btn-tooltip"><CometIcon Icon="IconName.Info" Size="16"/></button>
                 </Tooltip>
             </div>
-       
+        </div>
+        <div class="row">
             <DxChart Data="@this.Elements" CustomizeSeriesPoint="@PreparePointLabel">
                 <DxChartFullStackedBarSeries Color="System.Drawing.Color.IndianRed" Name="@WebAppConstantValues.UsedElements" Filter="@((ElementDefinition e) => this.UnusedElementDefinitions.All(x => x.Iid != e.Iid))"
                                             ArgumentField="@(e => e.Owner.ShortName)" ValueField="@(e => 1)"

--- a/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor
+++ b/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor
@@ -23,16 +23,18 @@
 
 <LoadingComponent IsVisible="this.ViewModel.IsLoading">
     <div id="@WebAppConstantValues.ModelDashboardPage.QueryPageBodyName()" class="container-fluid">
+        <div class="filter-bar">
+            <div class="filter-bar-item">
+                <MultiOptionSelector ViewModel="@(this.ViewModel.OptionSelector)" DisplayText=""/>
+            </div>
+            <div class="filter-bar-item">
+                <MultiFiniteStateSelector ViewModel="@(this.ViewModel.FiniteStateSelector)" DisplayText=""/>
+            </div>
+            <div class="filter-bar-item">
+                <MultiParameterTypeSelector ViewModel="@(this.ViewModel.ParameterTypeSelector)" DisplayText=""/>
+            </div>
+        </div>
         <div class="row">
-            <div class="col-2 width-fit-content">
-                <OptionSelector ViewModel="@(this.ViewModel.OptionSelector)"/>
-            </div>
-            <div class="col-2 width-fit-content">
-                <FiniteStateSelector ViewModel="@(this.ViewModel.FiniteStateSelector)"/>
-            </div>
-            <div class="col-2 width-fit-content">
-                <ParameterTypeSelector ViewModel="@(this.ViewModel.ParameterTypeSelector)"/>
-            </div>
             <div class="row">
                 <ParameterDashboard ViewModel="@(this.ViewModel.ParameterDashboard)" OnToDoClick="@(this.RedirectToParameterEditor)"/>
             </div>

--- a/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
+++ b/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
@@ -22,6 +22,9 @@
 
 namespace COMETwebapp.Components.ModelDashboard
 {
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
     using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
@@ -43,19 +46,40 @@ namespace COMETwebapp.Components.ModelDashboard
         /// <param name="parameters">A <see cref="Dictionary{TKey,TValue}" /> for parameters</param>
         protected override void InitializeValues(Dictionary<string, string> parameters)
         {
-            if (parameters.TryGetValue(QueryKeys.OptionKey, out var option))
+            if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                this.ViewModel.OptionSelector.SelectedOption = this.ViewModel.OptionSelector.AvailableOptions.FirstOrDefault(x => x.Iid == option.FromShortGuid());
+                var ids = optionsValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
             }
 
-            if (parameters.TryGetValue(QueryKeys.StateKey, out var state))
+            if (parameters.TryGetValue(QueryKeys.StatesKey, out var statesValue) && !string.IsNullOrWhiteSpace(statesValue))
             {
-                this.ViewModel.FiniteStateSelector.SelectedActualFiniteState = this.ViewModel.FiniteStateSelector.AvailableFiniteStates.FirstOrDefault(x => x.Iid == state.FromShortGuid());
+                var ids = statesValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.FiniteStateSelector.SelectedActualFiniteStates = this.ViewModel.FiniteStateSelector.AvailableFiniteStates
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
             }
 
-            if (parameters.TryGetValue(QueryKeys.ParameterKey, out var parameter))
+            if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                this.ViewModel.ParameterTypeSelector.SelectedParameterType = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes.FirstOrDefault(x => x.Iid == parameter.FromShortGuid());
+                var ids = parametersValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
             }
         }
 
@@ -66,9 +90,9 @@ namespace COMETwebapp.Components.ModelDashboard
         {
             base.OnViewModelAssigned();
 
-            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption,
-                    x => x.ViewModel.FiniteStateSelector.SelectedActualFiniteState,
-                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterType)
+            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOptions,
+                    x => x.ViewModel.FiniteStateSelector.SelectedActualFiniteStates,
+                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterTypes)
                 .Subscribe(_ => this.UpdateUrl()));
         }
 
@@ -80,19 +104,25 @@ namespace COMETwebapp.Components.ModelDashboard
         {
             var additionalParameters = new Dictionary<string, string>();
 
-            if (this.ViewModel.OptionSelector.SelectedOption != null)
+            var selectedOptions = this.ViewModel.OptionSelector.SelectedOptions?.ToList() ?? new List<Option>();
+
+            if (selectedOptions.Count > 0)
             {
-                additionalParameters[QueryKeys.OptionKey] = this.ViewModel.OptionSelector.SelectedOption.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.OptionsKey] = string.Join(",", selectedOptions.Select(x => x.Iid.ToShortGuid()));
             }
 
-            if (this.ViewModel.FiniteStateSelector.SelectedActualFiniteState != null)
+            var selectedStates = this.ViewModel.FiniteStateSelector.SelectedActualFiniteStates?.ToList() ?? new List<ActualFiniteState>();
+
+            if (selectedStates.Count > 0)
             {
-                additionalParameters[QueryKeys.StateKey] = this.ViewModel.FiniteStateSelector.SelectedActualFiniteState.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.StatesKey] = string.Join(",", selectedStates.Select(x => x.Iid.ToShortGuid()));
             }
 
-            if (this.ViewModel.ParameterTypeSelector.SelectedParameterType != null)
+            var selectedParameterTypes = this.ViewModel.ParameterTypeSelector.SelectedParameterTypes?.ToList() ?? new List<ParameterType>();
+
+            if (selectedParameterTypes.Count > 0)
             {
-                additionalParameters[QueryKeys.ParameterKey] = this.ViewModel.ParameterTypeSelector.SelectedParameterType.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.ParametersKey] = string.Join(",", selectedParameterTypes.Select(x => x.Iid.ToShortGuid()));
             }
 
             this.ViewModel.UpdateDashboards();

--- a/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
+++ b/COMETwebapp/Components/ModelDashboard/ModelDashboardBody.razor.cs
@@ -29,6 +29,7 @@ namespace COMETwebapp.Components.ModelDashboard
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
+    using COMETwebapp.Extensions;
     using COMETwebapp.Utilities;
 
     using Microsoft.AspNetCore.Components;
@@ -48,10 +49,7 @@ namespace COMETwebapp.Components.ModelDashboard
         {
             if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                var ids = optionsValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = optionsValue.FromShortGuids();
 
                 this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
                     .Where(x => ids.Contains(x.Iid))
@@ -60,10 +58,7 @@ namespace COMETwebapp.Components.ModelDashboard
 
             if (parameters.TryGetValue(QueryKeys.StatesKey, out var statesValue) && !string.IsNullOrWhiteSpace(statesValue))
             {
-                var ids = statesValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = statesValue.FromShortGuids();
 
                 this.ViewModel.FiniteStateSelector.SelectedActualFiniteStates = this.ViewModel.FiniteStateSelector.AvailableFiniteStates
                     .Where(x => ids.Contains(x.Iid))
@@ -72,10 +67,7 @@ namespace COMETwebapp.Components.ModelDashboard
 
             if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                var ids = parametersValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = parametersValue.FromShortGuids();
 
                 this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
                     .Where(x => ids.Contains(x.Iid))

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/DefaultValues.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/DefaultValues.razor
@@ -23,14 +23,14 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 @inherits HaveValueSetsChartData
 
 <div class="width-100" data-testid="dashboard-chart">
-	<div class="row">
-		<div class="col-8">
-			<h3 class="text-align-end">Missing Values</h3>
+	<div class="row align-items-center justify-content-center">
+		<div class="col-auto p-0">
+			<h3 class="m-0">Missing Values</h3>
 		</div>
-		<div class="col text-align-start p-0">
+		<div class="col-auto p-0">
 			<Tooltip MarginBottom="bottom-60" Text="Missing Values = Published Values with Default Value '-'">
-				<button type="button" class="btn btn-secondary btn-tooltip">
-					<CometIcon Icon="IconName.Info"/>
+				<button type="button" class="btn-tooltip">
+					<CometIcon Icon="IconName.Info" Size="16"/>
 				</button>
 			</Tooltip>
 		</div>

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/ParameterDomainProgress.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/ParameterDomainProgress.razor
@@ -23,13 +23,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 {
 	<div class="row">
 		<div class="col">
-			<div class="row">
-				<div class="col-9">
-					<h3 class="text-align-end">Published Parameters</h3>
+			<div class="row align-items-center justify-content-center">
+				<div class="col-auto p-0">
+					<h3 class="m-0">Published Parameters</h3>
 				</div>
-				<div class="col text-align-start p-0">
+				<div class="col-auto p-0">
 					<Tooltip MarginBottom="bottom-60" Text="Publishable parameter : current value not equal to published value">
-						<button type="button" class="btn btn-secondary btn-tooltip"><CometIcon Icon="IconName.Info"/></button>
+						<button type="button" class="btn-tooltip"><CometIcon Icon="IconName.Info" Size="16"/></button>
 					</Tooltip>
 				</div>
 			</div>
@@ -46,13 +46,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
 		</div>
 		<div class="col">
-			<div class="row">
-				<div class="col-8">
-					<h3 class="text-align-end">Missing Values</h3>
+			<div class="row align-items-center justify-content-center">
+				<div class="col-auto p-0">
+					<h3 class="m-0">Missing Values</h3>
 				</div>
-				<div class="col text-align-start p-0">
+				<div class="col-auto p-0">
 					<Tooltip MarginBottom="bottom-60" Text="Missing Values = Published Values with Default Value '-'">
-						<button type="button" class="btn btn-secondary btn-tooltip"><CometIcon Icon="IconName.Info"/></button>
+						<button type="button" class="btn-tooltip"><CometIcon Icon="IconName.Info" Size="16"/></button>
 					</Tooltip>
 				</div>
 			</div>

--- a/COMETwebapp/Components/ModelDashboard/ParameterValues/PublishedParameters.razor
+++ b/COMETwebapp/Components/ModelDashboard/ParameterValues/PublishedParameters.razor
@@ -23,13 +23,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 @inherits HaveValueSetsChartData
 
 <div class="width-100" data-testid="dashboard-chart">
-    <div class="row">
-        <div class="col-9">
-            <h3 class="text-align-end">Published Parameters</h3>
+    <div class="row align-items-center justify-content-center">
+        <div class="col-auto p-0">
+            <h3 class="m-0">Published Parameters</h3>
         </div>
-        <div class="col text-align-start p-0">
+        <div class="col-auto p-0">
             <Tooltip MarginBottom="bottom-60" Text="Publishable parameter : actual value not equal to published value">
-                <button type="button" class="btn btn-secondary btn-tooltip"><CometIcon Icon="IconName.Info"/></button>
+                <button type="button" class="btn-tooltip"><CometIcon Icon="IconName.Info" Size="16"/></button>
             </Tooltip>
         </div>
     </div>

--- a/COMETwebapp/Components/ModelEditor/AddParameter.razor
+++ b/COMETwebapp/Components/ModelEditor/AddParameter.razor
@@ -64,6 +64,6 @@
     <div class="pt-3"></div>
     <ValidationSummary />
     <div class="modal-footer m-top-10px">
-        <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Create" SubmitFormOnClick="true"/>
+        <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Create" SubmitFormOnClick="true"/>
     </div>
 </EditForm>

--- a/COMETwebapp/Components/ModelEditor/CopySettings.razor
+++ b/COMETwebapp/Components/ModelEditor/CopySettings.razor
@@ -25,5 +25,5 @@ When a user drops an ElementDefinition on a different Iteration, data from the o
     ValueFieldName="Value"
     @bind-Value="@this.ViewModel.SelectedOperationKind" />
 <div class="modal-footer m-top-10px">
-    <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save Settings" Click="async () => await this.SaveSettings()" />
+    <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save Settings" Click="async () => await this.SaveSettings()" />
 </div>

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -18,6 +18,7 @@
 //    along with this program. If not, see http://www.gnu.org/licenses/.
 ------------------------------------------------------------------------------->
 @using COMET.Web.Common.Extensions
+@using COMETwebapp.Extensions
 @using CDP4Common.EngineeringModelData
 @using COMETwebapp.Components.Common
 @using COMETwebapp.ViewModels.Components.SystemRepresentation.Rows
@@ -26,26 +27,30 @@
 
 @if (this.ViewModel.SelectedSystemNode != null)
 {
-    @* ── Summary card ── *@
-    <div class="card cardview-detailspanel-summary mb-2" style="padding:8px;">
-        <div class="row" style="margin-bottom:4px;">
-            <div class="col-7">
+     <div class="card cardview-detailspanel-summary mb-2" style="padding:8px;">
+        <div class="d-flex align-items-center" style="gap:8px;">
+            <div style="min-width:0; flex:1 1 auto;">
                 <h6 title="@this.ViewModel.SelectedSystemNode.Name"
                     style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:0;">
                     @this.ViewModel.SelectedSystemNode.Name
                 </h6>
-                <small class="text-muted">@this.ViewModel.SelectedSystemNode.ShortName</small>
+                <small class="text-muted" style="display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">@this.ViewModel.SelectedSystemNode.ShortName</small>
             </div>
-            <div class="col-5" align="right">
+
+            <div class="d-flex flex-wrap align-items-center justify-content-end" style="gap:4px; flex:0 1 auto; min-width:0;">
                 <StarionPill ColorSeed="@($"owner:{this.ViewModel.SelectedSystemNode.Owner.ShortName}")" Title="@($"Owning Domain Of Expertise: {this.ViewModel.SelectedSystemNode.Owner.ShortName}")">
                     @this.ViewModel.SelectedSystemNode.Owner.ShortName
                 </StarionPill>
+                <CategoryPills Categories="@this.ViewModel.SelectedSystemNode.GetDisplayCategories()" UseShortName="false"/>
+            </div>
+
+            <div class="d-flex align-items-center" style="gap:2px; flex:0 0 auto;">
                 @if (this.OnEditDefinition.HasDelegate && this.ViewModel.SelectedSystemNode is ElementUsage)
                 {
                     <DxButton Id="editDefinition"
                               IconCssClass="@IconName.Box.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                               RenderStyleMode="ButtonRenderStyleMode.Text"
-                              CssClass="ms-1"
                               Click="@(() => this.OnEditDefinition.InvokeAsync())"
                               title="Edit Element Definition"/>
                 }
@@ -53,8 +58,8 @@
                 {
                     <DxButton Id="editElement"
                               IconCssClass="@IconName.Edit.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
                               RenderStyleMode="ButtonRenderStyleMode.Text"
-                              CssClass="ms-1"
                               Click="@(() => this.OnEditElement.InvokeAsync())"
                               title="@(this.ViewModel.SelectedSystemNode is ElementUsage ? "Edit Element Usage" : "Edit Element Definition")"/>
                 }
@@ -64,43 +69,20 @@
                               IconCssClass="@IconName.Delete.GetCssClass()"
                               RenderStyle="ButtonRenderStyle.Danger"
                               RenderStyleMode="ButtonRenderStyleMode.Text"
-                              CssClass="ms-1"
                               Enabled="@(!this.DisableDelete)"
                               Click="@(() => this.OnDeleteElement.InvokeAsync())"
                               title="@(this.DisableDelete ? "The top element of the iteration cannot be deleted" : "Delete the selected element")"/>
                 }
+                @this.HeaderActions
             </div>
         </div>
-        @{
-            var categories = this.ViewModel.SelectedSystemNode.GetAllCategories().ToList();
-        }
-        @if (categories.Count > 0)
-        {
-            <div class="row" style="margin-bottom:4px;">
-                <div class="col-12">
-                    @foreach (var category in categories)
-                    {
-                        <StarionPill ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.Name}")" Style="margin-right:4px;">
-                            @category.Name
-                        </StarionPill>
-                    }
-                </div>
-            </div>
-        }
-        @{
-            var definition = this.ViewModel.SelectedSystemNode.Definition.Select(x => x.Content).AsCommaSeparated();
-        }
-        @if (!string.IsNullOrWhiteSpace(definition))
-        {
-            <div class="row" style="border-top:1px dotted darkgray;margin-top:8px;padding-top:8px;">
-                <div class="col-12" title="@definition">
-                    @definition
-                </div>
-            </div>
-        }
     </div>
+}
 
-    @* ── Collapsible grouped parameter sections ── *@
+@this.ActionBar
+
+@if (this.ViewModel.SelectedSystemNode != null)
+{
     <div class="param-groups-container" @ref="this.groupsContainer">
         @foreach (var group in this.TopLevelGroups)
         {

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor
@@ -67,7 +67,7 @@
                 {
                     <DxButton Id="deleteElement"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              RenderStyle="ButtonRenderStyle.Danger"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"
                               RenderStyleMode="ButtonRenderStyleMode.Text"
                               Enabled="@(!this.DisableDelete)"
                               Click="@(() => this.OnDeleteElement.InvokeAsync())"

--- a/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/DetailsPanelEditor.razor.cs
@@ -51,6 +51,20 @@ namespace COMETwebapp.Components.ModelEditor
         public IElementDefinitionDetailsViewModel ViewModel { get; set; }
 
         /// <summary>
+        ///     Optional content rendered on the right of the element summary header, next to the edit/delete
+        ///     buttons (used by the Model Editor to place the panel-collapse chevron on the same line).
+        /// </summary>
+        [Parameter]
+        public RenderFragment HeaderActions { get; set; }
+
+        /// <summary>
+        ///     Optional content rendered between the element summary card and the parameter groups (the search
+        ///     bar and the "Add" button), so the element context sits on top and the search/add sit below it.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ActionBar { get; set; }
+
+        /// <summary>
         ///     Optional callback invoked when the user clicks the per-card edit affordance, carrying the row's
         ///     <see cref="ParameterOrOverrideBase" /> (the <see cref="ParameterOverride" /> when one exists on the
         ///     selected usage, otherwise the underlying <see cref="Parameter" />). When unset, the edit affordance

--- a/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
+++ b/COMETwebapp/Components/ModelEditor/EditElementDefinition.razor
@@ -59,7 +59,7 @@
         </DxFormLayout>
         <ValidationSummary />
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save" SubmitFormOnClick="true" />
         </div>
     </EditForm>
 }

--- a/COMETwebapp/Components/ModelEditor/EditElementUsage.razor
+++ b/COMETwebapp/Components/ModelEditor/EditElementUsage.razor
@@ -48,7 +48,7 @@
         </DxFormLayout>
         <ValidationSummary />
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save" SubmitFormOnClick="true" />
         </div>
     </EditForm>
 }

--- a/COMETwebapp/Components/ModelEditor/EditParameter.razor
+++ b/COMETwebapp/Components/ModelEditor/EditParameter.razor
@@ -174,8 +174,8 @@
     </DxFormLayout>
 
     <div class="modal-footer m-top-10px">
-        <DxButton Text="Cancel" RenderStyle="ButtonRenderStyle.Secondary" Click="@(() => this.ViewModel.CancelAsync())"/>
-        <DxButton Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(() => this.ViewModel.SaveAsync())"/>
+        <DxButton Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.ViewModel.CancelAsync())"/>
+        <DxButton Text="OK" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(() => this.ViewModel.SaveAsync())"/>
     </div>
 
     @if (this.ViewModel.IsOnComponentEditMode)

--- a/COMETwebapp/Components/ModelEditor/EditParameterSubscription.razor
+++ b/COMETwebapp/Components/ModelEditor/EditParameterSubscription.razor
@@ -87,7 +87,7 @@
     </div>
 
     <div class="modal-footer m-top-10px">
-        <DxButton Text="Cancel" RenderStyle="ButtonRenderStyle.Secondary" Click="@(() => this.ViewModel.CancelAsync())"/>
-        <DxButton Text="OK" RenderStyle="ButtonRenderStyle.Primary" Click="@(() => this.ViewModel.SaveAsync())"/>
+        <DxButton Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(() => this.ViewModel.CancelAsync())"/>
+        <DxButton Text="OK" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(() => this.ViewModel.SaveAsync())"/>
     </div>
 }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionCreation.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionCreation.razor
@@ -52,6 +52,6 @@
     </DxFormLayout>
     <ValidationSummary />
     <div class="modal-footer m-top-10px">
-        <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Create" SubmitFormOnClick="true" />
+        <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Create" SubmitFormOnClick="true" />
     </div>
 </EditForm>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
@@ -21,22 +21,25 @@
 @using COMETwebapp.ViewModels.Components.ModelEditor.Rows
 @inject IJSRuntime JSRuntime
 
-<div style = "height:50px;">
-@if (this.IsModelSelectionEnabled)
-{
-    <DxComboBox TData="IterationData"
-                TValue="IterationData"
-                FilteringMode="DataGridFilteringMode.Contains" 
-                SizeMode="SizeMode.Medium" 
-                Data="@this.ViewModel.Iterations"
-                TextFieldName="IterationName"
-                @bind-Value="@this.ViewModel.SelectedIterationData">
-    </DxComboBox>
-}
-else
-{
-    <h6>@this.ViewModel.Description</h6>
-}
+<div style="flex:0 0 60px; display:flex; align-items:center; gap:6px;">
+    @this.HeaderPrefix
+    <div style="flex:1 1 auto; min-width:0;">
+        @if (this.IsModelSelectionEnabled)
+        {
+            <DxComboBox TData="IterationData"
+                        TValue="IterationData"
+                        FilteringMode="DataGridFilteringMode.Contains"
+                        SizeMode="SizeMode.Medium"
+                        Data="@this.ViewModel.Iterations"
+                        TextFieldName="IterationName"
+                        @bind-Value="@this.ViewModel.SelectedIterationData">
+            </DxComboBox>
+        }
+        else
+        {
+            <h6 class="m-0">@this.ViewModel.Description</h6>
+        }
+    </div>
 </div>
 <div id="search-textbox" style="visibility:@(this.AllowSearch ? "visible" : "hidden");">
     <SearchBar @bind-Text="this.SearchTerm"/>
@@ -47,10 +50,10 @@ else
      @ondragenter="@(() => this.DragEnterAsync(this.TreeView))"
      @ondragleave="@(() => this.DragLeaveAsync(this.TreeView))"
      @ondrop="@(async (DragEventArgs e) => await this.DropAsync(null, e))"
-     style="padding:2px;border:dotted 1px;border-radius: 5px;height:25px;@(this.AllowDrop ? "" : "visibility:hidden;")">
+     style="display:flex;align-items:center;justify-content:center;padding:8px 10px;margin:4px 0;border:dashed 1px var(--colors-primary-600);border-radius:6px;min-height:38px;color:var(--colors-primary-600);background:var(--colors-primary-50);font-size:0.85rem;font-weight:500;@(this.AllowDrop ? "" : "visibility:hidden;")">
     Drop here to create new element...
 </div>
-<div class="@this.ScrollableAreaCssClass" style="overflow:auto;">
+<div id="@this.ScrollAreaId" class="@this.ScrollableAreaCssClass" style="overflow:auto;">
     <DxTreeView @ref="this.TreeView" Data="@this.ViewModel.Rows"
                 FilterString="@this.SearchTerm"
                 FilterMinLength="1"
@@ -74,6 +77,7 @@ else
                     <ElementDefinitionTreeItem
                         CssClass="@($"{cssClass} {(this.AllowDrop && this.dragOverNode == dataItem && this.AllowNodeDrop ? "treeview-item-drag-over" : "")}")"
                         ElementBaseTreeRowViewModel="@dataItem"
+                        ShowName="@this.ShowName"
                         ShowOwner="@this.ShowOwner"
                         ShowCategories="@this.ShowCategories"
                         draggable="@(this.AllowDrag ? "true" : "false")"
@@ -90,6 +94,7 @@ else
                     <ElementDefinitionTreeItem
                         CssClass="@cssClass"
                         ElementBaseTreeRowViewModel="@dataItem"
+                        ShowName="@this.ShowName"
                         ShowOwner="@this.ShowOwner"
                         ShowCategories="@this.ShowCategories"/>
                 }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor
@@ -44,13 +44,12 @@
 <div id="search-textbox" style="visibility:@(this.AllowSearch ? "visible" : "hidden");">
     <SearchBar @bind-Text="this.SearchTerm"/>
 </div>
-<div class="drop-area-color @(this.dragOverNode == this.TreeView && this.AllowNodeDrop && this.AllowDrop ? "treeview-drag-over" : "")"
+<div class="drop-here-bar drop-area-color @(this.dragOverNode == this.TreeView && this.AllowNodeDrop && this.AllowDrop ? "treeview-drag-over" : "") @(this.AllowDrop ? "" : "drop-here-bar-hidden")"
      dropzone="@(this.AllowDrop ? "move" : "")"
      ondragover="@(this.AllowDrop ? "event.preventDefault();" : "")"
      @ondragenter="@(() => this.DragEnterAsync(this.TreeView))"
      @ondragleave="@(() => this.DragLeaveAsync(this.TreeView))"
-     @ondrop="@(async (DragEventArgs e) => await this.DropAsync(null, e))"
-     style="display:flex;align-items:center;justify-content:center;padding:8px 10px;margin:4px 0;border:dashed 1px var(--colors-primary-600);border-radius:6px;min-height:38px;color:var(--colors-primary-600);background:var(--colors-primary-50);font-size:0.85rem;font-weight:500;@(this.AllowDrop ? "" : "visibility:hidden;")">
+     @ondrop="@(async (DragEventArgs e) => await this.DropAsync(null, e))">
     Drop here to create new element...
 </div>
 <div id="@this.ScrollAreaId" class="@this.ScrollableAreaCssClass" style="overflow:auto;">

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
@@ -229,9 +229,11 @@ namespace COMETwebapp.Components.ModelEditor
             {
                 await this.JSRuntime.InvokeVoidAsync("cometDragScroll.init", this.ScrollAreaId);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                // JS interop failures during pre-rendering or test environments are non-fatal.
+                // JS interop failures during pre-rendering or test environments are non-fatal, but log them so a
+                // genuine failure to wire the drag auto-scroll in the browser can be tracked.
+                this.Logger.LogWarning(exception, "Failed to initialise drag auto-scroll for the element definition tree.");
             }
         }
 

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.cs
@@ -31,6 +31,7 @@ namespace COMETwebapp.Components.ModelEditor
 
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Web;
+    using Microsoft.JSInterop;
 
     /// <summary>
     /// Support class for the <see cref="ElementDefinitionTree" /> component
@@ -72,6 +73,21 @@ namespace COMETwebapp.Components.ModelEditor
         /// </summary>
         [Parameter]
         public bool ShowCategories { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether each node shows the element's full name (when
+        /// <see langword="true" />) or its short name (when <see langword="false" />)
+        /// </summary>
+        [Parameter]
+        public bool ShowName { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets optional content rendered at the start of the tree header, to the left of the model
+        /// selector or description (used by the Model Editor to place the panel-collapse chevron next to the
+        /// source-model dropdown).
+        /// </summary>
+        [Parameter]
+        public RenderFragment HeaderPrefix { get; set; }
 
         /// <summary>
         /// Fires after node selection has been changed for a specific item.
@@ -141,6 +157,12 @@ namespace COMETwebapp.Components.ModelEditor
         public string ScrollableAreaCssClass { get; set; } = string.Empty;
 
         /// <summary>
+        /// A unique id for this tree's scroll container, so the drag auto-scroll JS can target it. Two instances
+        /// (source and target) live side by side in the Model Editor, so a shared id would not be unique.
+        /// </summary>
+        public string ScrollAreaId { get; } = $"ed-tree-scrollarea-{Guid.NewGuid():N}";
+
+        /// <summary>
         /// Holds a reference to the object where the dragged node is dragged over
         /// </summary>
         private object dragOverNode;
@@ -191,14 +213,26 @@ namespace COMETwebapp.Components.ModelEditor
         /// Use the <paramref name="firstRender" /> parameter to ensure that initialization work is only performed
         /// once.
         /// </remarks>
-        protected override Task OnAfterRenderAsync(bool firstRender)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (this.ViewModel.Iteration != this.InitialIteration)
             {
                 this.InitialIteration = this.ViewModel.Iteration;
             }
 
-            return Task.CompletedTask;
+            if (!firstRender)
+            {
+                return;
+            }
+
+            try
+            {
+                await this.JSRuntime.InvokeVoidAsync("cometDragScroll.init", this.ScrollAreaId);
+            }
+            catch (Exception)
+            {
+                // JS interop failures during pre-rendering or test environments are non-fatal.
+            }
         }
 
         /// <summary>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
@@ -1,3 +1,23 @@
+/* The "drop here to create new element" bar shown above the tree. */
+.drop-here-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 10px;
+    margin: 4px 0;
+    border: dashed 1px var(--colors-primary-600);
+    border-radius: 6px;
+    min-height: 38px;
+    color: var(--colors-primary-600);
+    background: var(--colors-primary-50);
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.drop-here-bar-hidden {
+    visibility: hidden;
+}
+
 ::deep .sticky-scrollable-column {
     position: sticky;
     top: 0px;

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor.css
@@ -1,13 +1,55 @@
-/* ::deep is required: the class sits on DxTreeView, which is a child component, so a plain scoped
-   rule would never reach it. */
 ::deep .sticky-scrollable-column {
     position: sticky;
     top: 0px;
-    /* Lay the tree out at its natural width so that a deeply nested or long-named node overflows the
-       panel and the scroll area scrolls to it, rather than being squeezed into the panel width (issue #742). */
-    min-width: max-content;
+   min-width: max-content;
 }
 
 ::deep .sticky-scrollable-column .dxbl-treeview-item-text {
     white-space: nowrap;
+}
+
+::deep .dxbl-treeview {
+    --dxbl-treeview-item-hover-bg: #f5f5f5;
+    --tree-indent-step: 18px;
+    --dxbl-treeview-item-indent: 0;
+}
+
+::deep .dxbl-treeview-item-content {
+    position: relative;
+    padding-left: calc(var(--dxbl-treeview-item-indent, 0) * var(--tree-indent-step)) !important;
+}
+
+::deep .dxbl-treeview-item-content::before {
+    content: "";
+    position: absolute;
+    top: -8px;
+    bottom: -8px;
+    left: calc(var(--dxbl-treeview-item-indent, 0) * var(--tree-indent-step) - (var(--tree-indent-step) / 2));
+    width: 1px;
+    background: #e5e9ee;
+}
+
+::deep .dxbl-treeview-items-container > .dxbl-treeview-item:last-child > .dxbl-treeview-item-content::before {
+    bottom: 50%;
+}
+
+::deep .dxbl-treeview-item-content::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: calc(var(--dxbl-treeview-item-indent, 0) * var(--tree-indent-step) - (var(--tree-indent-step) / 2));
+    width: calc(var(--tree-indent-step) / 2);
+    height: 1px;
+    background: #e5e9ee;
+}
+
+::deep .dxbl-treeview-item-container {
+    border-radius: 8px;
+    border-left: 3px solid transparent;
+}
+
+::deep .dxbl-treeview-item-container.dxbl-active {
+    background-color: #e7f1ff;
+    border-left-color: #2b6cb0;
+    font-weight: 600;
 }

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor
@@ -21,7 +21,14 @@
 
 <div data-testid="element-node" class="@this.CssClass" style="display: flex; justify-content: space-between; align-items: center;" @attributes="this.AdditionalAttributes">
     <span>
-        <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="ElementName" />
+        @if (this.ShowName)
+        {
+            <CardField Context="@this.ElementBaseTreeRowViewModel" FieldName="ElementName" />
+        }
+        else
+        {
+            @this.ElementBaseTreeRowViewModel.ElementBase?.ShortName
+        }
     </span>
     <span style="text-align: end;">
         @if (this.ShowOwner)
@@ -35,14 +42,7 @@
 
         @if (this.ShowCategories)
         {
-            @foreach (var categoryShortName in this.ElementBaseTreeRowViewModel.ElementBase.GetDisplayCategories().Select(x => x.ShortName))
-            {
-                <span @key="categoryShortName">
-                    <StarionPill ColorSeed="@($"category:{categoryShortName}")" Title="@($"Category: {categoryShortName}")">
-                        <CardField Context="@categoryShortName"/>
-                    </StarionPill>
-                </span>
-            }
+            <CategoryPills Categories="@this.ElementBaseTreeRowViewModel.ElementBase.GetDisplayCategories()" UseShortName="true"/>
         }
     </span>
 </div>

--- a/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ElementDefinitionTreeItem.razor.cs
@@ -44,7 +44,14 @@ namespace COMETwebapp.Components.ModelEditor
         public ElementBaseTreeRowViewModel ElementBaseTreeRowViewModel { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the owning domain of expertise pill is shown
+        /// Gets or sets a value indicating whether the node shows the element's full name (when <see langword="true" />)
+        /// or its short name (when <see langword="false" />)
+        /// </summary>
+        [Parameter]
+        public bool ShowName { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the owning domain of expertise pill is shown on the node
         /// </summary>
         [Parameter]
         public bool ShowOwner { get; set; } = true;

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -24,7 +24,7 @@
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
     <div class="model-editor-root">
-    <div style="padding-bottom:5px;">
+    <div class="model-editor-toolbar">
         @if (this.ViewModel.IsSourceModelSameAsTargetModel)
         {
             <span title="Copy mode for copying ElementDefinitions inside the same Iteration. The modifier keys do not apply here: the SDK cannot copy an ElementDefinition into its own Iteration, so this copy always resets the parameter values and keeps the original owner.">
@@ -41,11 +41,13 @@
                 <span class="model-editor-modifier-hint">(hold Ctrl / Shift / Ctrl+Shift while dropping to override)</span>
             </span>
         }
-        @* One setting for both trees, so that the two panels always show the same kind of node. *@
-        <span class="model-editor-display-options">
-            <DxCheckBox @bind-Checked="@this.ShowOwner">Owner</DxCheckBox>
-            <DxCheckBox @bind-Checked="@this.ShowCategories">Categories</DxCheckBox>
-        </span>
+        <div class="model-editor-toolbar-right">
+             <ViewOptionsMenu ButtonId="modelEditorViewMenuButton">
+                <DxCheckBox @bind-Checked="@this.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                <DxCheckBox @bind-Checked="@this.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
+            </ViewOptionsMenu>
+        </div>
     </div>
     <ValidationMessageComponent ValidationMessage="@(this.ErrorMessage)" />
     <div class="selected-data-item-page" style="flex-wrap:nowrap!important;">
@@ -54,14 +56,6 @@
                injects a transient ViewModel that it never disposes, so unmounting it would leak that
                ViewModel's message bus and DynamicData subscriptions on every collapse. *@
             <div id="sourcePanel" class="model-editor-panel @(this.IsSourcePanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
-                <div class="model-editor-panel-header">
-                    <DxButton Id="collapseSourcePanel"
-                              IconCssClass="@IconName.ChevronLeft.GetCssClass()"
-                              RenderStyle="ButtonRenderStyle.Link"
-                              SizeMode="SizeMode.Small"
-                              Click="@(() => this.IsSourcePanelCollapsed = true)"
-                              title="Minimize the source model panel"/>
-                </div>
                 <ElementDefinitionTree
                     @ref="this.SourceTree"
                     ScrollableAreaCssClass="treeview-scrollarea"
@@ -82,10 +76,19 @@
                     OnDragStart="@(async x => await this.OnDragStartAsync(x))"
                     OnDragEnd="@(async x => await this.OnDragEndAsync())"
                     OnDrop="@(async x => await this.OnDropAsync(x))"
+                    ShowName="@this.ShowName"
                     ShowOwner="@this.ShowOwner"
                     ShowCategories="@this.ShowCategories"
                     AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel or ElementUsageTreeRowViewModel"
                     IsModelSelectionEnabled="true">
+                    <HeaderPrefix>
+                        <DxButton Id="collapseSourcePanel"
+                                  IconCssClass="@IconName.ChevronLeft.GetCssClass()"
+                                  RenderStyle="ButtonRenderStyle.Link"
+                                  SizeMode="SizeMode.Small"
+                                  Click="@(() => this.IsSourcePanelCollapsed = true)"
+                                  title="Minimize the source model panel"/>
+                    </HeaderPrefix>
                 </ElementDefinitionTree>
             </div>
             @if (this.IsSourcePanelCollapsed)
@@ -117,6 +120,7 @@
                     OnDragStart="@(async x => await this.OnDragStartAsync(x))"
                     OnDragEnd="@(async x => await this.OnDragEndAsync())"
                     OnDrop="@(async x => await this.OnDropAsync(x))"
+                    ShowName="@this.ShowName"
                     ShowOwner="@this.ShowOwner"
                     ShowCategories="@this.ShowCategories"
                     AllowNodeDrag="(_, model) => model is ElementDefinitionTreeRowViewModel or ElementUsageTreeRowViewModel"
@@ -125,20 +129,32 @@
             </div>
             <div id="target-resizer" class="model-editor-resizer @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)" title="Drag to resize"></div>
             <div id="detailsPanel" class="model-editor-panel model-editor-panel-borderless model-editor-details-panel @(this.IsDetailsPanelCollapsed ? "model-editor-panel-collapsed" : string.Empty)">
-                <div class="model-editor-panel-header model-editor-panel-header-end">
-                    <DxButton Id="collapseDetailsPanel"
-                              IconCssClass="@IconName.ChevronRight.GetCssClass()"
-                              RenderStyle="ButtonRenderStyle.Link"
-                              SizeMode="SizeMode.Small"
-                              Click="@(() => this.IsDetailsPanelCollapsed = true)"
-                              title="Minimize the details panel"/>
-                </div>
                 <DataItemDetailsComponent IsSelected="@(this.ViewModel.DetailsPanelViewModel.SelectedElementDefinition is not null)"
                                           NotSelectedText="Select an item to view or edit"
                                           Width="100%"
                                           CssClass="model-editor-details">
-                    <ElementDetailsPanel ViewModel="this.ViewModel.DetailsPanelViewModel"/>
+                    <ElementDetailsPanel ViewModel="this.ViewModel.DetailsPanelViewModel">
+                        <DetailsHeaderActions>
+                            <DxButton Id="collapseDetailsPanel"
+                                      IconCssClass="@IconName.ChevronRight.GetCssClass()"
+                                      RenderStyle="ButtonRenderStyle.Link"
+                                      SizeMode="SizeMode.Small"
+                                      Click="@(() => this.IsDetailsPanelCollapsed = true)"
+                                      title="Minimize the details panel"/>
+                        </DetailsHeaderActions>
+                    </ElementDetailsPanel>
                 </DataItemDetailsComponent>
+                @if (!this.IsDetailsPanelCollapsed && this.ViewModel.DetailsPanelViewModel.SelectedElementDefinition is null)
+                {
+                    <div class="model-editor-details-collapse-floating">
+                        <DxButton Id="collapseDetailsPanelEmpty"
+                                  IconCssClass="@IconName.ChevronRight.GetCssClass()"
+                                  RenderStyle="ButtonRenderStyle.Link"
+                                  SizeMode="SizeMode.Small"
+                                  Click="@(() => this.IsDetailsPanelCollapsed = true)"
+                                  title="Minimize the details panel"/>
+                    </div>
+                }
             </div>
             @if (this.IsDetailsPanelCollapsed)
             {

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor
@@ -84,7 +84,7 @@
                     <HeaderPrefix>
                         <DxButton Id="collapseSourcePanel"
                                   IconCssClass="@IconName.ChevronLeft.GetCssClass()"
-                                  RenderStyle="ButtonRenderStyle.Link"
+                                  RenderStyle="@(CometButtonStyle.Link.ToButtonRenderStyle())"
                                   SizeMode="SizeMode.Small"
                                   Click="@(() => this.IsSourcePanelCollapsed = true)"
                                   title="Minimize the source model panel"/>
@@ -137,7 +137,7 @@
                         <DetailsHeaderActions>
                             <DxButton Id="collapseDetailsPanel"
                                       IconCssClass="@IconName.ChevronRight.GetCssClass()"
-                                      RenderStyle="ButtonRenderStyle.Link"
+                                      RenderStyle="@(CometButtonStyle.Link.ToButtonRenderStyle())"
                                       SizeMode="SizeMode.Small"
                                       Click="@(() => this.IsDetailsPanelCollapsed = true)"
                                       title="Minimize the details panel"/>
@@ -149,7 +149,7 @@
                     <div class="model-editor-details-collapse-floating">
                         <DxButton Id="collapseDetailsPanelEmpty"
                                   IconCssClass="@IconName.ChevronRight.GetCssClass()"
-                                  RenderStyle="ButtonRenderStyle.Link"
+                                  RenderStyle="@(CometButtonStyle.Link.ToButtonRenderStyle())"
                                   SizeMode="SizeMode.Small"
                                   Click="@(() => this.IsDetailsPanelCollapsed = true)"
                                   title="Minimize the details panel"/>

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.cs
@@ -98,6 +98,13 @@ namespace COMETwebapp.Components.ModelEditor
         public bool ShowCategories { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the tree nodes of both trees show the full element name (when
+        /// <see langword="true" />) or the short name (when <see langword="false" />). Held here, not per tree, so
+        /// the source and target panels always display the same way.
+        /// </summary>
+        public bool ShowName { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the <see cref="IJSRuntime" /> used to initialise the column resizers
         /// </summary>
         [Inject]

--- a/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
+++ b/COMETwebapp/Components/ModelEditor/ModelEditor.razor.css
@@ -1,11 +1,10 @@
-/* The Model Editor fills the height of the tab content and no longer scrolls as a whole page;
-   the two trees and the details panel each scroll internally (no vh — sized against the
-   #app -> .page (100%) -> #tabs-page-content (flex) chain). */
 .model-editor-root {
     height: 100%;
     display: flex;
     flex-direction: column;
     min-height: 0;
+    margin-left: -12px;
+    margin-right: -12px;
 }
 
 ::deep .selected-data-item-page {
@@ -23,25 +22,27 @@
     font-size: 0.8rem;
 }
 
-/* The Owner / Categories check boxes sit inline in the toolbar, next to the copy mode text. */
-.model-editor-display-options {
-    display: inline-flex;
+.model-editor-toolbar {
+    display: flex;
+    align-items: center;
     gap: 8px;
-    margin-left: 16px;
-    font-size: 0.875rem;
-    vertical-align: middle;
+    padding-bottom: 5px;
+    padding-right: 12px;
+}
+
+.model-editor-toolbar-right {
+    margin-left: auto;
+    flex: 0 0 auto;
 }
 
 .model-editor-panel {
-    flex: 1 1 0;
+    flex: 0 1 33%;
     min-width: 0;
     min-height: 0;
     height: 100%;
     display: flex;
     flex-direction: column;
-    border: dashed 1px;
-    padding: 15px;
-    border-radius: 10px;
+    padding: 4px;
 }
 
 .model-editor-panel-borderless {
@@ -50,7 +51,16 @@
 }
 
 .model-editor-details-panel {
+    flex: 1 1 0;
     min-width: 350px;
+    position: relative;
+}
+
+.model-editor-details-collapse-floating {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 2;
 }
 
 .model-editor-panel-grow {
@@ -64,14 +74,15 @@
 
 .model-editor-panel-header {
     flex: 0 0 auto;
+    height: 34px;
     display: flex;
+    align-items: center;
 }
 
 .model-editor-panel-header-end {
     justify-content: flex-end;
 }
 
-/* A minimized panel collapses to a clickable vertical strip that restores it. */
 .model-editor-collapsed-strip {
     flex: 0 0 28px;
     display: flex;
@@ -80,8 +91,8 @@
     gap: 8px;
     padding: 8px 4px;
     cursor: pointer;
-    border: dashed 1px;
-    border-radius: 10px;
+    border: solid 1px #e2e8f0;
+    border-radius: 8px;
     background: #f8fafc;
 }
 
@@ -96,8 +107,6 @@
     color: #475569;
 }
 
-/* Drag-to-resize handle between two panels, driven by wwwroot/js/columnResizer.js — the same handle the
-   System Representation page uses between the product tree and the details panel. */
 .model-editor-resizer {
     flex: 0 0 6px;
     align-self: stretch;
@@ -110,17 +119,21 @@
     background: #94a3b8;
 }
 
-/* Narrow window (a half or quarter-screen browser): three side-by-side panels no longer fit, so they stack
-   vertically and the whole row scrolls, instead of being squeezed past the point of usability. */
 @media (max-width: 1200px) {
     ::deep .selected-data-item-table {
         flex-direction: column;
         overflow-y: auto;
     }
 
+   .model-editor-toolbar {
+        padding-right: 4px;
+    }
+
+    ::deep .model-editor-details .data-item-details-section {
+        padding-right: 4px;
+    }
+
     .model-editor-panel {
-        /* !important is needed because columnResizer.js writes flex and max-width as inline styles on the
-           panel, and an inline style would otherwise win over this rule once the panels stack. */
         flex: 0 0 auto !important;
         max-width: none !important;
         width: 100%;
@@ -179,6 +192,16 @@
 ::deep .model-editor-details .cardview-detailspanel-summary,
 ::deep .model-editor-details .param-group-search-bar {
     flex: 0 0 auto;
+}
+
+::deep .model-editor-details .cardview-detailspanel-summary {
+    height: 46px;
+    padding: 4px 8px !important;
+    margin-bottom: 14px !important;
+}
+
+::deep .model-editor-details .cardview-detailspanel-summary .flex-wrap {
+    flex-wrap: nowrap !important;
 }
 
 ::deep .model-editor-details .param-groups-container {

--- a/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
+++ b/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
@@ -22,9 +22,10 @@ Copyright (c) 2023-2026 Starion Group S.A.
 @using COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues
 @inherits DisposableComponent
 
-<DxButton Id="openBatchParameterEditorButton" 
+<DxButton Id="openBatchParameterEditorButton"
           Click="(this.ViewModel.OpenPopup)"
           Text="Batch Update"
+          RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"
           SizeMode="SizeMode.Medium"/>
 
 <DxPopup @bind-Visible="@(this.ViewModel.IsVisible)"
@@ -54,7 +55,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                                 FilteringMode="DataGridFilteringMode.Contains"
                                 TextFieldName="@nameof(Category.Name)"
                                 ClearButtonDisplayMode="@(DataEditorClearButtonDisplayMode.Auto)"
-                                NullText="Select a Category" />
+                                NullText="Filter by category..." />
                 </div>
                 <div class="col">
                     <DomainOfExpertiseSelector ViewModel="@(this.ViewModel.DomainOfExpertiseSelectorViewModel)" 
@@ -102,6 +103,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <DxButton Id="okButton"
                       Text="Apply Changes"
                       Click="(() => this.ViewModel.ConfirmCancelPopupViewModel.IsVisible = true)"
+                      RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                       Enabled="@this.IsApplyButtonEnabled"/>
 
             <DxButton Id="closeButton"

--- a/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
+++ b/COMETwebapp/Components/ParameterEditor/BatchParameterEditor/BatchParameterEditor.razor
@@ -109,7 +109,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <DxButton Id="closeButton"
                       Text="Close"
                       Click="(() => this.ViewModel.IsVisible = false)"
-                      RenderStyle="ButtonRenderStyle.Secondary"/>
+                      RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())"/>
         </div>
     </div>
     <ConfirmCancelPopup ViewModel="@(this.ViewModel.ConfirmCancelPopupViewModel)"></ConfirmCancelPopup>

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
@@ -26,39 +26,29 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
 <LoadingComponent IsVisible="@(this.ViewModel.IsLoading)">
     <div id="@WebAppConstantValues.ParameterEditorPage.QueryPageBodyName()" class="container-fluid">
-        <div class="row ">
-            <div class="col">
-                <div class="width-fit-content">
-                    <ElementBaseSelector ViewModel="this.ViewModel.ElementSelector"></ElementBaseSelector>
-                </div>
+        <div class="filter-bar">
+            <div class="filter-bar-item">
+                <MultiElementBaseSelector ViewModel="this.ViewModel.ElementSelector" DisplayText=""></MultiElementBaseSelector>
             </div>
-            <div class="col">
-                <div class="width-fit-content">
-                    <MultiParameterTypeSelector ViewModel="this.ViewModel.ParameterTypeSelector"></MultiParameterTypeSelector>
-                </div>
+            <div class="filter-bar-item">
+                <MultiParameterTypeSelector ViewModel="this.ViewModel.ParameterTypeSelector" DisplayText=""></MultiParameterTypeSelector>
             </div>
-            <div class="col">
-                <div class="width-fit-content">
-                    <MultiCategorySelector ViewModel="this.ViewModel.CategorySelector"></MultiCategorySelector>
-                </div>
+            <div class="filter-bar-item">
+                <MultiCategorySelector ViewModel="this.ViewModel.CategorySelector" DisplayText=""></MultiCategorySelector>
             </div>
-            <div class="col">
-                <div class="width-fit-content">
-                    <OptionSelector ViewModel="this.ViewModel.OptionSelector"></OptionSelector>
-                </div>
+            <div class="filter-bar-item">
+                <MultiOptionSelector ViewModel="this.ViewModel.OptionSelector" DisplayText=""></MultiOptionSelector>
             </div>
-            <div class="col">
-                <div class="width-fit-content">
+            <div class="filter-bar-right">
+                <BatchParameterEditor ViewModel="@(this.ViewModel.BatchParameterEditorViewModel)"/>
+                <ViewOptionsMenu ButtonId="parameterEditorViewMenuButton">
                     <DxCheckBox Id="only-owned-parameters-toggle"
                                 @bind-Checked="@(this.ViewModel.IsOwnedParameters)"
                                 CheckType="CheckType.Switch">
                         Only Parameters owned by @this.ViewModel.CurrentDomain?.Name domain
                     </DxCheckBox>
-                </div>
+                </ViewOptionsMenu>
             </div>
-        </div>
-        <div class="pt-3">
-            <BatchParameterEditor ViewModel="@(this.ViewModel.BatchParameterEditorViewModel)"/>
         </div>
         <div id="parameter-table" class="row">
             <ParameterTable ViewModel="this.ViewModel.ParameterTableViewModel"/>

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -29,6 +29,7 @@ namespace COMETwebapp.Components.ParameterEditor
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
+    using COMETwebapp.Extensions;
     using COMETwebapp.Utilities;
 
     using Microsoft.AspNetCore.Components;
@@ -66,10 +67,7 @@ namespace COMETwebapp.Components.ParameterEditor
         {
             if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                var ids = optionsValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = optionsValue.FromShortGuids();
 
                 this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
                     .Where(x => ids.Contains(x.Iid))
@@ -78,10 +76,7 @@ namespace COMETwebapp.Components.ParameterEditor
 
             if (parameters.TryGetValue(QueryKeys.ElementsKey, out var elementsValue) && !string.IsNullOrWhiteSpace(elementsValue))
             {
-                var ids = elementsValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = elementsValue.FromShortGuids();
 
                 this.ViewModel.ElementSelector.SelectedElementBases = this.ViewModel.ElementSelector.AvailableElements
                     .Where(x => ids.Contains(x.Iid))
@@ -90,10 +85,7 @@ namespace COMETwebapp.Components.ParameterEditor
 
             if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                var ids = parametersValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = parametersValue.FromShortGuids();
 
                 this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
                     .Where(x => ids.Contains(x.Iid))
@@ -111,10 +103,7 @@ namespace COMETwebapp.Components.ParameterEditor
 
             if (parameters.TryGetValue(QueryKeys.CategoriesKey, out var categoriesValue) && !string.IsNullOrWhiteSpace(categoriesValue))
             {
-                var ids = categoriesValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = categoriesValue.FromShortGuids();
 
                 this.ViewModel.CategorySelector.SelectedCategories = this.ViewModel.CategorySelector.AvailableCategories
                     .Where(x => ids.Contains(x.Iid))

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.Components.ParameterEditor
 {
+    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
     using COMET.Web.Common.Components.Applications;
@@ -47,9 +48,9 @@ namespace COMETwebapp.Components.ParameterEditor
             base.OnViewModelAssigned();
 
             this.Disposables.Add(this.WhenAnyValue(
-                    x => x.ViewModel.OptionSelector.SelectedOption,
+                    x => x.ViewModel.OptionSelector.SelectedOptions,
                     x => x.ViewModel.ParameterTypeSelector.SelectedParameterTypes,
-                    x => x.ViewModel.ElementSelector.SelectedElementBase,
+                    x => x.ViewModel.ElementSelector.SelectedElementBases,
                     x => x.ViewModel.CategorySelector.SelectedCategories,
                     x => x.ViewModel.IsOwnedParameters)
                 .Subscribe(_ => this.UpdateUrl()));
@@ -63,9 +64,28 @@ namespace COMETwebapp.Components.ParameterEditor
         /// <param name="parameters">A <see cref="Dictionary{TKey,TValue}" /> for parameters</param>
         protected override void InitializeValues(Dictionary<string, string> parameters)
         {
-            if (parameters.TryGetValue(QueryKeys.OptionKey, out var option))
+            if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                this.ViewModel.OptionSelector.SelectedOption = this.ViewModel.OptionSelector.AvailableOptions.FirstOrDefault(x => x.Iid == option.FromShortGuid());
+                var ids = optionsValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
+            }
+
+            if (parameters.TryGetValue(QueryKeys.ElementsKey, out var elementsValue) && !string.IsNullOrWhiteSpace(elementsValue))
+            {
+                var ids = elementsValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.ElementSelector.SelectedElementBases = this.ViewModel.ElementSelector.AvailableElements
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
             }
 
             if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
@@ -109,14 +129,18 @@ namespace COMETwebapp.Components.ParameterEditor
         {
             var additionalParameters = new Dictionary<string, string>();
 
-            if (this.ViewModel.ElementSelector.SelectedElementBase != null)
+            var selectedElementBases = this.ViewModel.ElementSelector.SelectedElementBases?.ToList() ?? new List<ElementBase>();
+
+            if (selectedElementBases.Count > 0)
             {
-                additionalParameters["element"] = this.ViewModel.ElementSelector.SelectedElementBase.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.ElementsKey] = string.Join(",", selectedElementBases.Select(x => x.Iid.ToShortGuid()));
             }
 
-            if (this.ViewModel.OptionSelector.SelectedOption != null)
+            var selectedOptions = this.ViewModel.OptionSelector.SelectedOptions?.ToList() ?? new List<Option>();
+
+            if (selectedOptions.Count > 0)
             {
-                additionalParameters["option"] = this.ViewModel.OptionSelector.SelectedOption.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.OptionsKey] = string.Join(",", selectedOptions.Select(x => x.Iid.ToShortGuid()));
             }
 
             var selectedParameterTypes = this.ViewModel.ParameterTypeSelector.SelectedParameterTypes?.ToList() ?? new List<ParameterType>();

--- a/COMETwebapp/Components/ReferenceData/Categories/CategoryHierarchyDiagram.razor
+++ b/COMETwebapp/Components/ReferenceData/Categories/CategoryHierarchyDiagram.razor
@@ -21,7 +21,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <CascadingValue Value="this.Diagram">
     <DiagramCanvas @key="@("accc")"/>
     <DxButton Text="Open Details"
-              Click="@(() => this.IsOnDetailsMode = true)"/>
+              Click="@(() => this.IsOnDetailsMode = true)"
+              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
 
     <DxPopup @bind-Visible="this.IsOnDetailsMode"
              HeaderText="@($"Hierarchy Diagram of Category: {this.Category.Name}")"

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MappingToReferenceScalesTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MappingToReferenceScalesTable.razor
@@ -30,7 +30,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxButton Id="addMappingToReferenceScaleButton"
                           Text="Add"
                           IconCssClass="@IconName.Add.GetCssClass()"
-                          Click="this.StartCreate" />
+                          Click="this.StartCreate"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" />
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -38,11 +39,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editMappingToReferenceScaleButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
-                              Click="@(() => this.StartEdit(row))" />
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                     <DxButton Id="removeMappingToReferenceScaleButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="() => this.RemoveMappingToReferenceScale(row)" />
+                              Click="() => this.RemoveMappingToReferenceScale(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/MeasurementScalesForm.razor
@@ -128,7 +128,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                             <DxTextBox @bind-Text="@(this.ViewModel.SelectedReferenceQuantityValue.Value)"/>
                         </DxFormLayoutItem>
                         <DxButton Id="clearReferenceQuantityValue"
-                                  Click="@(this.ClearReferenceQuantityValue)">
+                                  Click="@(this.ClearReferenceQuantityValue)"
+                                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
                             Clear
                         </DxButton>
                     </DxFormLayoutGroup>

--- a/COMETwebapp/Components/ReferenceData/MeasurementScales/ScaleValueDefinitionsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementScales/ScaleValueDefinitionsTable.razor
@@ -29,7 +29,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxButton Id="addScaleValueDefinitionButton"
                           Text="Add"
                           IconCssClass="@IconName.Add.GetCssClass()"
-                          Click="this.StartCreate" />
+                          Click="this.StartCreate"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" />
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -37,11 +38,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editScaleValueDefinitionButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
-                              Click="@(() => this.StartEdit(row))" />
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                     <DxButton Id="removeScaleValueDefinitionButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="() => this.RemoveScaleValueDefinition(row)" />
+                              Click="() => this.RemoveScaleValueDefinition(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/MeasurementUnits/UnitFactorsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/MeasurementUnits/UnitFactorsTable.razor
@@ -26,7 +26,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <DxButton Id="addUnitFactorButton"
                           Text="Add Unit Factor"
                           IconCssClass="@IconName.Add.GetCssClass()"
-                          Click="this.StartCreate" />
+                          Click="this.StartCreate"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" />
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -34,10 +35,12 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editUnitFactorButton"
                               Text="Edit"
-                              Click="@(() => this.StartEdit(row))" />
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" />
                     <DxButton Id="removeUnitFactorButton"
                               Text="Remove"
-                              Click="() => this.RemoveItem(row)" />
+                              Click="() => this.RemoveItem(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/ComponentsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/ComponentsTable.razor
@@ -37,7 +37,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <HeaderTemplate>
                 @if (this.Thing is not ArrayParameterType)
                 {
-                    <DxButton Id="addParameterTypeComponentButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                    <DxButton Id="addParameterTypeComponentButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
                 }
                 else
                 {
@@ -50,13 +50,15 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editParameterTypeComponentButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
-                              Click="@(() => this.StartEdit(row))"/>
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                     @if (this.Thing is not ArrayParameterType)
                     {
                         <DxButton Id="removeParameterTypeComponentButton"
                                   IconCssClass="@IconName.Delete.GetCssClass()"
-                                  Click="() => this.RemoveItem(row)"/>
+                                  Click="() => this.RemoveItem(row)"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                     }
                 }
             </CellDisplayTemplate>
@@ -72,12 +74,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                     <DxButton Id="moveUpButton"
                               IconCssClass="@IconName.ArrowUp.GetCssClass()"
                               Click="() => this.MoveUp(row)"
-                              Enabled="@(this.Thing.Component.IndexOf(row.Thing) > 0)"/>
+                              Enabled="@(this.Thing.Component.IndexOf(row.Thing) > 0)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
 
                     <DxButton Id="moveDownButton"
                               IconCssClass="@IconName.ArrowDown.GetCssClass()"
                               Click="() => this.MoveDown(row)"
-                              Enabled="@(this.Thing.Component.LastOrDefault() != row.Thing)"/>
+                              Enabled="@(this.Thing.Component.LastOrDefault() != row.Thing)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/DependentParameterTypeTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/DependentParameterTypeTable.razor
@@ -28,7 +28,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         {
             <DxGridCommandColumn Width="100px">
                 <HeaderTemplate>
-                    <DxButton Id="addDependentParameterTypeButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                    <DxButton Id="addDependentParameterTypeButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
                 </HeaderTemplate>
                 <CellDisplayTemplate>
                     @{
@@ -36,11 +36,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                         <DxButton Id="editDependentParameterTypeButton"
                                   IconCssClass="@IconName.Edit.GetCssClass()"
-                                  Click="@(() => this.StartEdit(row))"/>
+                                  Click="@(() => this.StartEdit(row))"
+                                  RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                         <DxButton Id="removeDependentParameterTypeButton"
                                   IconCssClass="@IconName.Delete.GetCssClass()"
-                                  Click="() => this.RemoveItem(row)"/>
+                                  Click="() => this.RemoveItem(row)"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
@@ -55,12 +57,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         <DxButton Id="moveUpButton"
                                   IconCssClass="@IconName.ArrowUp.GetCssClass()"
                                   Click="() => this.MoveUp(row)"
-                                  Enabled="@(this.Thing.DependentParameterType.IndexOf(row.Thing) > 0)"/>
+                                  Enabled="@(this.Thing.DependentParameterType.IndexOf(row.Thing) > 0)"
+                                  RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
 
                         <DxButton Id="moveDownButton"
                                   IconCssClass="@IconName.ArrowDown.GetCssClass()"
                                   Click="() => this.MoveDown(row)"
-                                  Enabled="@(this.Thing.DependentParameterType.LastOrDefault() != row.Thing)" />
+                                  Enabled="@(this.Thing.DependentParameterType.LastOrDefault() != row.Thing)"
+                                  RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/EnumerationValueDefinitionsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/EnumerationValueDefinitionsTable.razor
@@ -25,7 +25,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxGridDataColumn FieldName="@nameof(EnumerationValueDefinitionRowViewModel.ShortName)" MinWidth="80" SearchEnabled="false"/>
         <DxGridCommandColumn Width="100px">
             <HeaderTemplate>
-                <DxButton Id="addEnumerationValueDefinitionButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                <DxButton Id="addEnumerationValueDefinitionButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -33,11 +33,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editScaleValueDefinitionButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
-                              Click="@(() => this.StartEdit(row))"/>
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                     <DxButton Id="removeScaleValueDefinitionButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="() => this.RemoveItem(row)"/>
+                              Click="() => this.RemoveItem(row)"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/IndependentParameterTypeTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/IndependentParameterTypeTable.razor
@@ -29,7 +29,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         {
             <DxGridCommandColumn Width="100px">
                 <HeaderTemplate>
-                    <DxButton Id="addIndependentParameterTypeButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                    <DxButton Id="addIndependentParameterTypeButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
                 </HeaderTemplate>
                 <CellDisplayTemplate>
                     @{
@@ -37,11 +37,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                         <DxButton Id="editIndependentParameterTypeButton"
                                   IconCssClass="@IconName.Edit.GetCssClass()"
-                                  Click="@(() => this.StartEdit(row))"/>
+                                  Click="@(() => this.StartEdit(row))"
+                                  RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                         <DxButton Id="removeIndependentParameterTypeButton"
                                   IconCssClass="@IconName.Delete.GetCssClass()"
-                                  Click="(() => this.RemoveIndependentParameterType(row))"/>
+                                  Click="(() => this.RemoveIndependentParameterType(row))"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
@@ -56,12 +58,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         <DxButton Id="moveUpButton"
                                   IconCssClass="@IconName.ArrowUp.GetCssClass()"
                                   Click="() => this.MoveUp(row)"
-                                  Enabled="@(this.Thing.IndependentParameterType.IndexOf(row.Thing) > 0)"/>
+                                  Enabled="@(this.Thing.IndependentParameterType.IndexOf(row.Thing) > 0)"
+                                  RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
 
                         <DxButton Id="moveDownButton"
                                   IconCssClass="@IconName.ArrowDown.GetCssClass()"
                                   Click="() => this.MoveDown(row)"
-                                  Enabled="@(this.Thing.IndependentParameterType.LastOrDefault() != row.Thing)"/>
+                                  Enabled="@(this.Thing.IndependentParameterType.LastOrDefault() != row.Thing)"
+                                  RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>

--- a/COMETwebapp/Components/ReferenceData/ParameterTypes/QuantityKindFactorsTable.razor
+++ b/COMETwebapp/Components/ReferenceData/ParameterTypes/QuantityKindFactorsTable.razor
@@ -25,7 +25,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxGridDataColumn FieldName="@nameof(QuantityKindFactorRowViewModel.QuantityKind)"/>
         <DxGridCommandColumn Width="100px">
             <HeaderTemplate>
-                <DxButton Id="addQuantityKindFactorButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                <DxButton Id="addQuantityKindFactorButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
             </HeaderTemplate>
             <CellDisplayTemplate>
                 @{
@@ -33,11 +33,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
                     <DxButton Id="editQuantityKindFactorButton"
                               IconCssClass="@IconName.Edit.GetCssClass()"
-                              Click="@(() => this.StartEdit(row))"/>
+                              Click="@(() => this.StartEdit(row))"
+                              RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                     <DxButton Id="removeQuantityKindFactorButton"
                               IconCssClass="@IconName.Delete.GetCssClass()"
-                              Click="@(() => this.RemoveItem(row))"/>
+                              Click="@(() => this.RemoveItem(row))"
+                              RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>
@@ -52,12 +54,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                     <DxButton Id="moveUpButton"
                               IconCssClass="@IconName.ArrowUp.GetCssClass()"
                               Click="() => this.MoveUp(row)"
-                              Enabled="@(this.Thing.QuantityKindFactor.IndexOf(row.Thing) > 0)"/>
+                              Enabled="@(this.Thing.QuantityKindFactor.IndexOf(row.Thing) > 0)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
 
                     <DxButton Id="moveDownButton"
                               IconCssClass="@IconName.ArrowDown.GetCssClass()"
                               Click="() => this.MoveDown(row)"
-                              Enabled="@(this.Thing.QuantityKindFactor.LastOrDefault() != row.Thing)" />
+                              Enabled="@(this.Thing.QuantityKindFactor.LastOrDefault() != row.Thing)"
+                              RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"/>
                 }
             </CellDisplayTemplate>
         </DxGridCommandColumn>

--- a/COMETwebapp/Components/RelationshipMatrix/MatrixConfigurationDialog.razor
+++ b/COMETwebapp/Components/RelationshipMatrix/MatrixConfigurationDialog.razor
@@ -69,6 +69,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <div class="matrix-dialog-actions">
                 <DxButton Text="@this.ExportButtonText"
                           IconCssClass="@IconName.Download.GetCssClass()"
+                          RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                           Enabled="@this.CanExportOrSave"
                           Click="@(async () => await this.OnExportOrSaveAsync())"/>
             </div>
@@ -104,6 +105,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <div class="matrix-dialog-actions">
                     <DxButton Text="Load from model"
                               IconCssClass="@IconName.Download.GetCssClass()"
+                              RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                               Enabled="@(this.selectedStoredConfiguration != null)"
                               Click="@(async () => await this.OnLoadFromModelAsync())"/>
                 </div>

--- a/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor
+++ b/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor
@@ -26,14 +26,13 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
     <div class="matrix-editor">
         <div id="matrixConfigPanel" class="matrix-config-panel @(this.ViewModel.IsConfigurationPanelCollapsed ? "matrix-config-panel-collapsed" : string.Empty)">
-            <div class="matrix-config-panel-header">
-                <DxButton Id="matrix-config-minimize"
-                          IconCssClass="@IconName.ChevronLeft.GetCssClass()"
-                          RenderStyle="ButtonRenderStyle.Link"
-                          SizeMode="SizeMode.Small"
-                          Click="@(() => this.ViewModel.IsConfigurationPanelCollapsed = true)"
-                          title="Minimize the configuration panel"/>
-            </div>
+            <DxButton Id="matrix-config-minimize"
+                      CssClass="matrix-config-minimize"
+                      IconCssClass="@IconName.ChevronRight.GetCssClass()"
+                      RenderStyle="ButtonRenderStyle.Link"
+                      SizeMode="SizeMode.Small"
+                      Click="@(() => this.ViewModel.IsConfigurationPanelCollapsed = true)"
+                      title="Minimize the configuration panel"/>
 
             <SourceConfiguration Title="Rows" ViewModel="@this.ViewModel.RowConfiguration"/>
             <SourceConfiguration Title="Columns" ViewModel="@this.ViewModel.ColumnConfiguration"/>
@@ -49,16 +48,16 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <DxCheckBox @bind-Checked="@this.ViewModel.ShowNonRelatedBackgroundColor">Highlight unrelated rows/columns</DxCheckBox>
 
             <div class="matrix-config-actions">
-                <DxButton Text="Swap rows &amp; columns" IconCssClass="@IconName.Refresh.GetCssClass()" Click="@(() => this.ViewModel.SwapAxes())"/>
-                <DxButton Text="Export to Excel" IconCssClass="@IconName.Grid.GetCssClass()" Click="@(async () => await this.ViewModel.ExportAsync())"/>
-                <DxButton Text="Configuration" IconCssClass="@IconName.Settings.GetCssClass()" Click="@(() => this.ViewModel.IsConfigurationDialogVisible = true)"/>
+                <DxButton Text="Swap rows &amp; columns" IconCssClass="@IconName.Refresh.GetCssClass()" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Click="@(() => this.ViewModel.SwapAxes())"/>
+                <DxButton Text="Export to Excel" IconCssClass="@IconName.Grid.GetCssClass()" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Click="@(async () => await this.ViewModel.ExportAsync())"/>
+                <DxButton Text="Configuration" IconCssClass="@IconName.Settings.GetCssClass()" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Click="@(() => this.ViewModel.IsConfigurationDialogVisible = true)"/>
             </div>
         </div>
 
         @if (this.ViewModel.IsConfigurationPanelCollapsed)
         {
             <div id="expandMatrixConfigPanel" class="matrix-collapsed-strip" title="Restore the configuration panel" @onclick="@(() => this.ViewModel.IsConfigurationPanelCollapsed = false)">
-                <CometIcon Icon="IconName.ChevronRight"/>
+                <CometIcon Icon="IconName.ChevronLeft"/>
                 <span class="matrix-collapsed-strip-text">Configuration</span>
             </div>
         }

--- a/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor
+++ b/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor
@@ -29,7 +29,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <DxButton Id="matrix-config-minimize"
                       CssClass="matrix-config-minimize"
                       IconCssClass="@IconName.ChevronRight.GetCssClass()"
-                      RenderStyle="ButtonRenderStyle.Link"
+                      RenderStyle="@(CometButtonStyle.Link.ToButtonRenderStyle())"
                       SizeMode="SizeMode.Small"
                       Click="@(() => this.ViewModel.IsConfigurationPanelCollapsed = true)"
                       title="Minimize the configuration panel"/>

--- a/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor.css
+++ b/COMETwebapp/Components/RelationshipMatrix/RelationshipMatrixBody.razor.css
@@ -20,6 +20,14 @@
     background: #fff;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
     font-size: 0.85rem;
+    position: relative;
+}
+
+.matrix-config-panel ::deep .matrix-config-minimize {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 2;
 }
 
 .matrix-config-panel ::deep .dxbl-edit,
@@ -36,11 +44,6 @@
 
 .matrix-config-panel-collapsed {
     display: none;
-}
-
-.matrix-config-panel-header {
-    flex: 0 0 auto;
-    display: flex;
 }
 
 .matrix-config-actions {

--- a/COMETwebapp/Components/RequirementsEditor/BooleanExpressionNode.razor
+++ b/COMETwebapp/Components/RequirementsEditor/BooleanExpressionNode.razor
@@ -98,8 +98,8 @@ else if (this.Row is CompositeExpressionRow group)
                         FooterVisible="false">
                 <BodyTemplate>
                     <div style="display:flex; flex-direction:column; min-width:170px;">
-                        <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Add.GetCssClass()" Text="Add Expression" Click="@(() => this.AddExpressionClicked(group))" />
-                        <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Branch.GetCssClass()" Text="Add Group" Click="@(() => this.AddGroupClicked(group))" />
+                        <DxButton RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" Text="Add Expression" Click="@(() => this.AddExpressionClicked(group))" />
+                        <DxButton RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" IconCssClass="@IconName.Branch.GetCssClass()" Text="Add Group" Click="@(() => this.AddGroupClicked(group))" />
                     </div>
                 </BodyTemplate>
             </DxDropDown>

--- a/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor
+++ b/COMETwebapp/Components/RequirementsEditor/DeprecateThingButton.razor
@@ -18,7 +18,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
-<DxButton RenderStyle="ButtonRenderStyle.Light"
+<DxButton RenderStyle="@(this.IsDeprecated ? ButtonRenderStyle.Light : CometButtonStyle.Danger.ToButtonRenderStyle())"
           IconCssClass="@(this.IsDeprecated ? IconName.Undo.GetCssClass() : IconName.Ban.GetCssClass())"
           title="@($"{(this.IsDeprecated ? "Restore" : "Deprecate")} {this.KindLabel}")"
           Click="@(() => this.ViewModel.ConfirmDeprecation(this.Thing))" />

--- a/COMETwebapp/Components/RequirementsEditor/EditParametricConstraint.razor
+++ b/COMETwebapp/Components/RequirementsEditor/EditParametricConstraint.razor
@@ -26,7 +26,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     {
         <div class="pc-empty">
             <p>No expression defined. Click the button below to add your first expression.</p>
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Add.GetCssClass()" Text="Add First Expression" Click="@(() => this.AddFirstExpression())" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" Text="Add First Expression" Click="@(() => this.AddFirstExpression())" />
         </div>
     }
     else
@@ -60,8 +60,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
                             FooterVisible="false">
                     <BodyTemplate>
                         <div style="display:flex; flex-direction:column; min-width:170px;">
-                            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Add.GetCssClass()" Text="Add Expression" Click="@(() => this.RootAddExpression())" />
-                            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Branch.GetCssClass()" Text="Add Group" Click="@(() => this.RootAddGroup())" />
+                            <DxButton RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" Text="Add Expression" Click="@(() => this.RootAddExpression())" />
+                            <DxButton RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" IconCssClass="@IconName.Branch.GetCssClass()" Text="Add Group" Click="@(() => this.RootAddGroup())" />
                         </div>
                     </BodyTemplate>
                 </DxDropDown>
@@ -71,8 +71,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
 </div>
 
 <div class="modal-footer m-top-10px">
-    <DxButton RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="@(() => this.OnCancelled.InvokeAsync())" />
-    <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" Click="@(() => this.SaveAsync())" Enabled="@(this.viewModel.CanSave)" />
+    <DxButton RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Cancel" Click="@(() => this.OnCancelled.InvokeAsync())" />
+    <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save" Click="@(() => this.SaveAsync())" Enabled="@(this.viewModel.CanSave)" />
 </div>
 
 <DxPopup CloseOnOutsideClick="false"
@@ -116,8 +116,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </DxFormLayout>
 
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="@(() => this.CancelRelational())" />
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" Click="@(() => this.ConfirmRelational())" Enabled="@(this.CanConfirmRelational)" />
+            <DxButton RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Cancel" Click="@(() => this.CancelRelational())" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save" Click="@(() => this.ConfirmRelational())" Enabled="@(this.CanConfirmRelational)" />
         </div>
     </BodyContentTemplate>
 </DxPopup>

--- a/COMETwebapp/Components/RequirementsEditor/EditRequirementThing.razor
+++ b/COMETwebapp/Components/RequirementsEditor/EditRequirementThing.razor
@@ -97,7 +97,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </DxFormLayout>
         <ValidationSummary />
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" SubmitFormOnClick="true"
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Save" SubmitFormOnClick="true"
                       Enabled="@this.ViewModel.CanSave"
                       title="@(this.ViewModel.CanSave ? null : "A requirement must have a definition")" />
         </div>

--- a/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor
+++ b/COMETwebapp/Components/RequirementsEditor/EditThingButton.razor
@@ -18,4 +18,4 @@ Copyright (c) 2023-2026 Starion Group S.A.
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------->
 
-<DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Edit.GetCssClass()" title="@($"Edit {this.KindLabel}")" Click="@(() => this.ViewModel.OpenEdit(this.Thing))" />
+<DxButton RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" IconCssClass="@IconName.Edit.GetCssClass()" title="@($"Edit {this.KindLabel}")" Click="@(() => this.ViewModel.OpenEdit(this.Thing))" />

--- a/COMETwebapp/Components/RequirementsEditor/ParametricConstraintsTable.razor
+++ b/COMETwebapp/Components/RequirementsEditor/ParametricConstraintsTable.razor
@@ -32,14 +32,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </DxGridDataColumn>
             <DxGridCommandColumn Width="90px">
                 <HeaderTemplate>
-                    <DxButton Id="addParametricConstraintButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="@(() => this.OpenAdd())" />
+                    <DxButton Id="addParametricConstraintButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(() => this.OpenAdd())" />
                 </HeaderTemplate>
                 <CellDisplayTemplate>
                     @{
                         var constraint = (ParametricConstraint)context.DataItem;
                     }
-                    <DxButton IconCssClass="@IconName.Edit.GetCssClass()" Click="@(() => this.OpenEdit(constraint))" />
-                    <DxButton Id="removeParametricConstraintButton" IconCssClass="@IconName.Delete.GetCssClass()" Click="@(() => this.RemovalPopup.Request(constraint))" />
+                    <DxButton IconCssClass="@IconName.Edit.GetCssClass()" RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" Click="@(() => this.OpenEdit(constraint))" />
+                    <DxButton Id="removeParametricConstraintButton" IconCssClass="@IconName.Delete.GetCssClass()" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(() => this.RemovalPopup.Request(constraint))" />
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
         </Columns>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementDetails.razor
@@ -169,8 +169,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
         }
 
         <div class="modal-footer m-top-10px">
-            <DxButton RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="@(() => this.CancelLinks())" />
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="OK" Click="@(() => this.ConfirmLinksAsync())" />
+            <DxButton RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Cancel" Click="@(() => this.CancelLinks())" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="OK" Click="@(() => this.ConfirmLinksAsync())" />
         </div>
     </BodyContentTemplate>
 </DxPopup>

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -44,8 +44,8 @@ else if (this.Container == null)
         }
         <RequirementPills ViewModel="@this.ViewModel" Owner="@specification.Owner" Categories="@specification.Category" />
         <span class="req-actions">
-            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(specification))" />
-            <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Folder.GetCssClass()" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(specification))" />
+            <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Folder.GetCssClass()" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
             <EditThingButton ViewModel="@this.ViewModel" Thing="@specification" />
             <DeprecateThingButton ViewModel="@this.ViewModel" Thing="@specification" />
         </span>
@@ -76,10 +76,10 @@ else
             <span class="req-group-name">@group.Name</span>
             <RequirementPills ViewModel="@this.ViewModel" Owner="@group.Owner" Categories="@group.Category" />
             <span class="req-actions">
-                <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(group))" />
-                <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Folder.GetCssClass()" title="Add sub-group" Click="@(() => this.ViewModel.OpenCreateGroup(group))" />
+                <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(group))" />
+                <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Folder.GetCssClass()" title="Add sub-group" Click="@(() => this.ViewModel.OpenCreateGroup(group))" />
                 <EditThingButton ViewModel="@this.ViewModel" Thing="@group" />
-                <DxButton RenderStyle="ButtonRenderStyle.Light" IconCssClass="@IconName.Delete.GetCssClass()" title="Delete group" Click="@(() => this.ViewModel.ConfirmDeletion(group))" />
+                <DxButton RenderStyle="ButtonRenderStyle.Danger" IconCssClass="@IconName.Delete.GetCssClass()" title="Delete group" Click="@(() => this.ViewModel.ConfirmDeletion(group))" />
             </span>
         </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsDocument.razor
@@ -44,8 +44,8 @@ else if (this.Container == null)
         }
         <RequirementPills ViewModel="@this.ViewModel" Owner="@specification.Owner" Categories="@specification.Category" />
         <span class="req-actions">
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(specification))" />
-            <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Folder.GetCssClass()" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(specification))" />
+            <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Folder.GetCssClass()" title="Add group" Click="@(() => this.ViewModel.OpenCreateGroup(specification))" />
             <EditThingButton ViewModel="@this.ViewModel" Thing="@specification" />
             <DeprecateThingButton ViewModel="@this.ViewModel" Thing="@specification" />
         </span>
@@ -76,10 +76,10 @@ else
             <span class="req-group-name">@group.Name</span>
             <RequirementPills ViewModel="@this.ViewModel" Owner="@group.Owner" Categories="@group.Category" />
             <span class="req-actions">
-                <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(group))" />
-                <DxButton RenderStyle="ButtonRenderStyle.Primary" IconCssClass="@IconName.Folder.GetCssClass()" title="Add sub-group" Click="@(() => this.ViewModel.OpenCreateGroup(group))" />
+                <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Add.GetCssClass()" title="Add requirement" Click="@(() => this.ViewModel.OpenCreateRequirement(group))" />
+                <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" IconCssClass="@IconName.Folder.GetCssClass()" title="Add sub-group" Click="@(() => this.ViewModel.OpenCreateGroup(group))" />
                 <EditThingButton ViewModel="@this.ViewModel" Thing="@group" />
-                <DxButton RenderStyle="ButtonRenderStyle.Danger" IconCssClass="@IconName.Delete.GetCssClass()" title="Delete group" Click="@(() => this.ViewModel.ConfirmDeletion(group))" />
+                <DxButton RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" IconCssClass="@IconName.Delete.GetCssClass()" title="Delete group" Click="@(() => this.ViewModel.ConfirmDeletion(group))" />
             </span>
         </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -29,7 +29,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     <div id="@WebAppConstantValues.RequirementManagementPage.QueryPageBodyName()" class="req-editor">
         <div class="req-toolbar">
             <DxButton Id="requirement-toc-toggle"
-                      RenderStyle="ButtonRenderStyle.Light"
+                      RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"
                       IconCssClass="@((this.ViewModel.IsTocCollapsed ? IconName.ChevronRight : IconName.ChevronLeft).GetCssClass())"
                       title="Toggle table of contents"
                       Click="@(() => this.ViewModel.IsTocCollapsed = !this.ViewModel.IsTocCollapsed)"
@@ -72,7 +72,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             }
 
             <div class="req-toolbar-group req-toolbar-right">
-                <DxButton RenderStyle="ButtonRenderStyle.Primary"
+                <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                           IconCssClass="@IconName.Add.GetCssClass()"
                           Text="Specification"
                           title="Create a new specification"
@@ -84,7 +84,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         <div class="btn-group" role="group" aria-label="Requirement layout">
                             @foreach (var mode in DisplayModes)
                             {
-                                <DxButton RenderStyle="ButtonRenderStyle.Light"
+                                <DxButton RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())"
                                           CssClass="@(this.ViewModel.DisplayMode == mode ? "req-view-toggle-on" : string.Empty)"
                                           Text="@GetDisplayModeLabel(mode)"
                                           title="@GetDisplayModeTitle(mode)"

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor
@@ -30,7 +30,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <div class="req-toolbar">
             <DxButton Id="requirement-toc-toggle"
                       RenderStyle="ButtonRenderStyle.Light"
-                      Text="@(this.ViewModel.IsTocCollapsed ? "»" : "«")"
+                      IconCssClass="@((this.ViewModel.IsTocCollapsed ? IconName.ChevronRight : IconName.ChevronLeft).GetCssClass())"
                       title="Toggle table of contents"
                       Click="@(() => this.ViewModel.IsTocCollapsed = !this.ViewModel.IsTocCollapsed)"
                       CssClass="req-collapse-toggle" />
@@ -39,31 +39,36 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <SearchBar @bind-Text="@this.ViewModel.SearchText" Placeholder="Search in definitions..."/>
             </div>
 
-            <DxTagBox Id="requirement-owner-filter"
-                      Data="@this.ViewModel.AvailableOwners"
-                      Values="@this.ViewModel.SelectedOwners"
-                      ValuesChanged="@((IEnumerable<DomainOfExpertise> values) => this.ViewModel.SelectedOwners = values.ToList())"
-                      TextFieldName="@nameof(DomainOfExpertise.ShortName)"
-                      NullText="Filter by owner..."
-                      CssClass="req-filter" />
+            <div class="filter-bar-item">
+                <FilterTagBox TItem="DomainOfExpertise"
+                              Id="requirement-owner-filter"
+                              Data="@this.ViewModel.AvailableOwners"
+                              Values="@this.ViewModel.SelectedOwners"
+                              ValuesChanged="@((IEnumerable<DomainOfExpertise> values) => this.ViewModel.SelectedOwners = values.ToList())"
+                              TextFieldName="@nameof(DomainOfExpertise.Name)"
+                              NullText="Filter by owner..." />
+            </div>
 
-            <DxTagBox Id="requirement-category-filter"
-                      Data="@this.ViewModel.AvailableCategories"
-                      Values="@this.ViewModel.SelectedCategories"
-                      ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values.ToList())"
-                      TextFieldName="@nameof(Category.ShortName)"
-                      NullText="Filter by category..."
-                      CssClass="req-filter" />
+            <div class="filter-bar-item">
+                <FilterTagBox TItem="Category"
+                              Id="requirement-category-filter"
+                              Data="@this.ViewModel.AvailableCategories"
+                              Values="@this.ViewModel.SelectedCategories"
+                              ValuesChanged="@((IEnumerable<Category> values) => this.ViewModel.SelectedCategories = values.ToList())"
+                              TextFieldName="@nameof(Category.Name)"
+                              NullText="Filter by category..." />
+            </div>
 
             @if (this.ViewModel.ShowSimpleParameterValues && this.ViewModel.GetSpecificationParameterTypes().Count > 0)
             {
-                <DxTagBox Data="@this.ViewModel.GetSpecificationParameterTypes()"
-                          Values="@this.ViewModel.SelectedParameterTypeColumns"
-                          ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypeColumns = values.ToList())"
-                          TextFieldName="@nameof(ParameterType.ShortName)"
-                          NullText="All value columns..."
-                          title="Choose which simple parameter value columns to show"
-                          CssClass="req-filter" />
+                <div class="filter-bar-item" title="Choose which simple parameter value columns to show">
+                    <FilterTagBox TItem="ParameterType"
+                                  Data="@this.ViewModel.GetSpecificationParameterTypes()"
+                                  Values="@this.ViewModel.SelectedParameterTypeColumns"
+                                  ValuesChanged="@((IEnumerable<ParameterType> values) => this.ViewModel.SelectedParameterTypeColumns = values.ToList())"
+                                  TextFieldName="@nameof(ParameterType.Name)"
+                                  NullText="All value columns..." />
+                </div>
             }
 
             <div class="req-toolbar-group req-toolbar-right">
@@ -73,51 +78,35 @@ Copyright (c) 2023-2026 Starion Group S.A.
                           title="Create a new specification"
                           Click="@(() => this.ViewModel.OpenCreateSpecification())" />
 
-                <DxButton Id="reqViewMenuButton"
-                          RenderStyle="ButtonRenderStyle.Light"
-                          IconCssClass="@IconName.Settings.GetCssClass()"
-                          Text="View"
-                          title="Layout and display options"
-                          Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
-
-                <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
-                            PositionMode="DropDownPositionMode.Bottom"
-                            PositionTarget="#reqViewMenuButton"
-                            CloseMode="DropDownCloseMode.Close"
-                            HeaderVisible="false"
-                            FooterVisible="false">
-                    <BodyTemplate>
-                        <div class="req-view-menu">
-                            <div class="req-view-section">
-                                <span class="req-toolbar-label">Layout</span>
-                                <div class="btn-group" role="group" aria-label="Requirement layout">
-                                    @foreach (var mode in DisplayModes)
-                                    {
-                                        <DxButton RenderStyle="ButtonRenderStyle.Light"
-                                                  CssClass="@(this.ViewModel.DisplayMode == mode ? "req-view-toggle-on" : string.Empty)"
-                                                  Text="@GetDisplayModeLabel(mode)"
-                                                  title="@GetDisplayModeTitle(mode)"
-                                                  Click="@(() => this.ViewModel.DisplayMode = mode)" />
-                                    }
-                                </div>
-                            </div>
-
-                            <div class="req-view-section">
-                                <span class="req-toolbar-label">Show</span>
-                                <DxCheckBox Checked="@(!this.ViewModel.TreeUsesShortName)"
-                                            CheckedChanged="@((bool value) => this.ViewModel.TreeUsesShortName = !value)"
-                                            CheckType="CheckType.Switch"
-                                            title="Label the table of contents and traceability by full name instead of short name">Full names</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent groups</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowSimpleParameterValues" CheckType="CheckType.Switch" title="Show the simple parameter values of each requirement as editable columns">Values</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowParametricConstraints" CheckType="CheckType.Switch" title="Show the parametric constraints of each requirement">Constraints</DxCheckBox>
-                                <DxCheckBox @bind-Checked="@this.ViewModel.ShowTraceability" CheckType="CheckType.Switch" title="Show the relationships to and from each requirement">Traceability</DxCheckBox>
-                            </div>
+                <ViewOptionsMenu ButtonId="reqViewMenuButton" ButtonTitle="Layout and display options">
+                    <div class="req-view-section">
+                        <span class="req-toolbar-label">Layout</span>
+                        <div class="btn-group" role="group" aria-label="Requirement layout">
+                            @foreach (var mode in DisplayModes)
+                            {
+                                <DxButton RenderStyle="ButtonRenderStyle.Light"
+                                          CssClass="@(this.ViewModel.DisplayMode == mode ? "req-view-toggle-on" : string.Empty)"
+                                          Text="@GetDisplayModeLabel(mode)"
+                                          title="@GetDisplayModeTitle(mode)"
+                                          Click="@(() => this.ViewModel.DisplayMode = mode)" />
+                            }
                         </div>
-                    </BodyTemplate>
-                </DxDropDown>
+                    </div>
+
+                    <div class="req-view-section">
+                        <span class="req-toolbar-label">Show</span>
+                        <DxCheckBox Checked="@(!this.ViewModel.TreeUsesShortName)"
+                                    CheckedChanged="@((bool value) => this.ViewModel.TreeUsesShortName = !value)"
+                                    CheckType="CheckType.Switch"
+                                    title="Label the table of contents and traceability by full name instead of short name">Full names</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.IndentGroups" CheckType="CheckType.Switch">Indent groups</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategory" CheckType="CheckType.Switch">Category</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.ShowSimpleParameterValues" CheckType="CheckType.Switch" title="Show the simple parameter values of each requirement as editable columns">Values</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.ShowParametricConstraints" CheckType="CheckType.Switch" title="Show the parametric constraints of each requirement">Constraints</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@this.ViewModel.ShowTraceability" CheckType="CheckType.Switch" title="Show the relationships to and from each requirement">Traceability</DxCheckBox>
+                    </div>
+                </ViewOptionsMenu>
             </div>
         </div>
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -46,11 +46,6 @@ namespace COMETwebapp.Components.RequirementsEditor
         ];
 
         /// <summary>
-        /// Whether the "View" layout-and-display-options dropdown is open.
-        /// </summary>
-        private bool viewMenuOpen;
-
-        /// <summary>
         /// Gets or sets the <see cref="IDomDataService" /> used to scroll a navigated-to requirement into view.
         /// </summary>
         [Inject]

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -39,30 +39,21 @@
     max-width: 420px;
 }
 
-.req-view-menu {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    padding: 12px;
-    min-width: 200px;
-}
-
 .req-view-section {
     display: flex;
     flex-direction: column;
     gap: 6px;
 }
 
-.req-view-menu ::deep .req-view-toggle-on {
+.req-view-section ::deep .req-view-toggle-on {
     background-color: #e7f1ff !important;
     border-color: #b9d0f0 !important;
     color: #3b5b8c !important;
     font-weight: 600;
 }
 
-.req-filter {
-    flex: 1 1 100px;
-    min-width: 78px;
+.req-toolbar ::deep .dxbl-btn:not(.dxbl-edit-btn-clear):not(.dxbl-tag-btn-close) {
+    height: 34px;
 }
 
 .req-editor-layout {

--- a/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
+++ b/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
@@ -49,14 +49,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </DxGridDataColumn>
             <DxGridCommandColumn Width="90px">
                 <HeaderTemplate>
-                    <DxButton Id="addSimpleParameterValueButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="@(() => this.OpenAdd())" />
+                    <DxButton Id="addSimpleParameterValueButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Click="@(() => this.OpenAdd())" />
                 </HeaderTemplate>
                 <CellDisplayTemplate>
                     @{
                         var value = (SimpleParameterValue)context.DataItem;
                     }
-                    <DxButton IconCssClass="@IconName.Edit.GetCssClass()" Click="@(() => this.OpenEdit(value))" />
-                    <DxButton Id="removeSimpleParameterValueButton" IconCssClass="@IconName.Delete.GetCssClass()" Click="@(() => this.RemovalPopup.Request(value))" />
+                    <DxButton IconCssClass="@IconName.Edit.GetCssClass()" RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())" Click="@(() => this.OpenEdit(value))" />
+                    <DxButton Id="removeSimpleParameterValueButton" IconCssClass="@IconName.Delete.GetCssClass()" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(() => this.RemovalPopup.Request(value))" />
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
         </Columns>

--- a/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
+++ b/COMETwebapp/Components/RequirementsEditor/SimpleParameterValuesTable.razor
@@ -107,8 +107,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </DxFormLayout>
 
             <div class="modal-footer m-top-10px">
-                <DxButton RenderStyle="ButtonRenderStyle.Secondary" Text="Cancel" Click="@(() => this.ClosePanel())" />
-                <DxButton RenderStyle="ButtonRenderStyle.Primary" Text="OK" Click="@(() => this.Confirm())" Enabled="@(this.selectedParameterType != null)" />
+                <DxButton RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Cancel" Click="@(() => this.ClosePanel())" />
+                <DxButton RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="OK" Click="@(() => this.Confirm())" Enabled="@(this.selectedParameterType != null)" />
             </div>
         </BodyContentTemplate>
     </DxPopup>

--- a/COMETwebapp/Components/Shared/CategoryPills.razor
+++ b/COMETwebapp/Components/Shared/CategoryPills.razor
@@ -19,18 +19,12 @@
 ------------------------------------------------------------------------------->
 @using CDP4Common.SiteDirectoryData
 
-@{
-    var all = this.Categories?.ToList() ?? [];
-    var visible = all.Take(this.MaxVisible).ToList();
-    var overflow = all.Skip(this.MaxVisible).ToList();
-}
-
-@foreach (var category in visible)
+@foreach (var category in this.VisibleCategories)
 {
     <StarionPill @key="category" ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {this.Label(category)}")">@this.Label(category)</StarionPill>
 }
 
-@if (overflow.Count > 0)
+@if (this.OverflowCategories.Count > 0)
 {
-    <StarionPill ColorSeed="category-overflow" Title="@($"Also: {string.Join(", ", overflow.Select(this.Label))}")">+@overflow.Count</StarionPill>
+    <StarionPill ColorSeed="category-overflow" Title="@($"Also: {string.Join(", ", this.OverflowCategories.Select(this.Label))}")">+@this.OverflowCategories.Count</StarionPill>
 }

--- a/COMETwebapp/Components/Shared/CategoryPills.razor
+++ b/COMETwebapp/Components/Shared/CategoryPills.razor
@@ -1,0 +1,36 @@
+<!------------------------------------------------------------------------------
+// Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of COMET WEB Community Edition
+//    The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET WEB Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+------------------------------------------------------------------------------->
+@using CDP4Common.SiteDirectoryData
+
+@{
+    var all = this.Categories?.ToList() ?? [];
+    var visible = all.Take(this.MaxVisible).ToList();
+    var overflow = all.Skip(this.MaxVisible).ToList();
+}
+
+@foreach (var category in visible)
+{
+    <StarionPill @key="category" ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {this.Label(category)}")">@this.Label(category)</StarionPill>
+}
+
+@if (overflow.Count > 0)
+{
+    <StarionPill ColorSeed="category-overflow" Title="@($"Also: {string.Join(", ", overflow.Select(this.Label))}")">+@overflow.Count</StarionPill>
+}

--- a/COMETwebapp/Components/Shared/CategoryPills.razor.cs
+++ b/COMETwebapp/Components/Shared/CategoryPills.razor.cs
@@ -1,0 +1,64 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CategoryPills.razor.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Components.Shared
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Renders a list of category pills, showing at most <see cref="MaxVisible" /> and collapsing the remainder
+    /// into a single "+N" pill whose tooltip lists the hidden categories. Keeps rows readable when a thing carries
+    /// many categories (which would otherwise push the node text out of view).
+    /// </summary>
+    public partial class CategoryPills
+    {
+        /// <summary>
+        /// The categories to render.
+        /// </summary>
+        [Parameter]
+        public IEnumerable<Category> Categories { get; set; }
+
+        /// <summary>
+        /// Whether the pills show the category short name (when <see langword="true" />) or the full name.
+        /// </summary>
+        [Parameter]
+        public bool UseShortName { get; set; } = true;
+
+        /// <summary>
+        /// The maximum number of individual category pills to render before collapsing the rest into a "+N" pill.
+        /// </summary>
+        [Parameter]
+        public int MaxVisible { get; set; } = 2;
+
+        /// <summary>
+        /// Gets the display label of a category, honouring <see cref="UseShortName" />.
+        /// </summary>
+        /// <param name="category">The <see cref="Category" />.</param>
+        /// <returns>The short name or the full name.</returns>
+        private string Label(Category category)
+        {
+            return this.UseShortName ? category.ShortName : category.Name;
+        }
+    }
+}

--- a/COMETwebapp/Components/Shared/CategoryPills.razor.cs
+++ b/COMETwebapp/Components/Shared/CategoryPills.razor.cs
@@ -37,7 +37,7 @@ namespace COMETwebapp.Components.Shared
         /// The categories to render.
         /// </summary>
         [Parameter]
-        public IEnumerable<Category> Categories { get; set; }
+        public IEnumerable<Category> Categories { get; set; } = [];
 
         /// <summary>
         /// Whether the pills show the category short name (when <see langword="true" />) or the full name.
@@ -50,6 +50,26 @@ namespace COMETwebapp.Components.Shared
         /// </summary>
         [Parameter]
         public int MaxVisible { get; set; } = 2;
+
+        /// <summary>
+        /// Gets the categories rendered as individual pills (the first <see cref="MaxVisible" />).
+        /// </summary>
+        public List<Category> VisibleCategories { get; private set; } = [];
+
+        /// <summary>
+        /// Gets the categories collapsed into the single "+N" pill (those beyond <see cref="MaxVisible" />).
+        /// </summary>
+        public List<Category> OverflowCategories { get; private set; } = [];
+
+        /// <summary>
+        /// Recomputes the visible and overflow category partitions whenever the parameters change.
+        /// </summary>
+        protected override void OnParametersSet()
+        {
+            var all = this.Categories?.ToList() ?? [];
+            this.VisibleCategories = all.Take(this.MaxVisible).ToList();
+            this.OverflowCategories = all.Skip(this.MaxVisible).ToList();
+        }
 
         /// <summary>
         /// Gets the display label of a category, honouring <see cref="UseShortName" />.

--- a/COMETwebapp/Components/Shared/CategoryPills.razor.css
+++ b/COMETwebapp/Components/Shared/CategoryPills.razor.css
@@ -1,0 +1,8 @@
+::deep .starion-pill {
+    display: inline-block;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+}

--- a/COMETwebapp/Components/Shared/NodePills.razor
+++ b/COMETwebapp/Components/Shared/NodePills.razor
@@ -29,9 +29,6 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 
     @if (this.ShowCategories)
     {
-        @foreach (var category in this.ElementBase.GetDisplayCategories())
-        {
-            <StarionPill @key="category.Iid" ColorSeed="@($"category:{category.ShortName}")" Title="@($"Category: {category.ShortName}")">@category.ShortName</StarionPill>
-        }
+         <CategoryPills Categories="@this.ElementBase.GetDisplayCategories()" UseShortName="true" MaxVisible="int.MaxValue"/>
     }
 }

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor
@@ -23,26 +23,10 @@ along with this program. If not, see http://www.gnu.org/licenses/.
         <SearchBar @bind-Text="@this.ViewModel.SearchText"/>
     </div>
 
-    <DxButton Id="@this.ButtonId"
-              RenderStyle="ButtonRenderStyle.Light"
-              IconCssClass="@IconName.Settings.GetCssClass()"
-              Text="View"
-              title="Display options"
-              Click="@(() => this.viewMenuOpen = !this.viewMenuOpen)" />
-
-    <DxDropDown @bind-IsOpen="@this.viewMenuOpen"
-                PositionMode="DropDownPositionMode.Bottom"
-                PositionTarget="@($"#{this.ButtonId}")"
-                CloseMode="DropDownCloseMode.Close"
-                HeaderVisible="false"
-                FooterVisible="false">
-        <BodyTemplate>
-            <div class="product-tree-view-menu">
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
-                <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
-                @this.ChildContent
-            </div>
-        </BodyTemplate>
-    </DxDropDown>
+    <ViewOptionsMenu ButtonId="@this.ButtonId">
+        <DxCheckBox @bind-Checked="@this.ViewModel.ShowName" CheckType="CheckType.Switch">Full name</DxCheckBox>
+        <DxCheckBox @bind-Checked="@this.ViewModel.ShowOwner" CheckType="CheckType.Switch">Owner</DxCheckBox>
+        <DxCheckBox @bind-Checked="@this.ViewModel.ShowCategories" CheckType="CheckType.Switch">Categories</DxCheckBox>
+        @this.ChildContent
+    </ViewOptionsMenu>
 </div>

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.cs
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.cs
@@ -42,8 +42,8 @@ namespace COMETwebapp.Components.Shared
         public IProductTreeDisplayOptions ViewModel { get; set; }
 
         /// <summary>
-        /// Gets or sets the id given to the "View" cog <c>DxButton</c>, also used as the <c>DxDropDown</c>
-        /// <c>PositionTarget</c>. Must be unique per page so two toolbars can coexist.
+        /// Gets or sets the id forwarded to the shared <see cref="COMET.Web.Common.Components.ViewOptionsMenu" />
+        /// "View" cog. Must be unique per page so two toolbars can coexist.
         /// </summary>
         [Parameter]
         [EditorRequired]
@@ -54,10 +54,5 @@ namespace COMETwebapp.Components.Shared
         /// </summary>
         [Parameter]
         public RenderFragment ChildContent { get; set; }
-
-        /// <summary>
-        /// Whether the "View" display-options dropdown is open.
-        /// </summary>
-        private bool viewMenuOpen;
     }
 }

--- a/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.css
+++ b/COMETwebapp/Components/Shared/ProductTreeToolbar.razor.css
@@ -12,14 +12,6 @@
     min-width: 0;
 }
 
-.product-tree-view-menu {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 12px;
-    min-width: 180px;
-}
-
 ::deep #tree-search-filter {
     width: 100%;
     margin-left: 0;

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor
@@ -24,7 +24,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxToolbar ItemRenderStyleMode="ToolbarRenderStyleMode.Plain">
             <DxToolbarItem Text="Edit Active Domains"
                            Click="() => this.SetEditPopupVisibility(true)"
-                           RenderStyle="ButtonRenderStyle.Info"
+                           RenderStyle="@(CometButtonStyle.Info.ToButtonRenderStyle())"
                            Enabled="true"/>
         </DxToolbar>
     </ToolbarTemplate>
@@ -57,7 +57,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </DxButton>
         <DxButton Id="cancelActiveDomainsButton"
                   Click="@(() => this.SetEditPopupVisibility(false))"
-                  RenderStyle="ButtonRenderStyle.Secondary">
+                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
             Cancel
         </DxButton>
     </div>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ActiveDomainsTable.razor
@@ -51,7 +51,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
     <div class="dxbl-grid-edit-form-buttons">
         <DxButton Id="saveActiveDomainsButton"
-                  Click="@(() => this.SetEditPopupVisibility(false))">
+                  Click="@(() => this.SetEditPopupVisibility(false))"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
             Save
         </DxButton>
         <DxButton Id="cancelActiveDomainsButton"

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
@@ -52,7 +52,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@(this.ViewModel.IsOnDeletionMode)" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/EngineeringModelsTable.razor
@@ -53,6 +53,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.OnDeletionConfirmed)"/>
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(this.OnDeletionConfirmed)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor
@@ -89,6 +89,6 @@ Copyright (c) 2023-2026 Starion Group S.A.
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.ViewModel.OnConfirmPopupButtonClick)"/>
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@(this.ViewModel.OnConfirmPopupButtonClick)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/IterationsTable.razor
@@ -40,12 +40,12 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <HeaderTemplate>
                     @if (this.ViewModel.CanCreateIteration)
                     {
-                        <DxButton Id="addIterationButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate"/>
+                        <DxButton Id="addIterationButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
                     }
                     else
                     {
                         <span title="Iterations can only be created in Design Session Phase, Reporting Phase, or Completed Study.">
-                            <DxButton Id="addIterationButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Enabled="false"/>
+                            <DxButton Id="addIterationButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Enabled="false" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"/>
                         </span>
                     }
                 </HeaderTemplate>
@@ -56,12 +56,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         <DxButton Id="editIterationButton"
                                   IconCssClass="@IconName.Edit.GetCssClass()"
                                   Click="@(() => this.StartEdit(row))"
-                                  Enabled="@(row.IsAllowedToWrite)"/>
+                                  Enabled="@(row.IsAllowedToWrite)"
+                                  RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                         <DxButton Id="deleteIterationButton"
                                   IconCssClass="@IconName.Delete.GetCssClass()"
                                   Click="() => this.ViewModel.OnDeleteButtonClick(row)"
-                                  Enabled="@(this.IsDeleteEnabled(row))"/>
+                                  Enabled="@(this.IsDeleteEnabled(row))"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
@@ -86,7 +88,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@(this.ViewModel.IsOnDeletionMode)" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @(this.ViewModel.PopupDialog)
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel" RenderStyle="ButtonRenderStyle.Success" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
+        <DxButton Text="Cancel" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.ViewModel.OnCancelPopupButtonClick)"/>
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@(this.ViewModel.OnConfirmPopupButtonClick)"/>
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor
@@ -25,7 +25,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         <DxToolbar ItemRenderStyleMode="ToolbarRenderStyleMode.Plain">
             <DxToolbarItem Text="Edit Organizational Participants"
                            Click="(() => this.IsOnEditMode = true)"
-                           RenderStyle="ButtonRenderStyle.Info"
+                           RenderStyle="@(CometButtonStyle.Info.ToButtonRenderStyle())"
                            Enabled="true"/>
         </DxToolbar>
     </ToolbarTemplate>
@@ -70,7 +70,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
         </DxButton>
         <DxButton Id="cancelOrganizationalParticipantsButton"
                   Click="@(() => this.IsOnEditMode = false)"
-                  RenderStyle="ButtonRenderStyle.Secondary">
+                  RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())">
             Cancel
         </DxButton>
     </div>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/OrganizationalParticipantsTable.razor
@@ -64,7 +64,8 @@ Copyright (c) 2023-2026 Starion Group S.A.
 
     <div class="dxbl-grid-edit-form-buttons">
         <DxButton Id="saveOrganizationalParticipantsButton"
-                  Click="@(() => this.IsOnEditMode = false)">
+                  Click="@(() => this.IsOnEditMode = false)"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())">
             Save
         </DxButton>
         <DxButton Id="cancelOrganizationalParticipantsButton"

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
@@ -39,7 +39,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             </DxGridDataColumn>
             <DxGridCommandColumn Width="100px">
                 <HeaderTemplate>
-                    <DxButton Id="addParticipantButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" />
+                    <DxButton Id="addParticipantButton" Text="Add" IconCssClass="@IconName.Add.GetCssClass()" Click="this.StartCreate" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" />
                 </HeaderTemplate>
                 <CellDisplayTemplate>
                     @{
@@ -48,12 +48,14 @@ Copyright (c) 2023-2026 Starion Group S.A.
                         <DxButton Id="editParticipantButton"
                                   IconCssClass="@IconName.Edit.GetCssClass()"
                                   Click="@(() => this.StartEdit(row))"
-                                  Enabled="@(row.IsAllowedToWrite)"/>
+                                  Enabled="@(row.IsAllowedToWrite)"
+                                  RenderStyle="@(CometButtonStyle.Edit.ToButtonRenderStyle())"/>
 
                         <DxButton Id="deleteParticipantButton"
                                   IconCssClass="@IconName.Delete.GetCssClass()"
                                   Click="@(() => this.ViewModel.OnDeleteButtonClick(row))"
-                                  Enabled="@(row.IsAllowedToWrite)"/>
+                                  Enabled="@(row.IsAllowedToWrite)"
+                                  RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())"/>
                     }
                 </CellDisplayTemplate>
             </DxGridCommandColumn>
@@ -78,7 +80,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
 <DxPopup @bind-Visible="@this.ViewModel.IsOnDeletionMode" HeaderText="Please confirm" Width="auto" CloseOnOutsideClick="false">
     @this.ViewModel.PopupDialog
     <div class="dxbl-grid-confirm-dialog-buttons">
-        <DxButton Text="Cancel " RenderStyle="ButtonRenderStyle.Success" Click="@this.ViewModel.OnCancelPopupButtonClick" />
+        <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@this.ViewModel.OnCancelPopupButtonClick" />
         <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@this.ViewModel.OnConfirmPopupButtonClick" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
+++ b/COMETwebapp/Components/SiteDirectory/EngineeringModel/ParticipantsTable.razor
@@ -81,7 +81,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
     @this.ViewModel.PopupDialog
     <div class="dxbl-grid-confirm-dialog-buttons">
         <DxButton Text="Cancel " RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@this.ViewModel.OnCancelPopupButtonClick" />
-        <DxButton Text="Confirm" RenderStyle="ButtonRenderStyle.Danger" Click="@this.ViewModel.OnConfirmPopupButtonClick" />
+        <DxButton Text="Confirm" RenderStyle="@(CometButtonStyle.Danger.ToButtonRenderStyle())" Click="@this.ViewModel.OnConfirmPopupButtonClick" />
     </div>
 </DxPopup>
 

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscribedTable.razor
@@ -44,7 +44,7 @@ else
                 </div>
             </div>
             <div class="col align-self-center">
-                <DxButton CssClass="btn btn-outline-dark width-200 padding-bottom-1 padding-top-1" Text="Validate all changes" Click="@this.ViewModel.ValidateAllChanges"/>
+                <DxButton CssClass="width-200 padding-bottom-1 padding-top-1" RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())" Text="Validate all changes" Click="@this.ViewModel.ValidateAllChanges"/>
             </div>
         </div>
     }
@@ -74,7 +74,7 @@ else
                         if (revisions.Count >= 2)
                         {
                             var row = (ParameterSubscriptionRowViewModel)context.DataItem;
-                            <DxButton Text="More" Click="@(() => this.ShowEvolution(row))"/>
+                            <DxButton Text="More" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Click="@(() => this.ShowEvolution(row))"/>
                         }
                     }
                 </CellDisplayTemplate>

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor
@@ -22,12 +22,14 @@
 @inherits COMET.Web.Common.Components.Applications.SingleIterationApplicationBase<COMETwebapp.ViewModels.Components.SubscriptionDashboard.ISubscriptionDashboardBodyViewModel>
 
 <LoadingComponent IsVisible="@this.ViewModel.IsLoading">
-    <div id="@WebAppConstantValues.SubscriptionDashboardPage.QueryPageBodyName()" class="row">
-        <div class="col-2 width-fit-content">
-            <ParameterTypeSelector ViewModel="@(this.ViewModel.ParameterTypeSelector)"/>
-        </div>
-        <div class="col-2 width-fit-content">
-            <OptionSelector ViewModel="@(this.ViewModel.OptionSelector)"/>
+    <div id="@WebAppConstantValues.SubscriptionDashboardPage.QueryPageBodyName()">
+        <div class="filter-bar">
+            <div class="filter-bar-item">
+                <MultiParameterTypeSelector ViewModel="@(this.ViewModel.ParameterTypeSelector)" DisplayText=""/>
+            </div>
+            <div class="filter-bar-item">
+                <MultiOptionSelector ViewModel="@(this.ViewModel.OptionSelector)" DisplayText=""/>
+            </div>
         </div>
         <DxTreeView>
             <Nodes>

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
@@ -23,6 +23,7 @@
 namespace COMETwebapp.Components.SubscriptionDashboard
 {
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
 
     using COMET.Web.Common.Components.Applications;
     using COMET.Web.Common.Extensions;
@@ -56,8 +57,8 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         {
             base.OnViewModelAssigned();
 
-            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOption,
-                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterType)
+            this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionSelector.SelectedOptions,
+                    x => x.ViewModel.ParameterTypeSelector.SelectedParameterTypes)
                 .Subscribe(_ => this.UpdateUrl()));
         }
 
@@ -67,15 +68,37 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         /// <param name="parameters">A <see cref="Dictionary{TKey,TValue}" /> for parameters</param>
         protected override void InitializeValues(Dictionary<string, string> parameters)
         {
-            if (parameters.TryGetValue(QueryKeys.OptionKey, out var option))
+            if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                this.ViewModel.OptionSelector.SelectedOption = this.ViewModel.OptionSelector.AvailableOptions.FirstOrDefault(x => x.Iid == option.FromShortGuid());
+                var ids = optionsValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
             }
 
-            if (parameters.TryGetValue(QueryKeys.ParameterKey, out var parameter))
+            if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                this.ViewModel.ParameterTypeSelector.SelectedParameterType = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
-                    .FirstOrDefault(x => x.Iid == parameter.FromShortGuid());
+                var ids = parametersValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(x => x.FromShortGuid())
+                    .ToHashSet();
+
+                this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
+                    .Where(x => ids.Contains(x.Iid))
+                    .ToList();
+            }
+            else if (parameters.TryGetValue(QueryKeys.ParameterKey, out var parameter))
+            {
+                var match = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes.FirstOrDefault(x => x.Iid == parameter.FromShortGuid());
+
+                if (match != null)
+                {
+                    this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = new List<ParameterType> { match };
+                }
             }
         }
 
@@ -86,14 +109,18 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         {
             var additionalParameters = new Dictionary<string, string>();
 
-            if (this.ViewModel.OptionSelector.SelectedOption != null)
+            var selectedOptions = this.ViewModel.OptionSelector.SelectedOptions?.ToList() ?? new List<Option>();
+
+            if (selectedOptions.Count > 0)
             {
-                additionalParameters[QueryKeys.OptionKey] = this.ViewModel.OptionSelector.SelectedOption.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.OptionsKey] = string.Join(",", selectedOptions.Select(x => x.Iid.ToShortGuid()));
             }
 
-            if (this.ViewModel.ParameterTypeSelector.SelectedParameterType != null)
+            var selectedParameterTypes = this.ViewModel.ParameterTypeSelector.SelectedParameterTypes?.ToList() ?? new List<ParameterType>();
+
+            if (selectedParameterTypes.Count > 0)
             {
-                additionalParameters[QueryKeys.ParameterKey] = this.ViewModel.ParameterTypeSelector.SelectedParameterType.Iid.ToShortGuid();
+                additionalParameters[QueryKeys.ParametersKey] = string.Join(",", selectedParameterTypes.Select(x => x.Iid.ToShortGuid()));
             }
 
             this.ViewModel.UpdateTables();

--- a/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
+++ b/COMETwebapp/Components/SubscriptionDashboard/SubscriptionDashboardBody.razor.cs
@@ -29,6 +29,7 @@ namespace COMETwebapp.Components.SubscriptionDashboard
     using COMET.Web.Common.Extensions;
     using COMET.Web.Common.Utilities;
 
+    using COMETwebapp.Extensions;
     using COMETwebapp.Utilities;
 
     using Microsoft.AspNetCore.Components;
@@ -70,10 +71,7 @@ namespace COMETwebapp.Components.SubscriptionDashboard
         {
             if (parameters.TryGetValue(QueryKeys.OptionsKey, out var optionsValue) && !string.IsNullOrWhiteSpace(optionsValue))
             {
-                var ids = optionsValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = optionsValue.FromShortGuids();
 
                 this.ViewModel.OptionSelector.SelectedOptions = this.ViewModel.OptionSelector.AvailableOptions
                     .Where(x => ids.Contains(x.Iid))
@@ -82,10 +80,7 @@ namespace COMETwebapp.Components.SubscriptionDashboard
 
             if (parameters.TryGetValue(QueryKeys.ParametersKey, out var parametersValue) && !string.IsNullOrWhiteSpace(parametersValue))
             {
-                var ids = parametersValue
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(x => x.FromShortGuid())
-                    .ToHashSet();
+                var ids = parametersValue.FromShortGuids();
 
                 this.ViewModel.ParameterTypeSelector.SelectedParameterTypes = this.ViewModel.ParameterTypeSelector.AvailableParameterTypes
                     .Where(x => ids.Contains(x.Iid))

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
@@ -49,7 +49,7 @@
 
 .node-text {
     margin: 0;
-    sflex: 0 0 auto;
+    flex: 0 0 auto;
     white-space: nowrap;
 }
 

--- a/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css
@@ -4,8 +4,9 @@
     justify-content: flex-start;
     align-items: flex-start;
     flex-wrap: nowrap;
-    flex: 1 1 auto;
-    min-width: 0;
+    flex: 0 0 auto;
+    min-width: 100%;
+    width: max-content;
     padding: 3px 4px;
     padding-left: 0;
     border-radius: 8px;
@@ -20,7 +21,6 @@
     flex-direction: row;
     justify-content: stretch;
     align-items: start;
-    overflow: hidden;
     transition: background-color .15s ease;
 }
 
@@ -44,13 +44,12 @@
 .children {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
 }
 
 .node-text {
     margin: 0;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    sflex: 0 0 auto;
     white-space: nowrap;
 }
 
@@ -58,20 +57,19 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     gap: 8px;
-    flex: 1 1 auto;
-    min-width: 0;
+    flex: 0 0 auto;
 }
 
 .node-pills {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     justify-content: flex-end;
     gap: 4px;
     margin-left: auto;
-    flex-shrink: 0;
+    flex: 0 0 auto;
 }
 
 .expandIcon {

--- a/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
+++ b/COMETwebapp/Components/SystemRepresentation/SystemRepresentationBody.razor.css
@@ -9,8 +9,6 @@
 #leftColumn {
     flex: 0 0 320px;
     min-width: 280px;
-    position: sticky;
-    top: 8px;
     align-self: flex-start;
     max-height: 100%;
     display: flex;
@@ -21,8 +19,6 @@
 #rightColumn {
     flex: 1 1 auto;
     min-width: 350px;
-    position: sticky;
-    top: 8px;
     align-self: flex-start;
     max-height: 100%;
     display: flex;
@@ -43,7 +39,7 @@
 
 #option-filter {
     flex: 0 0 auto;
-    margin-bottom: 8px;
+    margin-bottom: 24px;
 }
 
 #option-filter ::deep h6 {
@@ -56,8 +52,6 @@
     cursor: col-resize;
     background: #e2e8f0;
     border-radius: 3px;
-    position: sticky;
-    top: 8px;
     max-height: 100%;
 }
 

--- a/COMETwebapp/Components/Tabs/OpenTab.razor
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor
@@ -27,7 +27,7 @@
     <DxFormLayoutItem ColSpanLg="12">
         <div style="display:flex; flex-direction: column; align-items: center;">
             <CometIcon Icon="IconName.Smile" Size="42" Color="var(--colors-primary-500)"/>
-            <h5 class="font-weight-bold mt-1 text-primary">You have no model selected</h5>
+            <h5 class="font-weight-bold mt-1" style="color: var(--colors-gray-800);">You have no model selected</h5>
             <span style="color: var(--colors-gray-600);">Select a model to start working on it</span>
         </div>
     </DxFormLayoutItem>
@@ -106,6 +106,7 @@
         <DxButton Id="opentab__button"
                   CssClass="btn btn-connect w-100 lh-lg mt-3"
                   Text="@($"{this.ButtonText} Tab")"
+                  RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                   Click="@(this.OpenModelAndNavigateToView)"
                   Enabled="@(this.ButtonEnabled)"/>
 
@@ -114,6 +115,7 @@
             <DxButton Id="closetab__button"
                       CssClass="btn btn-connect w-100 lh-lg mt-2"
                       Text="Close"
+                      RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())"
                       Click="@(() => this.OnCancel?.Invoke())"
                       RenderStyleMode="ButtonRenderStyleMode.Outline"/>
         }

--- a/COMETwebapp/Components/Tabs/TabComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabComponent.razor
@@ -26,7 +26,7 @@
 
     @if (this.ApplicationIcon is not null)
     {
-        <DxButton RenderStyle="ButtonRenderStyle.None"
+        <DxButton RenderStyle="@(CometButtonStyle.None.ToButtonRenderStyle())"
                   CssClass="px-1">
             <CometIcon Icon="@(this.ApplicationIcon.Value)" Size="22" CssClass="cursor-pointer"/>
         </DxButton>
@@ -36,7 +36,7 @@
 
     @if (this.CustomOptionIcon is not null && this.CustomOptionIconVisible)
     {
-        <DxButton RenderStyle="ButtonRenderStyle.None"
+        <DxButton RenderStyle="@(CometButtonStyle.None.ToButtonRenderStyle())"
                   Click="@(() => this.OnCustomOptionIconClick?.Invoke())"
                   CssClass="ps-2 pe-0"
                   Id="tab-custom-option-button">
@@ -44,7 +44,7 @@
         </DxButton>
     }
 
-    <DxButton RenderStyle="ButtonRenderStyle.None"
+    <DxButton RenderStyle="@(CometButtonStyle.None.ToButtonRenderStyle())"
               Click="@(() => this.OnIconClick?.Invoke())"
               CssClass="px-1 tab-close-button">
         <CometIcon Icon="@(this.Icon.Value)" Size="22" CssClass="cursor-pointer"/>

--- a/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
+++ b/COMETwebapp/Components/Tabs/TabsPanelComponent.razor
@@ -56,7 +56,7 @@
             @if (this.IsSidePanelAvailable)
             {
                 <DxButton Click="@(() => this.AddSidePanel())"
-                          RenderStyle="ButtonRenderStyle.None"
+                          RenderStyle="@(CometButtonStyle.None.ToButtonRenderStyle())"
                           Id="new-side-panel-button"
                           CssClass="ml-auto p-0">
                     <CometIcon Icon="IconName.Columns" Size="30"/>

--- a/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor
+++ b/COMETwebapp/Components/Viewer/PropertiesPanel/PropertiesComponent.razor
@@ -27,6 +27,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
             <h4 id="properties-title">@(this.Title)</h4>
             <DxButton Click="@(() => this.ViewModel.OnSubmit())"
                       Text="Submit"
+                      RenderStyle="@(CometButtonStyle.Primary.ToButtonRenderStyle())"
                       Enabled="@(this.ViewModel.ParameterHaveChanges)"/>
         </div>
 

--- a/COMETwebapp/Extensions/StringExtensions.cs
+++ b/COMETwebapp/Extensions/StringExtensions.cs
@@ -23,6 +23,8 @@
 namespace COMETwebapp.Extensions
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Numerics;
     using System.Text;
 
@@ -88,6 +90,26 @@ namespace COMETwebapp.Extensions
         public static string QueryPageBodyName(this string pageName)
         {
             return $"{pageName}-body".ToLower();
+        }
+
+        /// <summary>
+        /// Splits a separated list of short-guid strings (for example a URL query value) and converts each entry to
+        /// a <see cref="Guid" />. Returns an empty set for a null, empty or whitespace input.
+        /// </summary>
+        /// <param name="value">The separated list of short guids.</param>
+        /// <param name="separator">The separator between entries. Defaults to a comma.</param>
+        /// <returns>The set of <see cref="Guid" />s parsed from <paramref name="value" />.</returns>
+        public static HashSet<Guid> FromShortGuids(this string value, char separator = ',')
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return [];
+            }
+
+            return value
+                .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(x => x.FromShortGuid())
+                .ToHashSet();
         }
     }
 }

--- a/COMETwebapp/Shared/SideBar.razor
+++ b/COMETwebapp/Shared/SideBar.razor
@@ -25,7 +25,7 @@
     <div class="@(this.IsCollapsed ? "text-center" : "text-end")">
         <DxButton Text="Collapse"
                   Click="@this.ToggleCollapsed"
-                  RenderStyle="ButtonRenderStyle.None"
+                  RenderStyle="@(CometButtonStyle.None.ToButtonRenderStyle())"
                   Id="side-bar-collapse-button">
             @if (this.IsCollapsed)
             {

--- a/COMETwebapp/Shared/SideBarEntry/AboutSideBar.razor
+++ b/COMETwebapp/Shared/SideBarEntry/AboutSideBar.razor
@@ -26,6 +26,6 @@
 <DxPopup @bind-Visible="this.IsVisible" HeaderText="CDP4-COMET-WEB CE">
     <About/>
     <div class="text-center">
-        <DxButton CssClass="popup-button" RenderStyle="ButtonRenderStyle.Primary" Text="Close" Click="@(() => this.SetVisibility(false))" />
+        <DxButton CssClass="popup-button" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Close" Click="@(() => this.SetVisibility(false))" />
     </div>
 </DxPopup>

--- a/COMETwebapp/Shared/SideBarEntry/SessionSideBar.razor
+++ b/COMETwebapp/Shared/SideBarEntry/SessionSideBar.razor
@@ -57,12 +57,12 @@
                 sec
             </div>
             <div class="session__buttons">
-                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" Click="@(this.OnEditProfileClick)"/>
+                <DxButton Id="edit-profile-button" CssClass="btn btn-connect" Text="Edit my profile" IconCssClass="@IconName.User.GetCssClass()" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Click="@(this.OnEditProfileClick)"/>
             </div>
 
             <div class="session__buttons session__buttons--secondary">
-                <DxButton Id="refresh-button" CssClass="btn btn-connect" Text="@(this.RefreshButtonText)" IconCssClass="@IconName.Refresh.GetCssClass()" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
-                <DxButton Id="logout-button" CssClass="btn btn-connect" Text="Log out" IconCssClass="@IconName.LogOut.GetCssClass()" Click="@(this.Logout)"/>
+                <DxButton Id="refresh-button" CssClass="btn btn-connect" Text="@(this.RefreshButtonText)" IconCssClass="@IconName.Refresh.GetCssClass()" RenderStyle="@(CometButtonStyle.Light.ToButtonRenderStyle())" Enabled="@(!this.IsRefreshing)" Click="@(this.OnRefreshClick)"/>
+                <DxButton Id="logout-button" CssClass="btn btn-connect" Text="Log out" IconCssClass="@IconName.LogOut.GetCssClass()" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Click="@(this.Logout)"/>
             </div>
         </div>
     </BodyContentTemplate>

--- a/COMETwebapp/Shared/TopMenuEntry/AboutMenu.razor
+++ b/COMETwebapp/Shared/TopMenuEntry/AboutMenu.razor
@@ -23,6 +23,6 @@
 <DxPopup @bind-Visible="this.IsVisible" HeaderText="CDP4-COMET-WEB CE">
     <About/>
     <div class="text-center">
-        <DxButton CssClass="popup-button" RenderStyle="ButtonRenderStyle.Primary" Text="Close" Click="@(() => this.SetVisibility(false))" />
+        <DxButton CssClass="popup-button" RenderStyle="@(CometButtonStyle.Secondary.ToButtonRenderStyle())" Text="Close" Click="@(() => this.SetVisibility(false))" />
     </div>
 </DxPopup>

--- a/COMETwebapp/ViewModels/Components/ModelDashboard/IModelDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelDashboard/IModelDashboardBodyViewModel.cs
@@ -34,19 +34,22 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard
     public interface IModelDashboardBodyViewModel : ISingleIterationApplicationBaseViewModel
     {
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// means no option filtering is applied.
         /// </summary>
-        IOptionSelectorViewModel OptionSelector { get; }
+        IMultiOptionSelectorViewModel OptionSelector { get; }
 
         /// <summary>
-        /// Gets the <see cref="IFiniteStateSelectorViewModel" />
+        /// Gets the <see cref="IMultiFiniteStateSelectorViewModel" /> driving the finite state filter. An empty
+        /// selection means no state filtering is applied.
         /// </summary>
-        IFiniteStateSelectorViewModel FiniteStateSelector { get; }
+        IMultiFiniteStateSelectorViewModel FiniteStateSelector { get; }
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter. An empty
+        /// selection means no parameter-type filtering is applied.
         /// </summary>
-        IParameterTypeSelectorViewModel ParameterTypeSelector { get; }
+        IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; }
 
         /// <summary>
         /// The <see cref="IParameterDashboardViewModel" />

--- a/COMETwebapp/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelDashboard/ModelDashboardBodyViewModel.cs
@@ -67,19 +67,22 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard
         public IParameterDashboardViewModel ParameterDashboard { get; }
 
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// means no option filtering is applied.
         /// </summary>
-        public IOptionSelectorViewModel OptionSelector { get; private set; } = new OptionSelectorViewModel();
+        public IMultiOptionSelectorViewModel OptionSelector { get; private set; } = new MultiOptionSelectorViewModel();
 
         /// <summary>
-        /// Gets the <see cref="IFiniteStateSelectorViewModel" />
+        /// Gets the <see cref="IMultiFiniteStateSelectorViewModel" /> driving the finite state filter. An empty
+        /// selection means no state filtering is applied.
         /// </summary>
-        public IFiniteStateSelectorViewModel FiniteStateSelector { get; private set; } = new FiniteStateSelectorViewModel();
+        public IMultiFiniteStateSelectorViewModel FiniteStateSelector { get; private set; } = new MultiFiniteStateSelectorViewModel();
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter. An empty
+        /// selection means no parameter-type filtering is applied.
         /// </summary>
-        public IParameterTypeSelectorViewModel ParameterTypeSelector { get; private set; } = new ParameterTypeSelectorViewModel();
+        public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; private set; } = new MultiParameterTypeSelectorViewModel();
 
         /// <summary>
         /// Update the dashboard view models properties
@@ -88,8 +91,8 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard
         {
             this.IsLoading = true;
 
-            this.ParameterDashboard.UpdateProperties(this.CurrentThing, this.OptionSelector.SelectedOption,
-                this.FiniteStateSelector.SelectedActualFiniteState, this.ParameterTypeSelector.SelectedParameterType,
+            this.ParameterDashboard.UpdateProperties(this.CurrentThing, this.OptionSelector.SelectedOptions,
+                this.FiniteStateSelector.SelectedActualFiniteStates, this.ParameterTypeSelector.SelectedParameterTypes,
                 this.CurrentDomain, this.AvailableDomains);
 
             this.ElementDashboard.UpdateProperties(this.CurrentThing, this.CurrentDomain);

--- a/COMETwebapp/ViewModels/Components/ModelDashboard/ParameterValues/IParameterDashboardViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelDashboard/ParameterValues/IParameterDashboardViewModel.cs
@@ -51,12 +51,21 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues
         /// Updates this view model properties
         /// </summary>
         /// <param name="iteration">The current <see cref="Iteration" /></param>
-        /// <param name="selectedOption">The current <see cref="Option" /></param>
-        /// <param name="selectedState">The current <see cref="ActualFiniteState" /></param>
-        /// <param name="selectedParameterType">The current <see cref="ParameterType" /></param>
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedStates">
+        /// The collection of selected <see cref="ActualFiniteState" />s. <c>null</c> or an empty collection means
+        /// no state filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
         /// <param name="currentDomain">The current <see cref="DomainOfExpertise"/></param>
         /// <param name="availableDomains">A collection of available <see cref="DomainOfExpertise"/></param>
-        void UpdateProperties(Iteration iteration, Option selectedOption, ActualFiniteState selectedState, ParameterType selectedParameterType, DomainOfExpertise currentDomain,
+        void UpdateProperties(Iteration iteration, IEnumerable<Option> selectedOptions, IEnumerable<ActualFiniteState> selectedStates, IEnumerable<ParameterType> selectedParameterTypes, DomainOfExpertise currentDomain,
 	        IEnumerable<DomainOfExpertise> availableDomains);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ModelDashboard/ParameterValues/ParameterDashboardViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ModelDashboard/ParameterValues/ParameterDashboardViewModel.cs
@@ -53,12 +53,21 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues
         /// Updates this view model properties
         /// </summary>
         /// <param name="iteration">The current <see cref="Iteration" /></param>
-        /// <param name="selectedOption">The current <see cref="Option" /></param>
-        /// <param name="selectedState">The current <see cref="ActualFiniteState" /></param>
-        /// <param name="selectedParameterType">The current <see cref="ParameterType" /></param>
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedStates">
+        /// The collection of selected <see cref="ActualFiniteState" />s. <c>null</c> or an empty collection means
+        /// no state filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
         /// <param name="currentDomain">The current <see cref="DomainOfExpertise" /></param>
         /// <param name="availableDomains">A collection of available <see cref="DomainOfExpertise" /></param>
-        public void UpdateProperties(Iteration iteration, Option selectedOption, ActualFiniteState selectedState, ParameterType selectedParameterType, DomainOfExpertise currentDomain,
+        public void UpdateProperties(Iteration iteration, IEnumerable<Option> selectedOptions, IEnumerable<ActualFiniteState> selectedStates, IEnumerable<ParameterType> selectedParameterTypes, DomainOfExpertise currentDomain,
             IEnumerable<DomainOfExpertise> availableDomains)
         {
             this.ValueSets.Clear();
@@ -70,29 +79,42 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues
 
             this.CurrentDomain = currentDomain;
             this.AvailableDomains = availableDomains;
-            this.ValueSets.AddRange(FilterValueSets(iteration, selectedOption, selectedState, selectedParameterType));
+            this.ValueSets.AddRange(FilterValueSets(iteration, selectedOptions, selectedStates, selectedParameterTypes));
         }
 
         /// <summary>
         /// Filters the <see cref="ParameterValueSetBase" /> that are contained into an <see cref="Iteration" />
         /// </summary>
         /// <param name="iteration">The <see cref="Iteration" /></param>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedState">The selected <see cref="ActualFiniteState" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedStates">
+        /// The collection of selected <see cref="ActualFiniteState" />s. <c>null</c> or an empty collection means
+        /// no state filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
         /// <returns>A collection of filtered <see cref="ParameterValueSetBase" /></returns>
-        private static IEnumerable<ParameterValueSetBase> FilterValueSets(Iteration iteration, Option selectedOption,
-            ActualFiniteState selectedState, ParameterType selectedParameterType)
+        private static IEnumerable<ParameterValueSetBase> FilterValueSets(Iteration iteration, IEnumerable<Option> selectedOptions,
+            IEnumerable<ActualFiniteState> selectedStates, IEnumerable<ParameterType> selectedParameterTypes)
         {
             var valuesSets = iteration.QueryParameterValueSetBase().ToList();
 
-            if (selectedOption != null)
-            {
-                var nestedParameters = iteration.QueryNestedParameters(selectedOption).ToList();
+            var options = selectedOptions?.ToList() ?? new List<Option>();
 
-                if (nestedParameters.Any())
+            if (options.Count > 0)
+            {
+                var nestedValueSetIds = options.SelectMany(option => iteration.QueryNestedParameters(option))
+                    .Select(p => ((ParameterValueSetBase)p.ValueSet).Iid)
+                    .ToHashSet();
+
+                if (nestedValueSetIds.Count > 0)
                 {
-                    valuesSets = valuesSets.Where(x => nestedParameters.Select(p => p.ValueSet).Contains(x)).ToList();
+                    valuesSets = valuesSets.Where(x => nestedValueSetIds.Contains(x.Iid)).ToList();
                 }
                 else
                 {
@@ -100,14 +122,18 @@ namespace COMETwebapp.ViewModels.Components.ModelDashboard.ParameterValues
                 }
             }
 
-            if (selectedState != null)
+            var stateIds = selectedStates?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (stateIds.Count > 0)
             {
-                valuesSets.RemoveAll(v => v.ActualState?.Iid != selectedState.Iid);
+                valuesSets.RemoveAll(v => v.ActualState == null || !stateIds.Contains(v.ActualState.Iid));
             }
 
-            if (selectedParameterType != null)
+            var parameterTypeIds = selectedParameterTypes?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (parameterTypeIds.Count > 0)
             {
-                valuesSets.RemoveAll(v => ((ParameterOrOverrideBase)v.Container).ParameterType.Iid != selectedParameterType.Iid);
+                valuesSets.RemoveAll(v => !parameterTypeIds.Contains(((ParameterOrOverrideBase)v.Container).ParameterType.Iid));
             }
 
             return valuesSets;

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterEditorBodyViewModel.cs
@@ -39,14 +39,17 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         ISubscriptionService SubscriptionService { get; set; }
 
         /// <summary>
-        /// Gets the <see cref="IElementBaseSelectorViewModel" />
+        /// Gets the <see cref="IMultiElementBaseSelectorViewModel" /> driving the building-block filter. An empty
+        /// selection means no element filtering is applied.
         /// </summary>
-        public IElementBaseSelectorViewModel ElementSelector { get; }
+        public IMultiElementBaseSelectorViewModel ElementSelector { get; }
 
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// falls back to the <see cref="CDP4Common.EngineeringModelData.Iteration" />'s default
+        /// <see cref="CDP4Common.EngineeringModelData.Option" />.
         /// </summary>
-        public IOptionSelectorViewModel OptionSelector { get; }
+        public IMultiOptionSelectorViewModel OptionSelector { get; }
 
         /// <summary>
         /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter.

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
@@ -56,8 +56,11 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// </summary>
         /// <param name="currentIteration">The current <see cref="Iteration"/></param>
         /// <param name="currentDomain">The <see cref="DomainOfExpertise"/></param>
-        /// <param name="selectedOption">The select <see cref="Option"/></param>
-        void InitializeViewModel(Iteration currentIteration, DomainOfExpertise currentDomain, Option selectedOption);
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option"/>s. <c>null</c> or an empty collection falls back to the
+        /// <see cref="Iteration"/>'s default <see cref="Option"/>.
+        /// </param>
+        void InitializeViewModel(Iteration currentIteration, DomainOfExpertise currentDomain, IEnumerable<Option> selectedOptions);
 
         /// <summary>
         /// Update the current <see cref="DomainOfExpertise"/>
@@ -66,11 +69,19 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         void UpdateDomain(DomainOfExpertise currentDomain);
 
         /// <summary>
-        /// Apply filters based on <see cref="Option"/>, <see cref="ElementBase"/>, <see cref="ParameterType"/>,
-        /// <see cref="Category"/> and <see cref="DomainOfExpertise"/>.
+        /// Apply filters based on a multi-select set of <see cref="Option"/>s, a multi-select set of
+        /// <see cref="ElementBase"/>s, <see cref="ParameterType"/>, <see cref="Category"/> and
+        /// <see cref="DomainOfExpertise"/>.
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option"/>.</param>
-        /// <param name="selectedElementBase">The selected <see cref="ElementBase"/>.</param>
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option"/>s. <c>null</c> or an empty collection falls back to the
+        /// <see cref="Iteration"/>'s default <see cref="Option"/>.
+        /// </param>
+        /// <param name="selectedElementBases">
+        /// The collection of <see cref="ElementBase"/>s to filter on. <c>null</c> or an empty collection means no
+        /// element filter is applied; otherwise rows whose owning <see cref="ElementBase"/> is not in the
+        /// collection are removed.
+        /// </param>
         /// <param name="selectedParameterTypes">
         /// The collection of <see cref="ParameterType"/>s to filter on. <c>null</c> or an empty collection means
         /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType"/> is not in the
@@ -84,6 +95,6 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// are removed.
         /// </param>
         /// <param name="isOwnedParameters">Value asserting that only <see cref="Thing"/>s owned by the current <see cref="DomainOfExpertise"/> should be visible.</param>
-        void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters);
+        void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ElementBase> selectedElementBases, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters);
     }
 }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterEditorBodyViewModel.cs
@@ -82,14 +82,16 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public ISubscriptionService SubscriptionService { get; set; }
 
         /// <summary>
-        /// Gets the <see cref="IElementBaseSelectorViewModel" />
+        /// Gets the <see cref="IMultiElementBaseSelectorViewModel" /> driving the building-block filter. An empty
+        /// selection means no element filtering is applied.
         /// </summary>
-        public IElementBaseSelectorViewModel ElementSelector { get; private set; } = new ElementBaseSelectorViewModel();
+        public IMultiElementBaseSelectorViewModel ElementSelector { get; private set; } = new MultiElementBaseSelectorViewModel();
 
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// falls back to the <see cref="Iteration" />'s default <see cref="Option" />.
         /// </summary>
-        public IOptionSelectorViewModel OptionSelector { get; private set; } = new OptionSelectorViewModel(false);
+        public IMultiOptionSelectorViewModel OptionSelector { get; private set; } = new MultiOptionSelectorViewModel();
 
         /// <summary>
         /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter.
@@ -129,7 +131,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         {
             if (this.CurrentThing != null)
             {
-                this.ParameterTableViewModel.ApplyFilters(this.OptionSelector.SelectedOption, this.ElementSelector.SelectedElementBase,
+                this.ParameterTableViewModel.ApplyFilters(this.OptionSelector.SelectedOptions, this.ElementSelector.SelectedElementBases,
                     this.ParameterTypeSelector.SelectedParameterTypes, this.CategorySelector.SelectedCategories, this.IsOwnedParameters);
             }
         }
@@ -206,7 +208,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 this.BatchParameterEditorViewModel.CurrentIteration = this.CurrentThing;
             }
 
-            this.ParameterTableViewModel.InitializeViewModel(this.CurrentThing, this.CurrentDomain, this.OptionSelector.SelectedOption);
+            this.ParameterTableViewModel.InitializeViewModel(this.CurrentThing, this.CurrentDomain, this.OptionSelector.SelectedOptions);
             this.ApplyFilters();
             this.IsLoading = false;
         }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -55,7 +55,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private readonly ISessionService sessionService;
 
         /// <summary>
-        /// The set of <see cref="ElementBase.Iid" />s currently selected as a multi-select filter. Empty means
+        /// The set of <see cref="ElementBase" /> <c>Iid</c>s currently selected as a multi-select filter. Empty means
         /// "no filter".
         /// </summary>
         private HashSet<Guid> currentElementBaseIds = new();
@@ -67,13 +67,13 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private List<Option> currentOptions = new();
 
         /// <summary>
-        /// The set of <see cref="ParameterType.Iid" />s currently selected as a multi-select filter. Empty
+        /// The set of <see cref="ParameterType" /> <c>Iid</c>s currently selected as a multi-select filter. Empty
         /// means "no filter".
         /// </summary>
         private HashSet<Guid> currentParameterTypeIds = new();
 
         /// <summary>
-        /// The set of <see cref="Category.Iid" />s currently selected as a multi-select filter. Empty means
+        /// The set of <see cref="Category" /> <c>Iid</c>s currently selected as a multi-select filter. Empty means
         /// "no filter"; otherwise rows whose owning <see cref="ElementBase" /> does not carry (directly or
         /// through its referenced <see cref="ElementDefinition" /> / super-categories) at least one of these
         /// categories are removed.
@@ -410,8 +410,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// <paramref name="parameterTypeIds" />. Mutates <paramref name="parameters" /> in place.
         /// </summary>
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter.</param>
-        /// <param name="parameterTypeIds">The <see cref="ISet{T}" /> of allowed <see cref="ParameterType.Iid" /> values.</param>
-        private static void ApplyParameterTypeFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> parameterTypeIds)
+        /// <param name="parameterTypeIds">The <see cref="HashSet{T}" /> of allowed <see cref="ParameterType" /> <c>Iid</c> values.</param>
+        private static void ApplyParameterTypeFilter(List<ParameterOrOverrideBase> parameters, HashSet<Guid> parameterTypeIds)
         {
             parameters.RemoveAll(x => !parameterTypeIds.Contains(x.ParameterType.Iid));
         }
@@ -424,8 +424,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// and super-categories are honoured. Mutates <paramref name="parameters" /> in place.
         /// </summary>
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter.</param>
-        /// <param name="categoryIds">The <see cref="ISet{T}" /> of allowed <see cref="Category.Iid" /> values.</param>
-        private static void ApplyCategoryFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> categoryIds)
+        /// <param name="categoryIds">The <see cref="HashSet{T}" /> of allowed <see cref="Category" /> <c>Iid</c> values.</param>
+        private static void ApplyCategoryFilter(List<ParameterOrOverrideBase> parameters, HashSet<Guid> categoryIds)
         {
             parameters.RemoveAll(p =>
             {
@@ -444,8 +444,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// in <paramref name="elementBaseIds" />. Mutates <paramref name="parameters" /> in place.
         /// </summary>
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter</param>
-        /// <param name="elementBaseIds">The <see cref="ISet{T}" /> of allowed <see cref="ElementBase.Iid" /> values</param>
-        private static void ApplyElementBaseFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> elementBaseIds)
+        /// <param name="elementBaseIds">The <see cref="HashSet{T}" /> of allowed <see cref="ElementBase" /> <c>Iid</c> values</param>
+        private static void ApplyElementBaseFilter(List<ParameterOrOverrideBase> parameters, HashSet<Guid> elementBaseIds)
         {
             parameters.RemoveAll(x => x.Container switch
             {
@@ -461,7 +461,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /></param>
         /// <param name="optionIds">The set of <see cref="Guid" /> of the selected <see cref="Option" />s</param>
         /// <returns>A collection of created <see cref="ParameterBaseRowViewModel" /></returns>
-        private IEnumerable<ParameterBaseRowViewModel> CreateParameterBaseRowViewModels(IEnumerable<ParameterOrOverrideBase> parameters, ISet<Guid> optionIds)
+        private List<ParameterBaseRowViewModel> CreateParameterBaseRowViewModels(IEnumerable<ParameterOrOverrideBase> parameters, HashSet<Guid> optionIds)
         {
             var rows = new List<ParameterBaseRowViewModel>();
 

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -55,14 +55,16 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         private readonly ISessionService sessionService;
 
         /// <summary>
-        /// The currently selected <see cref="ElementBase" />
+        /// The set of <see cref="ElementBase.Iid" />s currently selected as a multi-select filter. Empty means
+        /// "no filter".
         /// </summary>
-        private ElementBase currentElementBase;
+        private HashSet<Guid> currentElementBaseIds = new();
 
         /// <summary>
-        /// The currently selected <see cref="Option" />
+        /// The currently effective <see cref="Option" />s. An empty selection resolves to the <see cref="Iteration" />'s
+        /// default <see cref="Option" />, mirroring the previous single-select behavior.
         /// </summary>
-        private Option currentOption;
+        private List<Option> currentOptions = new();
 
         /// <summary>
         /// The set of <see cref="ParameterType.Iid" />s currently selected as a multi-select filter. Empty
@@ -143,20 +145,26 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// </summary>
         /// <param name="currentIteration">The current <see cref="Iteration" /></param>
         /// <param name="currentDomain">The <see cref="DomainOfExpertise" /></param>
-        /// <param name="selectedOption">The select <see cref="Option" /></param>
-        public void InitializeViewModel(Iteration currentIteration, DomainOfExpertise currentDomain, Option selectedOption)
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection falls back to the
+        /// <see cref="Iteration" />'s default <see cref="Option" />.
+        /// </param>
+        public void InitializeViewModel(Iteration currentIteration, DomainOfExpertise currentDomain, IEnumerable<Option> selectedOptions)
         {
             this.iteration = currentIteration;
             this.domainOfExpertise = currentDomain;
-            this.currentOption = selectedOption;
-            this.currentElementBase = null;
+            this.currentOptions = this.ResolveSelectedOptions(selectedOptions);
+            this.currentElementBaseIds = new HashSet<Guid>();
             this.currentParameterTypeIds = new HashSet<Guid>();
             this.Rows.Clear();
 
             if (this.iteration != null)
             {
-                var ownedNestedParameters = this.iteration.QueryParameterAndOverrideBases(this.currentOption, this.domainOfExpertise);
-                this.Rows.AddRange(this.CreateParameterBaseRowViewModels(ownedNestedParameters, this.currentOption.Iid));
+                var ownedNestedParameters = this.currentOptions
+                    .SelectMany(option => this.iteration.QueryParameterAndOverrideBases(option, this.domainOfExpertise))
+                    .DistinctBy(x => x.Iid);
+
+                this.Rows.AddRange(this.CreateParameterBaseRowViewModels(ownedNestedParameters, this.currentOptions.Select(x => x.Iid).ToHashSet()));
             }
         }
 
@@ -170,12 +178,19 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         }
 
         /// <summary>
-        /// Apply filters based on <see cref="Option" />, <see cref="ElementBase" />, a multi-select set of
-        /// <see cref="ParameterType" />s, a multi-select set of <see cref="Category" />s and
-        /// <see cref="DomainOfExpertise" />.
+        /// Apply filters based on a multi-select set of <see cref="Option" />s, a multi-select set of
+        /// <see cref="ElementBase" />s, a multi-select set of <see cref="ParameterType" />s, a multi-select set of
+        /// <see cref="Category" />s and <see cref="DomainOfExpertise" />.
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" />.</param>
-        /// <param name="selectedElementBase">The selected <see cref="ElementBase" />.</param>
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection falls back to the
+        /// <see cref="Iteration" />'s default <see cref="Option" />.
+        /// </param>
+        /// <param name="selectedElementBases">
+        /// The collection of <see cref="ElementBase" />s to filter on. <c>null</c> or an empty collection means no
+        /// element filter is applied; otherwise rows whose owning <see cref="ElementBase" /> is not in the
+        /// collection are removed.
+        /// </param>
         /// <param name="selectedParameterTypes">
         /// The collection of <see cref="ParameterType" />s to filter on. <c>null</c> or an empty collection means
         /// no parameter-type filter is applied; otherwise rows whose <see cref="ParameterType" /> is not in the
@@ -192,15 +207,17 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         /// Value asserting that only <see cref="Thing" />s owned by the current <see cref="DomainOfExpertise" />
         /// should be visible.
         /// </param>
-        public void ApplyFilters(Option selectedOption, ElementBase selectedElementBase, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters)
+        public void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ElementBase> selectedElementBases, IEnumerable<ParameterType> selectedParameterTypes, IEnumerable<Category> selectedCategories, bool isOwnedParameters)
         {
             if (this.iteration == null)
             {
                 return;
             }
 
-            this.currentOption = selectedOption;
-            this.currentElementBase = selectedElementBase;
+            this.currentOptions = this.ResolveSelectedOptions(selectedOptions);
+            this.currentElementBaseIds = selectedElementBases == null
+                ? new HashSet<Guid>()
+                : new HashSet<Guid>(selectedElementBases.Select(x => x.Iid));
             this.currentParameterTypeIds = selectedParameterTypes == null
                 ? new HashSet<Guid>()
                 : new HashSet<Guid>(selectedParameterTypes.Select(x => x.Iid));
@@ -209,8 +226,34 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 : new HashSet<Guid>(selectedCategories.Select(x => x.Iid));
             this.ownedParameters = isOwnedParameters;
 
-            var rows = this.CreateRowsBasedOnFilters(this.iteration.QueryParameterAndOverrideBases(selectedOption).ToList());
+            var parameters = this.currentOptions
+                .SelectMany(option => this.iteration.QueryParameterAndOverrideBases(option))
+                .DistinctBy(x => x.Iid)
+                .ToList();
+
+            var rows = this.CreateRowsBasedOnFilters(parameters);
             this.UpdateVisibleRows(rows);
+        }
+
+        /// <summary>
+        /// Resolves the effective collection of <see cref="Option" />s to filter on. An empty or <c>null</c>
+        /// <paramref name="selectedOptions" /> falls back to the current <see cref="Iteration" />'s default
+        /// <see cref="Option" /> (or its first <see cref="Option" /> if none is set as default), mirroring the
+        /// behavior of the former single-select <see cref="Option" /> filter.
+        /// </summary>
+        /// <param name="selectedOptions">The collection of <see cref="Option" />s selected by the user.</param>
+        /// <returns>A non-null collection of <see cref="Option" />s to filter on.</returns>
+        private List<Option> ResolveSelectedOptions(IEnumerable<Option> selectedOptions)
+        {
+            var options = selectedOptions?.ToList() ?? new List<Option>();
+
+            if (options.Count > 0)
+            {
+                return options;
+            }
+
+            var defaultOption = this.iteration?.DefaultOption ?? this.iteration?.Option.FirstOrDefault();
+            return defaultOption == null ? new List<Option>() : new List<Option> { defaultOption };
         }
 
         /// <summary>
@@ -326,9 +369,9 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 parameters.RemoveAll(x => x.Owner.Iid != this.domainOfExpertise.Iid);
             }
 
-            if (this.currentElementBase != null)
+            if (this.currentElementBaseIds.Count > 0)
             {
-                ApplyElementBaseFilter(parameters, this.currentElementBase.Iid);
+                ApplyElementBaseFilter(parameters, this.currentElementBaseIds);
             }
 
             if (this.currentParameterTypeIds.Count > 0)
@@ -341,7 +384,8 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                 ApplyCategoryFilter(parameters, this.currentCategoryIds);
             }
 
-            return this.CreateParameterBaseRowViewModels(parameters, this.currentOption.Iid).DistinctBy(x => x.ValueSetId);
+            var optionIds = this.currentOptions.Select(x => x.Iid).ToHashSet();
+            return this.CreateParameterBaseRowViewModels(parameters, optionIds).DistinctBy(x => x.ValueSetId);
         }
 
         /// <summary>
@@ -395,35 +439,29 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         }
 
         /// <summary>
-        /// Apply a filtering base on <see cref="ElementBase" />
+        /// Apply a filtering pass that retains only parameters whose owning <see cref="ElementBase" /> identifier
+        /// (or, for an <see cref="ElementUsage" />, its referenced <see cref="ElementDefinition" /> identifier) is
+        /// in <paramref name="elementBaseIds" />. Mutates <paramref name="parameters" /> in place.
         /// </summary>
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /> to filter</param>
-        /// <param name="elementBaseId">The <see cref="Guid" /> of the <see cref="ElementBase" /> for filtering</param>
-        private static void ApplyElementBaseFilter(List<ParameterOrOverrideBase> parameters, Guid elementBaseId)
+        /// <param name="elementBaseIds">The <see cref="ISet{T}" /> of allowed <see cref="ElementBase.Iid" /> values</param>
+        private static void ApplyElementBaseFilter(List<ParameterOrOverrideBase> parameters, ISet<Guid> elementBaseIds)
         {
-            var parametersToRemove = new List<Guid>();
-
-            foreach (var parameterOrOverrideBase in parameters)
+            parameters.RemoveAll(x => x.Container switch
             {
-                switch (parameterOrOverrideBase.Container)
-                {
-                    case ElementDefinition elementDefinition when elementDefinition.Iid != elementBaseId:
-                    case ElementUsage elementUsage when elementUsage.Iid != elementBaseId && elementUsage.ElementDefinition.Iid != elementBaseId:
-                        parametersToRemove.Add(parameterOrOverrideBase.Iid);
-                        break;
-                }
-            }
-
-            parameters.RemoveAll(x => parametersToRemove.Contains(x.Iid));
+                ElementDefinition elementDefinition => !elementBaseIds.Contains(elementDefinition.Iid),
+                ElementUsage elementUsage => !elementBaseIds.Contains(elementUsage.Iid) && !elementBaseIds.Contains(elementUsage.ElementDefinition.Iid),
+                _ => true
+            });
         }
 
         /// <summary>
-        /// Creates <see cref="ParameterBaseRowViewModel" /> based on an <see cref="Option" />
+        /// Creates <see cref="ParameterBaseRowViewModel" /> based on a multi-select set of <see cref="Option" />s
         /// </summary>
         /// <param name="parameters">A collection of <see cref="ParameterOrOverrideBase" /></param>
-        /// <param name="optionId">The <see cref="Guid" /> of the <see cref="Option" /></param>
+        /// <param name="optionIds">The set of <see cref="Guid" /> of the selected <see cref="Option" />s</param>
         /// <returns>A collection of created <see cref="ParameterBaseRowViewModel" /></returns>
-        private IEnumerable<ParameterBaseRowViewModel> CreateParameterBaseRowViewModels(IEnumerable<ParameterOrOverrideBase> parameters, Guid optionId)
+        private IEnumerable<ParameterBaseRowViewModel> CreateParameterBaseRowViewModels(IEnumerable<ParameterOrOverrideBase> parameters, ISet<Guid> optionIds)
         {
             var rows = new List<ParameterBaseRowViewModel>();
 
@@ -431,7 +469,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             {
                 var isReadOnly = !this.permissionService.CanWrite(parameterOrOverrideBase);
 
-                rows.AddRange(parameterOrOverrideBase.ValueSets.Where(x => x.ActualOption == null || x.ActualOption.Iid == optionId)
+                rows.AddRange(parameterOrOverrideBase.ValueSets.Where(x => x.ActualOption == null || optionIds.Contains(x.ActualOption.Iid))
                     .Where(x => rows.TrueForAll(r => ((ParameterValueSetBase)r.ValueSet).Iid != ((ParameterValueSetBase)x).Iid))
                     .Select(x => new ParameterBaseRowViewModel(this.sessionService, isReadOnly, parameterOrOverrideBase, x, this.messageBus)));
             }

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/DomainOfExpertiseSubscriptionTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/DomainOfExpertiseSubscriptionTableViewModel.cs
@@ -56,24 +56,34 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         }
 
         /// <summary>
-        /// Apply filters on <see cref="OwnedParameterOrOverrideBaseRowViewModel" /> based on the <see cref="Option" /> and
-        /// <see cref="ParameterType" />
+        /// Apply filters on <see cref="OwnedParameterOrOverrideBaseRowViewModel" /> based on a multi-select set of
+        /// <see cref="Option" />s and a multi-select set of <see cref="ParameterType" />s
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
-        public void ApplyFilters(Option selectedOption, ParameterType selectedParameterType)
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
+        public void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ParameterType> selectedParameterTypes)
         {
             var filteredRows = new List<OwnedParameterOrOverrideBaseRowViewModel>(this.allRows);
 
-            if (selectedOption != null)
+            var optionIds = selectedOptions?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (optionIds.Count > 0)
             {
                 filteredRows.RemoveAll(x => x.Element is ElementUsage usage
-                                            && usage.ExcludeOption.Any(o => o.Iid == selectedOption.Iid));
+                                            && usage.ExcludeOption.Any(o => optionIds.Contains(o.Iid)));
             }
 
-            if (selectedParameterType != null)
+            var parameterTypeIds = selectedParameterTypes?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (parameterTypeIds.Count > 0)
             {
-                filteredRows.RemoveAll(x => x.Parameter.ParameterType.Iid != selectedParameterType.Iid);
+                filteredRows.RemoveAll(x => !parameterTypeIds.Contains(x.Parameter.ParameterType.Iid));
             }
 
             this.UpdateRows(filteredRows);

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/IDomainOfExpertiseSubscriptionTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/IDomainOfExpertiseSubscriptionTableViewModel.cs
@@ -47,11 +47,17 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         void UpdateProperties(IEnumerable<ParameterOrOverrideBase> parameters);
 
         /// <summary>
-        /// Apply filters on <see cref="OwnedParameterOrOverrideBaseRowViewModel" /> based on the <see cref="Option" /> and
-        /// <see cref="ParameterType" />
+        /// Apply filters on <see cref="OwnedParameterOrOverrideBaseRowViewModel" /> based on a multi-select set of
+        /// <see cref="Option" />s and a multi-select set of <see cref="ParameterType" />s
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
-        void ApplyFilters(Option selectedOption, ParameterType selectedParameterType);
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
+        void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ParameterType> selectedParameterTypes);
     }
 }

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/ISubscribedTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/ISubscribedTableViewModel.cs
@@ -60,12 +60,18 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         public void UpdateProperties(IEnumerable<ParameterSubscription> subscriptions, IEnumerable<Option> availableOptions, Iteration newIteration);
 
         /// <summary>
-        /// Apply filters on <see cref="ParameterSubscriptionRowViewModel" /> based on the <see cref="Option" /> and
-        /// <see cref="ParameterType" />
+        /// Apply filters on <see cref="ParameterSubscriptionRowViewModel" /> based on a multi-select set of
+        /// <see cref="Option" />s and a multi-select set of <see cref="ParameterType" />s
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
-        public void ApplyFilters(Option selectedOption, ParameterType selectedParameterType);
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
+        public void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ParameterType> selectedParameterTypes);
 
         /// <summary>
         /// Validates all changes of <see cref="ParameterValueSetBase" /> related to the current <see cref="Iteration" />

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/ISubscriptionDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/ISubscriptionDashboardBodyViewModel.cs
@@ -41,14 +41,16 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         IDomainOfExpertiseSubscriptionTableViewModel DomainOfExpertiseSubscriptionTable { get; }
 
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// means no option filtering is applied.
         /// </summary>
-        IOptionSelectorViewModel OptionSelector { get; }
+        IMultiOptionSelectorViewModel OptionSelector { get; }
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter. An empty
+        /// selection means no parameter-type filtering is applied.
         /// </summary>
-        IParameterTypeSelectorViewModel ParameterTypeSelector { get; }
+        IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; }
 
         /// <summary>
         /// Updates the <see cref="ISubscribedTableViewModel" /> and <see cref="IDomainOfExpertiseSubscriptionTableViewModel" />

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscribedTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscribedTableViewModel.cs
@@ -145,24 +145,34 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         }
 
         /// <summary>
-        /// Apply filters on <see cref="ParameterSubscriptionRowViewModel" /> based on the <see cref="Option" /> and
-        /// <see cref="ParameterType" />
+        /// Apply filters on <see cref="ParameterSubscriptionRowViewModel" /> based on a multi-select set of
+        /// <see cref="Option" />s and a multi-select set of <see cref="ParameterType" />s
         /// </summary>
-        /// <param name="selectedOption">The selected <see cref="Option" /></param>
-        /// <param name="selectedParameterType">The selected <see cref="ParameterType" /></param>
-        public void ApplyFilters(Option selectedOption, ParameterType selectedParameterType)
+        /// <param name="selectedOptions">
+        /// The collection of selected <see cref="Option" />s. <c>null</c> or an empty collection means no option
+        /// filtering is applied.
+        /// </param>
+        /// <param name="selectedParameterTypes">
+        /// The collection of selected <see cref="ParameterType" />s. <c>null</c> or an empty collection means no
+        /// parameter-type filtering is applied.
+        /// </param>
+        public void ApplyFilters(IEnumerable<Option> selectedOptions, IEnumerable<ParameterType> selectedParameterTypes)
         {
             this.filteredRows = [..this.allRows];
 
-            if (selectedOption != null)
+            var optionIds = selectedOptions?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (optionIds.Count > 0)
             {
-                this.filteredRows.RemoveAll(x => x.Element is ElementUsage usage && usage.ExcludeOption.Any(o => o.Iid == selectedOption.Iid));
-                this.filteredRows.RemoveAll(x => x.ValueSet.ActualOption == null || x.ValueSet.ActualOption.Iid != selectedOption.Iid);
+                this.filteredRows.RemoveAll(x => x.Element is ElementUsage usage && usage.ExcludeOption.Any(o => optionIds.Contains(o.Iid)));
+                this.filteredRows.RemoveAll(x => x.ValueSet.ActualOption == null || !optionIds.Contains(x.ValueSet.ActualOption.Iid));
             }
 
-            if (selectedParameterType != null)
+            var parameterTypeIds = selectedParameterTypes?.Select(x => x.Iid).ToHashSet() ?? new HashSet<Guid>();
+
+            if (parameterTypeIds.Count > 0)
             {
-                this.filteredRows.RemoveAll(x => x.Parameter.ParameterType.Iid != selectedParameterType.Iid);
+                this.filteredRows.RemoveAll(x => !parameterTypeIds.Contains(x.Parameter.ParameterType.Iid));
             }
 
             this.ApplyRowsVisibility();

--- a/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/SubscriptionDashboard/SubscriptionDashboardBodyViewModel.cs
@@ -49,8 +49,8 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         {
             this.SubscribedTable = subscribedTable;
 
-            this.Disposables.Add(this.WhenAnyValue(x => x.OptionSelector.SelectedOption,
-                    x => x.ParameterTypeSelector.SelectedParameterType)
+            this.Disposables.Add(this.WhenAnyValue(x => x.OptionSelector.SelectedOptions,
+                    x => x.ParameterTypeSelector.SelectedParameterTypes)
                 .Subscribe(_ => this.UpdateTables()));
         }
 
@@ -65,14 +65,16 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         public IDomainOfExpertiseSubscriptionTableViewModel DomainOfExpertiseSubscriptionTable { get; } = new DomainOfExpertiseSubscriptionTableViewModel();
 
         /// <summary>
-        /// Gets the <see cref="IOptionSelectorViewModel" />
+        /// Gets the <see cref="IMultiOptionSelectorViewModel" /> driving the option filter. An empty selection
+        /// means no option filtering is applied.
         /// </summary>
-        public IOptionSelectorViewModel OptionSelector { get; } = new OptionSelectorViewModel();
+        public IMultiOptionSelectorViewModel OptionSelector { get; } = new MultiOptionSelectorViewModel();
 
         /// <summary>
-        /// Gets the <see cref="IParameterTypeSelectorViewModel" />
+        /// Gets the <see cref="IMultiParameterTypeSelectorViewModel" /> driving the parameter-type filter. An empty
+        /// selection means no parameter-type filtering is applied.
         /// </summary>
-        public IParameterTypeSelectorViewModel ParameterTypeSelector { get; } = new ParameterTypeSelectorViewModel();
+        public IMultiParameterTypeSelectorViewModel ParameterTypeSelector { get; } = new MultiParameterTypeSelectorViewModel();
 
         /// <summary>
         /// Updates the <see cref="ISubscribedTableViewModel" /> and <see cref="IDomainOfExpertiseSubscriptionTableViewModel" />
@@ -82,8 +84,8 @@ namespace COMETwebapp.ViewModels.Components.SubscriptionDashboard
         {
             this.IsLoading = true;
 
-            this.SubscribedTable.ApplyFilters(this.OptionSelector.SelectedOption, this.ParameterTypeSelector.SelectedParameterType);
-            this.DomainOfExpertiseSubscriptionTable.ApplyFilters(this.OptionSelector.SelectedOption, this.ParameterTypeSelector.SelectedParameterType);
+            this.SubscribedTable.ApplyFilters(this.OptionSelector.SelectedOptions, this.ParameterTypeSelector.SelectedParameterTypes);
+            this.DomainOfExpertiseSubscriptionTable.ApplyFilters(this.OptionSelector.SelectedOptions, this.ParameterTypeSelector.SelectedParameterTypes);
 
             this.IsLoading = false;
         }

--- a/COMETwebapp/wwwroot/css/app.css
+++ b/COMETwebapp/wwwroot/css/app.css
@@ -53,6 +53,66 @@ html, body, #app {
 
 .height-fit-content { height: fit-content; }
 
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 10px;
+    margin-bottom: 8px;
+}
+
+.filter-bar-item {
+    flex: 1 1 220px;
+    min-width: 170px;
+    max-width: 480px;
+}
+
+.filter-bar-item > .dxbl-tagbox,
+.filter-bar-item > .dxbl-combobox,
+.filter-bar-item .dxbl-tagbox,
+.filter-bar-item .dxbl-combobox {
+    width: 100%;
+}
+
+.filter-bar-item .dxbl-tag-box,
+.filter-tag-box .dxbl-tag-box,
+.filter-tag-box.dxbl-tag-box {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    align-items: center;
+}
+
+.filter-bar-item .dxbl-tag-box .dxbl-tag,
+.filter-tag-box .dxbl-tag,
+.filter-tag-box .dxbl-tag * {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.filter-bar-search {
+    flex: 1 0 220px;
+    min-width: 200px;
+    max-width: 420px;
+}
+
+.filter-bar-right {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 0 0 auto;
+}
+
+.filter-bar-right > dxbl-popup-portal {
+    position: absolute;
+}
+
+.filter-bar-right .dxbl-btn {
+    height: 34px;
+}
+
 .max-width-40 { max-width: 40%; }
 
 .margin-top-120 { margin-top: 120px; }
@@ -121,9 +181,15 @@ html, body, #app {
 .text-align-end { text-align: end; }
 
 .btn-tooltip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 14rem;
-    font-size: 0.7rem;
-    padding: 4px 4px;
+    padding: 5px;
+    background-color: #eef2f6;
+    color: #475467;
+    border: 1px solid #dbe2ea;
+    cursor: pointer;
 }
 
 .width-10 { width: 10%; }
@@ -333,5 +399,5 @@ sub {
 }
 
 .drop-area-color {
-    color: cadetblue !important;
+    color: var(--colors-primary-600) !important;
 }

--- a/COMETwebapp/wwwroot/css/overwrite.css
+++ b/COMETwebapp/wwwroot/css/overwrite.css
@@ -58,7 +58,26 @@ h3, .h3 {
 }
 
 .text-primary {
-    color: var(--colors-primary-500) !important;
+    color: var(--colors-primary-accessible) !important;
+}
+
+.dxbl-btn.dxbl-btn-primary {
+    --dxbl-btn-bg: var(--colors-primary-accessible);
+    --dxbl-btn-border-color: var(--colors-primary-accessible);
+    --dxbl-btn-hover-bg: var(--colors-primary-700);
+    --dxbl-btn-hover-border-color: var(--colors-primary-700);
+}
+
+.dxbl-btn-standalone.dxbl-btn-info {
+    --dxbl-btn-bg: #0e7490;
+    --dxbl-btn-border-color: #0e7490;
+    --dxbl-btn-color: var(--colors-white);
+    --dxbl-btn-hover-bg: #155e75;
+    --dxbl-btn-hover-border-color: #155e75;
+}
+
+.dxbl-btn-standalone.dxbl-btn-text-info {
+    --dxbl-btn-color: #0e7490;
 }
 
 .dxbl-grid-selected-row > td {
@@ -83,4 +102,10 @@ h3, .h3 {
 .open-tab-box-container .dxbl-fl-cpt.dxbl-text {
     color: var(--colors-gray-950);
     font-weight: 500;
+}
+.dxbl-tag-box > .dxbl-edit-btn-clear {
+    top: 0;
+    bottom: 0;
+    height: auto;
+    align-items: center;
 }

--- a/COMETwebapp/wwwroot/css/vars.css
+++ b/COMETwebapp/wwwroot/css/vars.css
@@ -26,7 +26,8 @@
     --colors-black: #111111;
     --colors-deep-black: #030511;
     --colors-white: #ffffff;
-    --bs-primary: var(--colors-primary-500);
+    --bs-primary: var(--colors-primary-600);
+    --colors-primary-accessible: var(--colors-primary-600);
     --bs-body-bg: var(--colors-gray-50);
     --text-2xl: 1.5rem;
     --text-3xl: 1.75rem;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
feat #812 Harmonize filter settings and styling across the application 
and I see also #887 

I am already sorry for how big this issue got as I wanted the to incorporate the cometbuttonstyle to harmonize the buttons everywhere, but by doing this almost every razor was already changed. So, most of the changes are just small buttonstyle changes and can be skipped. However, the behaviour lives in a few shared components. 

### What changed

Shared filter components
- New `FilterTagBox<TItem>`: one reusable multi-select filter tag box that every filter now uses (dashboards, Parameter Editor, Requirements). It bakes in contains-filtering, a clear-all button, full-name display, and stays a single row tall.
- New multi-select filters `MultiOptionSelector`, `MultiFiniteStateSelector`, `MultiElementBaseSelector` (with view models and interfaces), matching the existing `MultiCategorySelector` and `MultiParameterTypeSelector`. All five render through `FilterTagBox`.
- Shared `.filter-bar`, `.filter-bar-item`, `.filter-bar-right` layout in `app.css`, so every filter row has the same padding, sizing, and single-row behaviour.

Shared "View" menu
- New `ViewOptionsMenu` (cog button plus dropdown) used by Requirements, Parameter Editor, Model Editor, the System Representation product tree, and the Viewer. It has a down-caret and a fixed height matching the filter and search inputs.

Button and colour system, now fully centralized
- `CometButtonStyle` plus `ToButtonRenderStyle()` is the single source of truth for button styling. Every `RenderStyle` in the app now routes through it (add and save use Primary, delete uses Danger, cancel uses Secondary, edit uses Edit, neutral uses Light, tab and side-bar triggers use the new None). There are no raw `ButtonRenderStyle` values left in any razor file, so a button's look can be changed in one place.
- Added `CometButtonStyle.Edit` and `CometButtonStyle.None`.
- GH887: `vars.css` splits the brand blue into `--colors-primary-500` (kept for fills) and a darker accessible token used for text and controls that failed WCAG AA. `overwrite.css` and `styles.css` apply it.

Model Editor
- The two tree panels are restyled like the product tree, with connector lines, collapse chevrons, and drag auto-scroll (dragging a node near the top or bottom of a long list scrolls it, same as the product tree).
- Details panel reworked: a compact summary card with a gap before the parameter search bar, an Add dropdown, and category pills. The View cog, the model selector, the search bar, and the Add button share one right edge in both the wide and stacked layouts.
- Reduced the page side padding for the dense three-panel layout.
- Drag-over highlight changed from yellow to blue to match the product tree and Requirements.
- Aligned the search bar of all three panels for a less chaotic layout.

Requirements, dashboards, Parameter Editor, System Representation, Relationship Matrix
- Filter labels removed, wording set to "Filter by ...", filters made multi-select and full-name, and all moved onto the shared filter bar. Parameter Editor keeps Batch Update and View on the same row.
- Product tree has a horizontal scrollbar and shows full node names and all category pills.
- Product tree now also aligns the search bar with the detailspanel.

### Most important files to review (real changes)

- COMET.Web.Common/Components/Selectors/FilterTagBox.razor and .razor.cs
- COMET.Web.Common/Components/Selectors/Multi*Selector.razor and the new view models under COMET.Web.Common/ViewModels/Components/Selectors/
- COMET.Web.Common/Components/ViewOptionsMenu.razor, .razor.cs, .razor.css
- COMET.Web.Common/Enumerations/CometButtonStyle.cs and Extensions/CometButtonStyleExtensions.cs
- COMETwebapp/Components/Common/FormButtons.razor (the shared Save/Cancel/Delete used by all the edit forms)
- COMETwebapp/Components/ModelEditor/ModelEditor.razor, .razor.cs, .razor.css
- COMETwebapp/Components/ModelEditor/ElementDefinitionTree.razor and .razor.cs (drag auto-scroll)
- COMETwebapp/Components/Common/ElementDetailsPanel.* and DetailsPanelEditor.*
- COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor, .razor.cs, .razor.css
- COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor and .razor.cs
- COMETwebapp/Components/ModelDashboard/ModelDashboardBody.* and COMETwebapp/Components/SubscriptionDashboard/* (plus their view models)
- COMETwebapp/Components/Shared/CategoryPills.*, NodePills.razor, ProductTreeToolbar.*
- COMETwebapp/Components/SystemRepresentation/SystemNode.razor.css and SystemRepresentationBody.razor.css
- CSS: COMETwebapp/wwwroot/css/app.css, overwrite.css, vars.css, and COMET.Web.Common/wwwroot/css/styles.css

## Bulk mechanical changes (safe to skim)

Many razor files under EngineeringModel, ReferenceData, SiteDirectory, FileStore, and the various tables and forms changed only to adopt the icon set and to route their `RenderStyle` through `CometButtonStyle`. This is visually neutral, since each style maps one-to-one to the render style it had before. No logic changed in these files.

<img width="940" height="546" alt="image" src="https://github.com/user-attachments/assets/b7e69d73-0aea-46c7-9ff5-b2f7897075cb" />
<img width="940" height="510" alt="image" src="https://github.com/user-attachments/assets/cc5fee9c-8861-4b1e-8f19-409678cc6fd9" />
<img width="940" height="536" alt="image" src="https://github.com/user-attachments/assets/b1320bec-a365-4c2b-a7cd-f80df77cd46e" />
<img width="940" height="510" alt="image" src="https://github.com/user-attachments/assets/fbea91de-9473-4be9-a422-cc3cb7d51fd5" />
<img width="940" height="515" alt="image" src="https://github.com/user-attachments/assets/5652f6e5-52c1-40ff-bce6-a68ef8ea7e5e" />
<img width="940" height="538" alt="image" src="https://github.com/user-attachments/assets/b5f36fe6-cffd-47c6-b87f-53646dd70c76" />
<img width="940" height="502" alt="image" src="https://github.com/user-attachments/assets/d18f32dd-efdb-4826-9c82-faf9269c9325" />




