### PR TITLE
fix #894 login validation

### DIFF
--- a/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
@@ -205,6 +205,28 @@ namespace COMET.Web.Common.Tests.Components
         }
 
         [Test]
+        public void VerifyFullTrustHintIsShownAndSourceAddressNotRequiredWhenPreconfigured()
+        {
+            var renderer = this.context.Render<Login>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Find(".full-trust-hint").TextContent, Is.Not.Empty);
+                Assert.That(this.viewModel.AuthenticationDto.ShouldValidateSourceAddress, Is.False);
+            });
+        }
+
+        [Test]
+        public void VerifySourceAddressRequiredWhenNotPreconfigured()
+        {
+            this.serverConfiguration.ServerAddress = null;
+
+            this.context.Render<Login>();
+
+            Assert.That(this.viewModel.AuthenticationDto.ShouldValidateSourceAddress, Is.True);
+        }
+
+        [Test]
         public async Task VerifyMultipleAuthenticationSchemeFlowWithInternalToken()
         {
             this.serverConfiguration.ServerAddress = null;

--- a/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
+++ b/COMET.Web.Common.Tests/Components/LoginTestFixture.cs
@@ -227,6 +227,18 @@ namespace COMET.Web.Common.Tests.Components
         }
 
         [Test]
+        public async Task VerifySourceAddressRequiredMessageIsRendered()
+        {
+            this.serverConfiguration.ServerAddress = null;
+
+            var renderer = this.context.Render<Login>();
+
+            await renderer.Find("#connectbtn").ClickAsync(new MouseEventArgs());
+
+            Assert.That(renderer.Find(".validation-errors").TextContent, Does.Contain("The Source Address is required."));
+        }
+
+        [Test]
         public async Task VerifyMultipleAuthenticationSchemeFlowWithInternalToken()
         {
             this.serverConfiguration.ServerAddress = null;

--- a/COMET.Web.Common.Tests/Validators/AuthenticationDtoValidatorTestFixture.cs
+++ b/COMET.Web.Common.Tests/Validators/AuthenticationDtoValidatorTestFixture.cs
@@ -1,0 +1,117 @@
+// --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="AuthenticationDtoValidatorTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2023-2026 Starion Group S.A.
+//
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+namespace COMET.Web.Common.Tests.Validators
+{
+    using COMET.Web.Common.Model.DTO;
+    using COMET.Web.Common.Validators;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AuthenticationDtoValidatorTestFixture
+    {
+        private AuthenticationDtoValidator validator;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.validator = new AuthenticationDtoValidator();
+        }
+
+        [Test]
+        public void VerifySourceAddressValidation()
+        {
+            var dto = new AuthenticationDto
+            {
+                ShouldValidateSourceAddress = true,
+                ShouldValidateCredentials = false
+            };
+
+            var emptyErrors = this.validator.Validate(dto).Errors;
+
+            dto.SourceAddress = "not a url";
+            var invalidErrors = this.validator.Validate(dto).Errors;
+
+            dto.SourceAddress = "ftp://localhost:5000";
+            var wrongSchemeErrors = this.validator.Validate(dto).Errors;
+
+            dto.SourceAddress = "http://localhost:5000";
+            var validErrors = this.validator.Validate(dto).Errors;
+
+            dto.SourceAddress = "https://localhost:5000";
+            var validHttpsErrors = this.validator.Validate(dto).Errors;
+
+            var notRequired = new AuthenticationDto
+            {
+                ShouldValidateSourceAddress = false,
+                ShouldValidateCredentials = false
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(emptyErrors.Select(x => x.ErrorMessage), Does.Contain("The Source Address is required."));
+                Assert.That(invalidErrors.Select(x => x.ErrorMessage), Does.Contain("The Source Address should be a valid HTTP or HTTPS URL."));
+                Assert.That(wrongSchemeErrors.Select(x => x.ErrorMessage), Does.Contain("The Source Address should be a valid HTTP or HTTPS URL."));
+                Assert.That(validErrors, Is.Empty);
+                Assert.That(validHttpsErrors, Is.Empty);
+                Assert.That(this.validator.Validate(notRequired).Errors, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyCredentialsValidationMessagesMatchLabels()
+        {
+            var dto = new AuthenticationDto
+            {
+                ShouldValidateCredentials = true,
+                ShouldValidateSourceAddress = false
+            };
+
+            var errors = this.validator.Validate(dto).Errors.Select(x => x.ErrorMessage).ToList();
+
+            dto.UserName = "user";
+            dto.Password = "pass";
+            var noErrors = this.validator.Validate(dto).Errors;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors, Does.Contain("The Username is required."));
+                Assert.That(errors, Does.Contain("The Password is required."));
+                Assert.That(noErrors, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void VerifyCredentialsAreNotValidatedWhenNotRequired()
+        {
+            var dto = new AuthenticationDto
+            {
+                ShouldValidateCredentials = false,
+                ShouldValidateSourceAddress = false
+            };
+
+            Assert.That(this.validator.Validate(dto).Errors, Is.Empty);
+        }
+    }
+}

--- a/COMET.Web.Common/Components/Login.razor
+++ b/COMET.Web.Common/Components/Login.razor
@@ -29,7 +29,7 @@
 <EditForm Context="editFormContext" Model="@this.ViewModel.AuthenticationDto" OnValidSubmit="this.HandleSubmitAsync" id="login-form" data-app-ready="@(this.formReady ? "true" : null)">
     <FluentValidationValidator />
     <DxFormLayout CaptionPosition="CaptionPosition.Vertical">
-        @if (string.IsNullOrEmpty(this.ServerConfiguration.ServerAddress) && this.ShouldProvideServerInformationInput())
+        @if (this.ShouldProvideSourceAddressInput())
         {
             <DxFormLayoutItem Caption="Source Address:" ColSpanLg="12">
                 <Template>
@@ -76,10 +76,11 @@
                 <Template>
                     <DxCheckBox Id="fulltrust"
                                 @bind-Checked="@(this.ViewModel.AuthenticationDto.FullTrust)"
-                                Enabled="@(this.ServerConfiguration.FullTrustConfiguration?.IsTrusted == FullTrustTrustedKind.UserDefined)">
+                                Enabled="@(this.ServerConfiguration.FullTrustConfiguration?.IsTrusted == FullTrustTrustedKind.UserDefined)"
+                                Attributes="@(new Dictionary<string, object> { ["aria-describedby"] = "fulltrust-hint" })">
                         @this.FullTrustLabel
                     </DxCheckBox>
-                    <div class="full-trust-hint font-size-small">Allow connecting to servers that present a self-signed certificate.</div>
+                    <div id="fulltrust-hint" class="full-trust-hint font-size-small">Allow connecting to servers that present a self-signed certificate.</div>
                 </Template>
             </DxFormLayoutItem>
         }

--- a/COMET.Web.Common/Components/Login.razor
+++ b/COMET.Web.Common/Components/Login.razor
@@ -72,12 +72,14 @@
         @if ((this.ServerConfiguration.FullTrustConfiguration?.IsVisible == true || this.ServerConfiguration.FullTrustConfiguration?.IsTrusted == FullTrustTrustedKind.UserDefined)
              && this.ShouldProvideServerInformationInput())
         {
-            <DxFormLayoutItem Caption="@(this.FullTrustLabel)" BeginRow="true" ColSpanLg="12" CaptionPosition="CaptionPosition.Horizontal">
+            <DxFormLayoutItem BeginRow="true" ColSpanLg="12">
                 <Template>
                     <DxCheckBox Id="fulltrust"
                                 @bind-Checked="@(this.ViewModel.AuthenticationDto.FullTrust)"
-                                Enabled="@(this.ServerConfiguration.FullTrustConfiguration?.IsTrusted == FullTrustTrustedKind.UserDefined)"
-                                Attributes="@(new Dictionary<string, object> {  ["title"] = "Checking this option will allow connecting to servers with self signed certificates" })" />
+                                Enabled="@(this.ServerConfiguration.FullTrustConfiguration?.IsTrusted == FullTrustTrustedKind.UserDefined)">
+                        @this.FullTrustLabel
+                    </DxCheckBox>
+                    <div class="full-trust-hint font-size-small">Allow connecting to servers that present a self-signed certificate.</div>
                 </Template>
             </DxFormLayoutItem>
         }

--- a/COMET.Web.Common/Components/Login.razor.cs
+++ b/COMET.Web.Common/Components/Login.razor.cs
@@ -87,7 +87,7 @@ namespace COMET.Web.Common.Components
         /// The label for the full trust checkbox field
         /// </summary>
         [Parameter]
-        public string FullTrustLabel { get; set; } = "Full Trust:";
+        public string FullTrustLabel { get; set; } = "Full Trust";
         
         /// <summary>
         /// The text of the login button
@@ -258,6 +258,7 @@ namespace COMET.Web.Common.Components
 
             this.ErrorMessages = errors;
             this.ViewModel.AuthenticationDto.ShouldValidateCredentials = this.RequiresUserNameAndPasswordInput();
+            this.ViewModel.AuthenticationDto.ShouldValidateSourceAddress = this.ShouldProvideServerInformationInput() && string.IsNullOrEmpty(this.ServerConfiguration.ServerAddress);
             this.InvokeAsync(this.StateHasChanged);
         }
 

--- a/COMET.Web.Common/Components/Login.razor.cs
+++ b/COMET.Web.Common/Components/Login.razor.cs
@@ -75,7 +75,7 @@ namespace COMET.Web.Common.Components
         /// The label for the username input field
         /// </summary>
         [Parameter]
-        public string UsernameLabel { get; set; } = "UserName:";
+        public string UsernameLabel { get; set; } = "Username:";
 
         /// <summary>
         /// The label for the password input field
@@ -258,7 +258,7 @@ namespace COMET.Web.Common.Components
 
             this.ErrorMessages = errors;
             this.ViewModel.AuthenticationDto.ShouldValidateCredentials = this.RequiresUserNameAndPasswordInput();
-            this.ViewModel.AuthenticationDto.ShouldValidateSourceAddress = this.ShouldProvideServerInformationInput() && string.IsNullOrEmpty(this.ServerConfiguration.ServerAddress);
+            this.ViewModel.AuthenticationDto.ShouldValidateSourceAddress = this.ShouldProvideSourceAddressInput();
             this.InvokeAsync(this.StateHasChanged);
         }
 
@@ -318,6 +318,16 @@ namespace COMET.Web.Common.Components
         {
             return this.ViewModel.AuthenticationSchemeResponseResult == null
                    || this.ViewModel.AuthenticationSchemeResponseResult.IsFailed;
+        }
+
+        /// <summary>
+        /// Asserts that the source address input is presented to the user, i.e. no server address is preconfigured and
+        /// the server-information step is active. The source address is required exactly when it is shown
+        /// </summary>
+        /// <returns>True when the source address input is displayed</returns>
+        private bool ShouldProvideSourceAddressInput()
+        {
+            return string.IsNullOrEmpty(this.ServerConfiguration.ServerAddress) && this.ShouldProvideServerInformationInput();
         }
 
         /// <summary>

--- a/COMET.Web.Common/Model/DTO/AuthenticationDto.cs
+++ b/COMET.Web.Common/Model/DTO/AuthenticationDto.cs
@@ -49,8 +49,14 @@ namespace COMET.Web.Common.Model.DTO
         public bool FullTrust { get; set; } = false;
         
         /// <summary>
-        /// Asserts that credentials should be validated or no 
+        /// Asserts that credentials should be validated or no
         /// </summary>
         public bool ShouldValidateCredentials { get; set; } = true;
+
+        /// <summary>
+        /// Asserts that the source address should be validated as a required field. Set by the login component when the
+        /// address input is presented to the user, i.e. when no server address is preconfigured
+        /// </summary>
+        public bool ShouldValidateSourceAddress { get; set; }
     }
 }

--- a/COMET.Web.Common/Validators/AuthenticationDtoValidator.cs
+++ b/COMET.Web.Common/Validators/AuthenticationDtoValidator.cs
@@ -1,22 +1,23 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="AuthenticationDtoValidator.cs" company="Starion Group S.A.">
-//     Copyright (c) 2023-2026 Starion Group S.A.
+//    Copyright (c) 2023-2026 Starion Group S.A.
 //
-//     This file is part of COMET WEB Community Edition
-//     The COMET WEB Community Edition is the Starion Group Web Application implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-// 
-//     The COMET WEB Community Edition is free software; you can redistribute it and/or
-//     modify it under the terms of the GNU Affero General Public
-//     License as published by the Free Software Foundation; either
-//     version 3 of the License, or (at your option) any later version.
-// 
-//     The COMET WEB Community Edition is distributed in the hope that it will be useful,
-//     but WITHOUT ANY WARRANTY; without even the implied warranty of
-//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//    Affero General Public License for more details.
-// 
-//    You should have received a copy of the GNU Affero General Public License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//    This file is part of CDP4-COMET WEB Community Edition
+//    The CDP4-COMET WEB Community Edition is the Starion Web Application implementation of ECSS-E-TM-10-25
+//    Annex A and Annex C.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
@@ -36,15 +37,34 @@ namespace COMET.Web.Common.Validators
         /// </summary>
         public AuthenticationDtoValidator()
         {
-            this.RuleFor(x => x.SourceAddress).Must(uri => Uri.TryCreate(uri, UriKind.Absolute, out _))
+            this.RuleFor(x => x.SourceAddress).NotEmpty()
+                .WithMessage("The Source Address is required.")
+                .When(x => x.ShouldValidateSourceAddress);
+
+            this.RuleFor(x => x.SourceAddress).Must(BeAValidHttpOrHttpsUrl)
                 .When(x => !string.IsNullOrEmpty(x.SourceAddress))
-                .WithMessage("The Source Address should be a valid URL.");
+                .WithMessage("The Source Address should be a valid HTTP or HTTPS URL.");
 
             this.RuleFor(x => x.UserName).NotEmpty()
+                .WithMessage("The Username is required.")
                 .When(x => x.ShouldValidateCredentials);
-            
+
             this.RuleFor(x => x.Password).NotEmpty()
+                .WithMessage("The Password is required.")
                 .When(x => x.ShouldValidateCredentials);
+        }
+
+        /// <summary>
+        /// Asserts that the provided source address is a well-formed absolute URL using the HTTP or HTTPS scheme, the
+        /// only schemes a CDP4-COMET web server is reachable on. This mirrors the CDP4-COMET-SDK
+        /// <c>UriExtensions.AssertUriIsHttpOrHttpsSchema</c> check enforced by the web data-access layer
+        /// </summary>
+        /// <param name="sourceAddress">The source address to validate</param>
+        /// <returns>True if the address is a valid HTTP or HTTPS URL, otherwise false</returns>
+        private static bool BeAValidHttpOrHttpsUrl(string sourceAddress)
+        {
+            return Uri.TryCreate(sourceAddress, UriKind.Absolute, out var uri)
+                   && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
         }
     }
 }

--- a/COMET.Web.Common/Validators/AuthenticationDtoValidator.cs
+++ b/COMET.Web.Common/Validators/AuthenticationDtoValidator.cs
@@ -42,8 +42,8 @@ namespace COMET.Web.Common.Validators
                 .When(x => x.ShouldValidateSourceAddress);
 
             this.RuleFor(x => x.SourceAddress).Must(BeAValidHttpOrHttpsUrl)
-                .When(x => !string.IsNullOrEmpty(x.SourceAddress))
-                .WithMessage("The Source Address should be a valid HTTP or HTTPS URL.");
+                .WithMessage("The Source Address should be a valid HTTP or HTTPS URL.")
+                .When(x => !string.IsNullOrEmpty(x.SourceAddress));
 
             this.RuleFor(x => x.UserName).NotEmpty()
                 .WithMessage("The Username is required.")

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -82,6 +82,11 @@
     font-size: small;
 }
 
+.full-trust-hint {
+    color: var(--colors-gray-600);
+    margin-top: 2px;
+}
+
 /* The shared "View" display-options trigger (ViewOptionsMenu). A minimum width lets it be sized to match a
    sibling "Add" button, and the down-caret signals that it opens a dropdown of options. Kept global (not in the
    component's scoped css) because the DxButton is that component's root element, leaving ::deep nothing to anchor to. */

--- a/COMET.Web.Common/wwwroot/css/styles.css
+++ b/COMET.Web.Common/wwwroot/css/styles.css
@@ -83,7 +83,7 @@
 }
 
 .full-trust-hint {
-    color: var(--colors-gray-600);
+    color: var(--colors-gray-600, #505B6A);
     margin-top: 2px;
 }
 

--- a/COMETwebapp.Tests/IntegrationTests/LoginTestFixture.cs
+++ b/COMETwebapp.Tests/IntegrationTests/LoginTestFixture.cs
@@ -57,6 +57,19 @@ namespace COMETwebapp.Tests.IntegrationTests
         }
 
         [Test]
+        public async Task VerifyRequiredFieldValidationIsShown()
+        {
+            await this.Login.NavigateAsync(AppUrl);
+
+            Assume.That(await this.Login.ConnectButton.IsVisibleAsync(), Is.True, "The credentials step is not reachable in a single click for this server configuration.");
+
+            await this.Login.ConnectButton.ClickAsync();
+
+            await Expect(this.Login.ValidationErrors).ToContainTextAsync("The Username is required.");
+            await Expect(this.Login.ValidationErrors).ToContainTextAsync("The Password is required.");
+        }
+
+        [Test]
         public async Task VerifyUserCanLogin()
         {
             await this.Login.NavigateAsync(AppUrl);

--- a/COMETwebapp.Tests/IntegrationTests/PageModels/LoginPageModel.cs
+++ b/COMETwebapp.Tests/IntegrationTests/PageModels/LoginPageModel.cs
@@ -54,6 +54,16 @@ namespace COMETwebapp.Tests.IntegrationTests.PageModels
         public ILocator UnauthorizedNotice => this.page.Locator("#unauthorized-notice");
 
         /// <summary>
+        /// Gets the Connect submit button of the credentials step.
+        /// </summary>
+        public ILocator ConnectButton => this.page.Locator("#connectbtn");
+
+        /// <summary>
+        /// Gets the list of client-side validation messages shown on the login form.
+        /// </summary>
+        public ILocator ValidationErrors => this.page.Locator(".validation-errors");
+
+        /// <summary>
         /// Navigates to the application root and waits for the unauthenticated landing page to appear.
         /// </summary>
         /// <param name="appUrl">The base URL of the application under test.</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #894  Login validation

Fixes the login form's validation and Full Trust presentation:

Validation messages now match the field labels instead of FluentValidation defaults ('User Name' must not be empty. → The Username is required.).
Source address is now required and must be a valid HTTP/HTTPS URL (mirrors the SDK/IME web-DAL scheme check), instead of only being checked when non-empty.
Full Trust: no longer truncates to Full Tr…  the label moved to the checkbox itself, with a visible hint explaining it allows connecting to servers with self-signed certificates.
