### PR TITLE
Feat #897 allow digit start for requirements, groups and specs name and shortname

### DIFF
--- a/COMET.Web.Common/App.razor.cs
+++ b/COMET.Web.Common/App.razor.cs
@@ -97,9 +97,18 @@ namespace COMET.Web.Common
                     {
                         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(navigationContext.CancellationToken);
                         await cancellationTokenSource.CancelAsync();
-                        cancellationTokenSource.Dispose();
 
-                        await Task.Delay(1, cancellationTokenSource.Token);
+                        try
+                        {
+                           await Task.Delay(1, cancellationTokenSource.Token);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                        finally
+                        {
+                            cancellationTokenSource.Dispose();
+                        }
 
                         this.NavigationManager.NavigateTo("/", replace: true);
                     }

--- a/COMETwebapp.Tests/Validators/EngineeringModel/RequirementValidatorsTestFixture.cs
+++ b/COMETwebapp.Tests/Validators/EngineeringModel/RequirementValidatorsTestFixture.cs
@@ -48,8 +48,11 @@ namespace COMETwebapp.Tests.Validators.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(validator.Validate(new Requirement()).IsValid, Is.False, "An empty requirement is invalid.");
-                Assert.That(validator.Validate(new Requirement { Name = "First", ShortName = "1REQ" }).IsValid, Is.False, "A short name starting with a digit is invalid.");
+                Assert.That(validator.Validate(new Requirement { Name = "First", ShortName = "1REQ" }).IsValid, Is.True, "A short name starting with a digit is allowed (GH897).");
+                Assert.That(validator.Validate(new Requirement { Name = "1 First", ShortName = "REQ1" }).IsValid, Is.True, "A name starting with a digit is allowed (GH897).");
                 Assert.That(validator.Validate(new Requirement { Name = "First", ShortName = "REQ1" }).IsValid, Is.True);
+                Assert.That(validator.Validate(new Requirement { Name = "Bad (draft)", ShortName = "REQ" }).IsValid, Is.False, "A name with parentheses is invalid.");
+                Assert.That(validator.Validate(new Requirement { Name = "First", ShortName = "RE Q" }).IsValid, Is.False, "A short name with a space is invalid.");
             });
         }
 
@@ -61,8 +64,9 @@ namespace COMETwebapp.Tests.Validators.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(validator.Validate(new RequirementsGroup()).IsValid, Is.False);
-                Assert.That(validator.Validate(new RequirementsGroup { Name = "Group", ShortName = "1GRP" }).IsValid, Is.False);
+                Assert.That(validator.Validate(new RequirementsGroup { Name = "1 Group", ShortName = "1GRP" }).IsValid, Is.True, "A name and short name starting with a digit are allowed (GH897).");
                 Assert.That(validator.Validate(new RequirementsGroup { Name = "Group", ShortName = "GRP" }).IsValid, Is.True);
+                Assert.That(validator.Validate(new RequirementsGroup { Name = "Group (draft)", ShortName = "GRP" }).IsValid, Is.False, "A name with parentheses is invalid.");
             });
         }
 
@@ -74,8 +78,9 @@ namespace COMETwebapp.Tests.Validators.EngineeringModel
             Assert.Multiple(() =>
             {
                 Assert.That(validator.Validate(new RequirementsSpecification()).IsValid, Is.False);
-                Assert.That(validator.Validate(new RequirementsSpecification { Name = "Spec", ShortName = "1SPEC" }).IsValid, Is.False);
+                Assert.That(validator.Validate(new RequirementsSpecification { Name = "1 Spec", ShortName = "1SPEC" }).IsValid, Is.True, "A name and short name starting with a digit are allowed (GH897).");
                 Assert.That(validator.Validate(new RequirementsSpecification { Name = "Spec", ShortName = "SPEC" }).IsValid, Is.True);
+                Assert.That(validator.Validate(new RequirementsSpecification { Name = "Spec (draft)", ShortName = "SPEC" }).IsValid, Is.False, "A name with parentheses is invalid.");
             });
         }
     }

--- a/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModelTestFixture.cs
@@ -28,6 +28,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
     using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using CDP4Web.Enumerations;
 
@@ -782,6 +783,45 @@ namespace COMETwebapp.Tests.ViewModels.Components.RequirementsEditor
                 It.IsAny<Thing>(),
                 It.Is<IReadOnlyCollection<Thing>>(things => things.OfType<Definition>().Any(d => d.LanguageCode == "fr" && d.Content == "Some new definition text.")),
                 It.IsAny<NotificationDescription>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifySaveReloadsOnlyOnceViaEndUpdate()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            // a brand-new owner the cached AvailableOwners does not yet know about; it only appears when the document reloads
+            var newOwner = new DomainOfExpertise { Iid = Guid.NewGuid(), ShortName = "PWR", Name = "Power" };
+            this.specification.Requirement.Add(new Requirement { Iid = Guid.NewGuid(), ShortName = "R42", Name = "Added", Owner = newOwner });
+
+            await this.viewModel.SaveInlineDefinitionAsync(this.topRequirement, "A changed definition.");
+
+            // the save no longer reloads the document on its own — that redundant reload was the second refresh (GH897)
+            Assert.That(this.viewModel.AvailableOwners, Does.Not.Contain(newOwner), "a save must not reload the document on its own");
+
+            // the single reload is driven centrally by the EndUpdate session event the write raises
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.EndUpdate));
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            Assert.That(this.viewModel.AvailableOwners, Does.Contain(newOwner), "OnEndUpdate reloads the document exactly once");
+        }
+
+        [Test]
+        public async Task VerifyNavigateToGroup()
+        {
+            await TaskHelper.WaitWhileAsync(() => this.viewModel.IsLoading);
+
+            // collapse the ancestor so the nested target would otherwise be hidden in the document
+            this.viewModel.ToggleDocumentGroup(this.operateGroup.Iid);
+            Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.True);
+
+            this.viewModel.NavigateToGroup(this.c4iGroup);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewModel.ScrollTargetGroup, Is.EqualTo(this.c4iGroup), "the clicked group is flagged as the scroll target");
+                Assert.That(this.viewModel.IsDocumentGroupCollapsed(this.operateGroup.Iid), Is.False, "the target's ancestor groups are expanded so it renders");
+            });
         }
 
         [Test]

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.cs
@@ -78,13 +78,14 @@ namespace COMETwebapp.Components.RequirementsEditor
             this.Disposables.Add(this.WhenAnyValue(
                     x => x.ViewModel.IsOnEditMode,
                     x => x.ViewModel.IsLoading,
+                    x => x.ViewModel.ScrollTargetGroup,
                     x => x.ViewModel.ConfirmCancelPopupViewModel.IsVisible)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
         }
 
         /// <summary>
-        /// Scrolls the document to the <see cref="IRequirementsEditorBodyViewModel.ScrollTarget" /> once it has been
-        /// rendered, after a traceability link navigated to it.
+        /// Scrolls the document to the requirement or group flagged as a scroll target once it has been rendered, after a
+        /// traceability link or a table-of-contents entry navigated to it.
         /// </summary>
         /// <param name="firstRender">true on the first render of the component</param>
         /// <returns>A <see cref="Task" /></returns>
@@ -92,22 +93,37 @@ namespace COMETwebapp.Components.RequirementsEditor
         {
             await base.OnAfterRenderAsync(firstRender);
 
-            var target = this.ViewModel?.ScrollTarget;
+            var requirementTarget = this.ViewModel?.ScrollTarget;
+            var groupTarget = this.ViewModel?.ScrollTargetGroup;
 
-            if (target != null)
+            if (requirementTarget != null)
             {
                 this.ViewModel.ScrollTarget = null;
+                await this.ScrollElementIntoView(RequirementsDocument.RequirementAnchorId(requirementTarget));
+            }
+            else if (groupTarget != null)
+            {
+                this.ViewModel.ScrollTargetGroup = null;
+                await this.ScrollElementIntoView(RequirementsDocument.GroupAnchorId(groupTarget));
+            }
+        }
 
-                try
-                {
-                    await this.DomDataService.ScrollElementIntoView(RequirementsDocument.RequirementAnchorId(target));
-                }
-                catch (Exception exception) when (exception is JSException or JSDisconnectedException)
-                {
-                    // The scroll is purely cosmetic; a stale cached DomData.js (missing ScrollElementIntoView) or a
-                    // circuit that disconnected mid-render must never kill the page. Navigation already switched the
-                    // specification and expanded the target's groups.
-                }
+        /// <summary>
+        /// Scrolls the element with the given <paramref name="anchorId" /> into view, swallowing the interop errors that
+        /// are harmless for a purely cosmetic scroll.
+        /// </summary>
+        /// <param name="anchorId">The HTML id of the element to scroll to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task ScrollElementIntoView(string anchorId)
+        {
+            try
+            {
+                await this.DomDataService.ScrollElementIntoView(anchorId);
+            }
+            catch (Exception exception) when (exception is JSException or JSDisconnectedException)
+            {
+                // The scroll is purely cosmetic; a stale cached DomData.js (missing ScrollElementIntoView) or a circuit
+                // that disconnected mid-render must never kill the page. Navigation already switched to the target.
             }
         }
 

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsEditorBody.razor.css
@@ -222,6 +222,12 @@
 .req-toc ::deep .req-tree-group {
     color: #344054;
     text-decoration: none;
+    cursor: pointer;
+    border: none;
+    background: none;
+    padding: 0;
+    font: inherit;
+    text-align: left;
 }
 
 .req-toc ::deep .req-tree-group:hover {
@@ -277,6 +283,8 @@
     border-radius: 6px;
     margin: 16px 0 8px;
     padding: 6px 10px;
+    /* the TOC jumps to this element via a #anchor; offset it below the sticky spec-title header, like .req-row */
+    scroll-margin-top: 60px;
 }
 
 .req-document ::deep .req-group-level-1 {

--- a/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
+++ b/COMETwebapp/Components/RequirementsEditor/RequirementsTree.razor
@@ -76,7 +76,7 @@ else
                     {
                         <span class="req-tree-chevron-placeholder"></span>
                     }
-                    <a class="req-tree-group" draggable="false" href="#@RequirementsDocument.GroupAnchorId(group)" title="@group.Name">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</a>
+                    <button type="button" class="req-tree-group" title="@group.Name" @onclick="@(() => this.ViewModel.NavigateToGroup(group))">@(this.ViewModel.TreeUsesShortName ? group.ShortName : group.Name)</button>
                     <RequirementPills ViewModel="@this.ViewModel" Owner="@group.Owner" Categories="@group.Category" />
                 </div>
                 @if (hasChildren && !collapsed)

--- a/COMETwebapp/Validators/EngineeringModel/RequirementValidationRules.cs
+++ b/COMETwebapp/Validators/EngineeringModel/RequirementValidationRules.cs
@@ -1,0 +1,54 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="RequirementValidationRules.cs" company="Starion Group S.A.">
+//     Copyright (c) 2023-2026 Starion Group S.A.
+//
+//     This file is part of COMET WEB Community Edition
+//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//     The COMET WEB Community Edition is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Affero General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or (at your option) any later version.
+//
+//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMETwebapp.Validators.EngineeringModel
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Holds the name and short-name validation rules shared by the <see cref="Requirement" />,
+    /// <see cref="RequirementsGroup" /> and <see cref="RequirementsSpecification" /> validators. Unlike the default
+    /// ECSS-E-TM-10-25 name rule, these allow the first character to be a digit, so a requirement, group or specification
+    /// can be numbered to control its reading order. This mirrors the desktop IME's <c>ImeValidationService</c>.
+    /// </summary>
+    public static class RequirementValidationRules
+    {
+        /// <summary>
+        /// The regular expression a <see cref="DefinedThing.Name" /> must match: it may start with a letter or a digit,
+        /// and must not contain parentheses or a trailing space. Same intent as the shared "Name" rule, but the first
+        /// character may also be a digit (identical to the desktop IME's <c>RequirementName</c> rule).
+        /// </summary>
+        public const string NameRule = @"^([\p{L}\d]|[\p{L}\d][^()]*[^()\s])$";
+
+        /// <summary>
+        /// The error text shown when a name does not match <see cref="NameRule" />.
+        /// </summary>
+        public const string NameRuleErrorText = "The Name must start with a letter or a digit and not contain any parentheses or trailing spaces.";
+
+        /// <summary>
+        /// The key of the CDP4-COMET-SDK validation rule to use for a requirement short name. The SDK's
+        /// <c>RequirementShortName</c> rule already allows a leading digit (alphanumeric characters and dashes), unlike
+        /// the generic "ShortName" rule which forbids one.
+        /// </summary>
+        public const string ShortNameRuleKey = "RequirementShortName";
+    }
+}

--- a/COMETwebapp/Validators/EngineeringModel/RequirementValidator.cs
+++ b/COMETwebapp/Validators/EngineeringModel/RequirementValidator.cs
@@ -30,8 +30,8 @@ namespace COMETwebapp.Validators.EngineeringModel
     using FluentValidation;
 
     /// <summary>
-    /// A class to validate the <see cref="Requirement" />, enforcing the ECSS-E-TM-10-25 name and short-name rules
-    /// (e.g. a short name may not start with a digit).
+    /// A class to validate the <see cref="Requirement" />, enforcing the ECSS-E-TM-10-25 name and short-name rules while
+    /// allowing the name and short name to start with a digit (so requirements can be numbered to control their order).
     /// </summary>
     public class RequirementValidator : AbstractValidator<Requirement>
     {
@@ -41,8 +41,8 @@ namespace COMETwebapp.Validators.EngineeringModel
         /// <param name="validationService">The <see cref="IValidationService" /></param>
         public RequirementValidator(IValidationService validationService)
         {
-            this.RuleFor(x => x.Name).Validate(validationService, nameof(Requirement.Name));
-            this.RuleFor(x => x.ShortName).Validate(validationService, nameof(Requirement.ShortName));
+            this.RuleFor(x => x.Name).Matches(RequirementValidationRules.NameRule).WithMessage(RequirementValidationRules.NameRuleErrorText);
+            this.RuleFor(x => x.ShortName).Validate(validationService, RequirementValidationRules.ShortNameRuleKey);
         }
     }
 }

--- a/COMETwebapp/Validators/EngineeringModel/RequirementsGroupValidator.cs
+++ b/COMETwebapp/Validators/EngineeringModel/RequirementsGroupValidator.cs
@@ -31,7 +31,7 @@ namespace COMETwebapp.Validators.EngineeringModel
 
     /// <summary>
     /// A class to validate the <see cref="RequirementsGroup" />, enforcing the ECSS-E-TM-10-25 name and short-name rules
-    /// (e.g. a short name may not start with a digit).
+    /// while allowing the name and short name to start with a digit (so groups can be numbered to control their order).
     /// </summary>
     public class RequirementsGroupValidator : AbstractValidator<RequirementsGroup>
     {
@@ -41,8 +41,8 @@ namespace COMETwebapp.Validators.EngineeringModel
         /// <param name="validationService">The <see cref="IValidationService" /></param>
         public RequirementsGroupValidator(IValidationService validationService)
         {
-            this.RuleFor(x => x.Name).Validate(validationService, nameof(RequirementsGroup.Name));
-            this.RuleFor(x => x.ShortName).Validate(validationService, nameof(RequirementsGroup.ShortName));
+            this.RuleFor(x => x.Name).Matches(RequirementValidationRules.NameRule).WithMessage(RequirementValidationRules.NameRuleErrorText);
+            this.RuleFor(x => x.ShortName).Validate(validationService, RequirementValidationRules.ShortNameRuleKey);
         }
     }
 }

--- a/COMETwebapp/Validators/EngineeringModel/RequirementsSpecificationValidator.cs
+++ b/COMETwebapp/Validators/EngineeringModel/RequirementsSpecificationValidator.cs
@@ -31,7 +31,8 @@ namespace COMETwebapp.Validators.EngineeringModel
 
     /// <summary>
     /// A class to validate the <see cref="RequirementsSpecification" />, enforcing the ECSS-E-TM-10-25 name and short-name
-    /// rules (e.g. a short name may not start with a digit).
+    /// rules while allowing the name and short name to start with a digit (so specifications can be numbered to control
+    /// their order).
     /// </summary>
     public class RequirementsSpecificationValidator : AbstractValidator<RequirementsSpecification>
     {
@@ -41,8 +42,8 @@ namespace COMETwebapp.Validators.EngineeringModel
         /// <param name="validationService">The <see cref="IValidationService" /></param>
         public RequirementsSpecificationValidator(IValidationService validationService)
         {
-            this.RuleFor(x => x.Name).Validate(validationService, nameof(RequirementsSpecification.Name));
-            this.RuleFor(x => x.ShortName).Validate(validationService, nameof(RequirementsSpecification.ShortName));
+            this.RuleFor(x => x.Name).Matches(RequirementValidationRules.NameRule).WithMessage(RequirementValidationRules.NameRuleErrorText);
+            this.RuleFor(x => x.ShortName).Validate(validationService, RequirementValidationRules.ShortNameRuleKey);
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/IRequirementsEditorBodyViewModel.cs
@@ -166,6 +166,13 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         Requirement ScrollTarget { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="RequirementsGroup" /> the document should scroll to on the next render, set by
+        /// <see cref="NavigateToGroup" /> when a table-of-contents entry is clicked and cleared by the component once the
+        /// scroll has happened.
+        /// </summary>
+        RequirementsGroup ScrollTargetGroup { get; set; }
+
+        /// <summary>
         /// Gets the distinct <see cref="ParameterType" />s used by the <see cref="SimpleParameterValue" />s of the
         /// non-deprecated requirements of the selected specification, ordered by short name. The columns are stable
         /// across search and owner/category filtering.
@@ -320,6 +327,13 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         /// </summary>
         /// <param name="requirement">The <see cref="Requirement" /> to navigate to</param>
         void NavigateToRequirement(Requirement requirement);
+
+        /// <summary>
+        /// Navigates the document to the given <paramref name="group" /> from a table-of-contents click: it expands the
+        /// group's ancestor document groups and flags it as the <see cref="ScrollTargetGroup" />.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> to navigate to</param>
+        void NavigateToGroup(RequirementsGroup group);
 
         /// <summary>
         /// Gets or sets the <see cref="RequirementsGroup" /> currently being dragged in the table of contents to change

--- a/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/RequirementsEditor/RequirementsEditorBodyViewModel.cs
@@ -163,6 +163,11 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         private Requirement scrollTarget;
 
         /// <summary>
+        /// Backing field for <see cref="ScrollTargetGroup" />
+        /// </summary>
+        private RequirementsGroup scrollTargetGroup;
+
+        /// <summary>
         /// Memoised result of <see cref="GetSpecificationParameterTypes" /> - it is queried once per requirement row,
         /// so caching it keeps document rendering linear in the number of requirements.
         /// </summary>
@@ -353,6 +358,18 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         {
             get => this.scrollTarget;
             set => this.RaiseAndSetIfChanged(ref this.scrollTarget, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RequirementsGroup" /> the document should scroll to on the next render, set by
+        /// <see cref="NavigateToGroup" /> when a table-of-contents entry is clicked and cleared by the component once the
+        /// scroll has happened. A dedicated JS scroll (not a native <c>#anchor</c>) is used so the click never triggers a
+        /// Blazor route navigation.
+        /// </summary>
+        public RequirementsGroup ScrollTargetGroup
+        {
+            get => this.scrollTargetGroup;
+            set => this.RaiseAndSetIfChanged(ref this.scrollTargetGroup, value);
         }
 
         /// <summary>
@@ -565,8 +582,6 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
             try
             {
-                this.IsLoading = true;
-
                 var clone = requirement.Clone(true);
                 var definition = clone.Definition.FirstOrDefault();
 
@@ -582,20 +597,13 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
                 var thingsToWrite = new List<Thing> { specificationClone, clone };
                 thingsToWrite.AddRange(clone.Definition);
 
-                var result = await this.SessionService.CreateOrUpdateThingsWithNotification(specificationClone, thingsToWrite, BuildNotification(requirement, "updated", "update"));
-
-                if (result.IsSuccess)
-                {
-                    await this.ReloadPreservingSelection();
-                }
+                // both the reload AND the loading indicator are owned by OnThingChanged (driven by the EndUpdate session
+                // event the write raises); doing them here as well is what made the document load twice on every save (GH897)
+                await this.SessionService.CreateOrUpdateThingsWithNotification(specificationClone, thingsToWrite, BuildNotification(requirement, "updated", "update"));
             }
             catch (Exception exception)
             {
                 this.logger.LogError(exception, "An error occurred while editing the definition of the Requirement with iid {Iid}", requirement.Iid);
-            }
-            finally
-            {
-                this.IsLoading = false;
             }
         }
 
@@ -678,33 +686,17 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
                 return Result.Fail("The group cannot be moved to that location.");
             }
 
-            try
-            {
-                // toggling IsLoading is what makes the body (tree AND document) re-render with the new nesting once the
-                // write returns — every other write in this VM follows the same IsLoading + ReloadPreservingSelection pattern
-                this.IsLoading = true;
+            // mirrors the desktop IME (RequirementsSpecificationRowViewModel.MoveGroup): only the NEW container is
+            // updated, with the moved group added to its Group list — the server re-parents it and removes it from
+            // its old container. Sending the old container or the group as separate updates trips the server's
+            // acyclic check (NullReferenceException in RequirementsGroupSideEffect) because it sees inconsistent state.
+            var newContainerClone = (RequirementsContainer)target.Clone(false);
+            newContainerClone.Group.Add(group.Clone(false));
 
-                // mirrors the desktop IME (RequirementsSpecificationRowViewModel.MoveGroup): only the NEW container is
-                // updated, with the moved group added to its Group list — the server re-parents it and removes it from
-                // its old container. Sending the old container or the group as separate updates trips the server's
-                // acyclic check (NullReferenceException in RequirementsGroupSideEffect) because it sees inconsistent state.
-                var newContainerClone = (RequirementsContainer)target.Clone(false);
-                newContainerClone.Group.Add(group.Clone(false));
-
-                var result = await this.SessionService.CreateOrUpdateThingsWithNotification(newContainerClone, [newContainerClone],
-                    BuildNotification(group, "moved", "move"));
-
-                if (result.IsSuccess)
-                {
-                    await this.ReloadPreservingSelection();
-                }
-
-                return result;
-            }
-            finally
-            {
-                this.IsLoading = false;
-            }
+            // the body re-renders with the new nesting through OnThingChanged (driven by the EndUpdate session event the
+            // write raises), which also owns the loading indicator — the VM no longer toggles IsLoading itself (GH897)
+            return await this.SessionService.CreateOrUpdateThingsWithNotification(newContainerClone, [newContainerClone],
+                BuildNotification(group, "moved", "move"));
         }
 
         /// <summary>
@@ -1130,6 +1122,22 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
         }
 
         /// <summary>
+        /// Navigates the document to the given <paramref name="group" /> from a table-of-contents click: it expands the
+        /// group's ancestor document groups (so the target header is rendered) and flags it as the
+        /// <see cref="ScrollTargetGroup" /> so the component scrolls to it.
+        /// </summary>
+        /// <param name="group">The <see cref="RequirementsGroup" /> to navigate to</param>
+        public void NavigateToGroup(RequirementsGroup group)
+        {
+            for (var ancestor = group.Container as RequirementsGroup; ancestor != null; ancestor = ancestor.Container as RequirementsGroup)
+            {
+                this.collapsedDocumentGroups.Remove(ancestor.Iid);
+            }
+
+            this.ScrollTargetGroup = group;
+        }
+
+        /// <summary>
         /// Handles the refresh of the current session by reloading the specifications while preserving the selection.
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>
@@ -1218,8 +1226,6 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
             try
             {
-                this.IsLoading = true;
-
                 var thingsToWrite = new List<Thing> { thing };
                 var topContainer = this.PrepareTopContainer(thing, thingsToWrite);
 
@@ -1235,17 +1241,14 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
                 if (result.IsSuccess)
                 {
+                    // both the reload AND the loading indicator are owned by OnThingChanged (driven by the EndUpdate session
+                    // event the write raises); doing them here as well is what made the document load twice on every save (GH897)
                     this.IsOnEditMode = false;
-                    await this.ReloadPreservingSelection();
                 }
             }
             catch (Exception exception)
             {
                 this.logger.LogError(exception, "An error occurred while saving the {ClassKind} with iid {Iid}", thing.ClassKind, thing.Iid);
-            }
-            finally
-            {
-                this.IsLoading = false;
             }
         }
 
@@ -1380,26 +1383,17 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
             try
             {
-                this.IsLoading = true;
-
                 var clone = thing.Clone(false);
                 ((IDeprecatableThing)clone).IsDeprecated = deprecate;
                 var containerClone = thing.Container.Clone(false);
 
-                var result = await this.SessionService.CreateOrUpdateThingsWithNotification(containerClone, [containerClone, clone], BuildNotification(thing, deprecate ? "deprecated" : "restored", deprecate ? "deprecate" : "restore"));
-
-                if (result.IsSuccess)
-                {
-                    await this.ReloadPreservingSelection();
-                }
+                // both the reload AND the loading indicator are owned by OnThingChanged (driven by the EndUpdate session
+                // event the write raises); doing them here as well is what made the document load twice on every save (GH897)
+                await this.SessionService.CreateOrUpdateThingsWithNotification(containerClone, [containerClone, clone], BuildNotification(thing, deprecate ? "deprecated" : "restored", deprecate ? "deprecate" : "restore"));
             }
             catch (Exception exception)
             {
                 this.logger.LogError(exception, "An error occurred while changing the deprecation of the {ClassKind} with iid {Iid}", thing.ClassKind, thing.Iid);
-            }
-            finally
-            {
-                this.IsLoading = false;
             }
         }
 
@@ -1414,30 +1408,18 @@ namespace COMETwebapp.ViewModels.Components.RequirementsEditor
 
             try
             {
-                this.IsLoading = true;
-
                 var containerClone = thing.Container.Clone(false);
                 var clone = thing.Clone(false);
 
-                var result = await this.SessionService.DeleteThingsWithNotification(containerClone, [clone], BuildNotification(thing, "deleted", "delete"));
-
-                if (result.IsSuccess)
-                {
-                    if (ReferenceEquals(this.SelectedSpecification, thing))
-                    {
-                        this.SelectedSpecification = null;
-                    }
-
-                    await this.ReloadPreservingSelection();
-                }
+                // both the reload AND the loading indicator are owned by OnThingChanged (driven by the EndUpdate session
+                // event the write raises) — see GH897. When the deleted thing was the selected specification,
+                // ReloadPreservingSelection cannot restore it (it is gone from AvailableSpecifications) so OnThingChanged
+                // falls back to the first remaining specification.
+                await this.SessionService.DeleteThingsWithNotification(containerClone, [clone], BuildNotification(thing, "deleted", "delete"));
             }
             catch (Exception exception)
             {
                 this.logger.LogError(exception, "An error occurred while deleting the {ClassKind} with iid {Iid}", thing.ClassKind, thing.Iid);
-            }
-            finally
-            {
-                this.IsLoading = false;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #897 Allow digit-start names for requirements + Requirements Editor save/nav fixes

### Changes

**Allow digit-start Name and ShortName**
Requirements, groups and specifications can now start their Name and ShortName with a digit, so they can be numbered to control reading order. ShortName reuses the SDK's `RequirementShortName` rule; Name uses the same digit-allowing pattern as the desktop IME. Shared regex lives in a new `RequirementValidationRules` helper. No SDK or shared validator changes.

**Save no longer refreshes twice**
Each save reloaded the document explicitly and again via the `EndUpdate` event, and toggled `IsLoading` on top of the reload's own toggle. Removed the redundant explicit reloads and `IsLoading` toggling so `OnEndUpdate` / `OnThingChanged` is the single owner of the reload and loading indicator. Split view cross-panel reload is unchanged.

**Table of contents scroll and crash**
Added `scroll-margin-top` to group headers so a target no longer lands under the sticky header. The table of contents now scrolls with JavaScript instead of a `#anchor` link, which was triggering the router and crashing with `ObjectDisposedException` in `App.OnNavigate`. Also fixed `App.OnNavigate` to read the cancellation token before disposing it, so its redirect works instead of throwing.


