### PR TITLE
Fix #888, #889 parameter editor filters and model selection title

### DIFF
--- a/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
+++ b/COMETwebapp.Tests/Components/Tabs/OpenTabTestFixture.cs
@@ -37,6 +37,7 @@ namespace COMETwebapp.Tests.Components.Tabs
     using COMETwebapp.Components.Tabs;
     using COMETwebapp.Model;
     using COMETwebapp.ViewModels.Components.Common.OpenTab;
+    using COMETwebapp.ViewModels.Pages;
 
     using DevExpress.Blazor;
 
@@ -185,6 +186,50 @@ namespace COMETwebapp.Tests.Components.Tabs
             this.renderer.Render();
             await this.renderer.InvokeAsync(openButton.Instance.Click.InvokeAsync);
             this.viewModel.Verify(x => x.OpenTab(It.IsAny<TabPanelInformation>()), Times.Exactly(3));
+        }
+
+        [Test]
+        public void VerifyHeaderTexts()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.HeaderText, Is.EqualTo("You have no model selected"));
+                Assert.That(this.renderer.Instance.SubtitleText, Is.EqualTo("Select a model to start working on it"));
+            });
+
+            this.viewModel.Setup(x => x.SelectedEngineeringModel).Returns(new EngineeringModelSetup { Name = "Model" });
+            this.renderer.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.renderer.Instance.HeaderText, Is.EqualTo("Model selected"));
+                Assert.That(this.renderer.Instance.SubtitleText, Is.EqualTo("Select options to start working on it"));
+            });
+        }
+
+        [Test]
+        public async Task VerifyGoToOpenTab()
+        {
+            var tabOpenedCalled = false;
+            this.renderer.Render(parameters => { parameters.Add(p => p.OnTabOpened, () => tabOpenedCalled = true); });
+
+            this.viewModel.Setup(x => x.HasOpenTab).Returns(true);
+            this.viewModel.Setup(x => x.NavigateToOpenTab()).Returns(true);
+
+            this.renderer.Render();
+
+            Assert.That(this.renderer.Instance.ViewModel.HasOpenTab, Is.True);
+
+            var alreadyOpenButton = this.renderer.FindComponents<DxButton>().FirstOrDefault(x => x.Instance.Id == "already-open-tab-button");
+            Assert.That(alreadyOpenButton, Is.Not.Null);
+
+            await this.renderer.InvokeAsync(alreadyOpenButton.Instance.Click.InvokeAsync);
+
+            using (Assert.EnterMultipleScope())
+            {
+                this.viewModel.Verify(x => x.NavigateToOpenTab(), Times.Once);
+                Assert.That(tabOpenedCalled, Is.True);
+            }
         }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
@@ -274,5 +274,55 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
                 this.tabsViewModel.Verify(x => x.CreateNewTab(engineeringModelBodyApplication, secondIteration.Iid, panel), Times.Once);
             }
         }
+
+        [Test]
+        public void VerifyNavigateToOpenTab()
+        {
+            var mainPanel = new TabPanelInformation();
+            var sidePanel = new TabPanelInformation();
+            this.tabsViewModel.Setup(x => x.MainPanel).Returns(mainPanel);
+            this.tabsViewModel.Setup(x => x.SidePanel).Returns(sidePanel);
+
+            var resultWhenNoModel = this.viewModel.NavigateToOpenTab();
+
+            var alreadyOpenIteration = this.alreadyOpenIterations.Items[0];
+            alreadyOpenIteration.IterationSetup.IterationIid = alreadyOpenIteration.Iid;
+            var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
+
+            var application = Applications.ExistingApplications.OfType<TabbedApplication>().First(x => x.ThingTypeOfInterest == typeof(Iteration));
+            this.viewModel.SelectedApplication = application;
+            this.viewModel.SelectedEngineeringModel = engineeringModelSetup;
+            this.viewModel.SelectedIterationSetup = new IterationData(alreadyOpenIteration.IterationSetup);
+
+            var hasOpenTabBeforeAdd = this.viewModel.HasOpenTab;
+            var resultWhenNoTabs = this.viewModel.NavigateToOpenTab();
+
+            var dummyViewModel = new Mock<COMET.Web.Common.ViewModels.Components.Applications.IApplicationBaseViewModel>();
+            var existingTab = new TabbedApplicationInformation(dummyViewModel.Object, application.ComponentType, alreadyOpenIteration);
+            mainPanel.OpenTabs.Add(existingTab);
+
+            var hasOpenTabAfterAdd = this.viewModel.HasOpenTab;
+            var resultMainPanel = this.viewModel.NavigateToOpenTab();
+            var currentTabMain = mainPanel.CurrentTab;
+
+            mainPanel.OpenTabs.Remove(existingTab);
+            mainPanel.CurrentTab = null;
+            sidePanel.OpenTabs.Add(existingTab);
+
+            var resultSidePanel = this.viewModel.NavigateToOpenTab();
+            var currentTabSide = sidePanel.CurrentTab;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resultWhenNoModel, Is.False);
+                Assert.That(hasOpenTabBeforeAdd, Is.False);
+                Assert.That(resultWhenNoTabs, Is.False);
+                Assert.That(hasOpenTabAfterAdd, Is.True);
+                Assert.That(resultMainPanel, Is.True);
+                Assert.That(currentTabMain, Is.EqualTo(existingTab));
+                Assert.That(resultSidePanel, Is.True);
+                Assert.That(currentTabSide, Is.EqualTo(existingTab));
+            }
+        }
     }
 }

--- a/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
+++ b/COMETwebapp.Tests/ViewModels/Components/Common/OpenTabViewModelTestFixture.cs
@@ -30,6 +30,7 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
     using COMET.Web.Common.Services.Cache;
     using COMET.Web.Common.Services.ConfigurationService;
     using COMET.Web.Common.Services.SessionManagement;
+    using COMET.Web.Common.ViewModels.Components.Applications;
 
     using COMETwebapp.Model;
     using COMETwebapp.Utilities;
@@ -278,13 +279,15 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
         [Test]
         public void VerifyNavigateToOpenTab()
         {
+            // When no application or model is selected, navigation fails
             var mainPanel = new TabPanelInformation();
             var sidePanel = new TabPanelInformation();
             this.tabsViewModel.Setup(x => x.MainPanel).Returns(mainPanel);
             this.tabsViewModel.Setup(x => x.SidePanel).Returns(sidePanel);
 
-            var resultWhenNoModel = this.viewModel.NavigateToOpenTab();
+            Assert.That(this.viewModel.NavigateToOpenTab(), Is.False);
 
+            // When an iteration view is selected but no tabs are currently open for it
             var alreadyOpenIteration = this.alreadyOpenIterations.Items[0];
             alreadyOpenIteration.IterationSetup.IterationIid = alreadyOpenIteration.Iid;
             var engineeringModelSetup = ((EngineeringModel)alreadyOpenIteration.Container).EngineeringModelSetup;
@@ -294,34 +297,51 @@ namespace COMETwebapp.Tests.ViewModels.Components.Common
             this.viewModel.SelectedEngineeringModel = engineeringModelSetup;
             this.viewModel.SelectedIterationSetup = new IterationData(alreadyOpenIteration.IterationSetup);
 
-            var hasOpenTabBeforeAdd = this.viewModel.HasOpenTab;
-            var resultWhenNoTabs = this.viewModel.NavigateToOpenTab();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.HasOpenTab, Is.False);
+                Assert.That(this.viewModel.NavigateToOpenTab(), Is.False);
+            }
 
-            var dummyViewModel = new Mock<COMET.Web.Common.ViewModels.Components.Applications.IApplicationBaseViewModel>();
+            // When a matching iteration tab is open in the main panel, navigate to it
+            var dummyViewModel = new Mock<IApplicationBaseViewModel>();
             var existingTab = new TabbedApplicationInformation(dummyViewModel.Object, application.ComponentType, alreadyOpenIteration);
             mainPanel.OpenTabs.Add(existingTab);
 
-            var hasOpenTabAfterAdd = this.viewModel.HasOpenTab;
-            var resultMainPanel = this.viewModel.NavigateToOpenTab();
-            var currentTabMain = mainPanel.CurrentTab;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.HasOpenTab, Is.True);
+                Assert.That(this.viewModel.NavigateToOpenTab(), Is.True);
+                Assert.That(mainPanel.CurrentTab, Is.EqualTo(existingTab));
+            }
 
+            // When a matching iteration tab is open in the side panel, navigate to it
             mainPanel.OpenTabs.Remove(existingTab);
             mainPanel.CurrentTab = null;
             sidePanel.OpenTabs.Add(existingTab);
 
-            var resultSidePanel = this.viewModel.NavigateToOpenTab();
-            var currentTabSide = sidePanel.CurrentTab;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.viewModel.NavigateToOpenTab(), Is.True);
+                Assert.That(sidePanel.CurrentTab, Is.EqualTo(existingTab));
+            }
+
+            // When an engineering-model-level view tab is open in the side panel, navigate to it
+            var engModelApp = Applications.ExistingApplications.OfType<TabbedApplication>().First(x => x.ThingTypeOfInterest == typeof(EngineeringModel));
+            this.viewModel.SelectedApplication = engModelApp;
+
+            var openEngModel = (EngineeringModel)alreadyOpenIteration.Container;
+            openEngModel.Iid = Guid.NewGuid();
+            engineeringModelSetup.EngineeringModelIid = openEngModel.Iid;
+            this.sessionService.Setup(x => x.OpenEngineeringModels).Returns([openEngModel]);
+
+            var engModelTab = new TabbedApplicationInformation(dummyViewModel.Object, engModelApp.ComponentType, openEngModel);
+            sidePanel.OpenTabs.Add(engModelTab);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(resultWhenNoModel, Is.False);
-                Assert.That(hasOpenTabBeforeAdd, Is.False);
-                Assert.That(resultWhenNoTabs, Is.False);
-                Assert.That(hasOpenTabAfterAdd, Is.True);
-                Assert.That(resultMainPanel, Is.True);
-                Assert.That(currentTabMain, Is.EqualTo(existingTab));
-                Assert.That(resultSidePanel, Is.True);
-                Assert.That(currentTabSide, Is.EqualTo(existingTab));
+                Assert.That(this.viewModel.HasOpenTab, Is.True);
+                Assert.That(this.viewModel.NavigateToOpenTab(), Is.True);
             }
         }
     }

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor
@@ -1,4 +1,4 @@
-﻿<!------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------
 Copyright (c) 2023-2026 Starion Group S.A.
 
     This file is part of COMET WEB Community Edition
@@ -40,6 +40,7 @@ Copyright (c) 2023-2026 Starion Group S.A.
                 <MultiOptionSelector ViewModel="this.ViewModel.OptionSelector" DisplayText=""></MultiOptionSelector>
             </div>
             <div class="filter-bar-right">
+                <span class="text-secondary small text-nowrap me-2">Showing @(this.ViewModel.ParameterTableViewModel.Rows.Count) of @(this.ViewModel.ParameterTableViewModel.TotalParametersCount) parameters</span>
                 <BatchParameterEditor ViewModel="@(this.ViewModel.BatchParameterEditorViewModel)"/>
                 <ViewOptionsMenu ButtonId="parameterEditorViewMenuButton">
                     <DxCheckBox Id="only-owned-parameters-toggle"

--- a/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
+++ b/COMETwebapp/Components/ParameterEditor/ParameterEditorBody.razor.cs
@@ -57,6 +57,7 @@ namespace COMETwebapp.Components.ParameterEditor
                 .Subscribe(_ => this.UpdateUrl()));
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.BatchParameterEditorViewModel.IsLoading).SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
+            this.Disposables.Add(this.ViewModel.ParameterTableViewModel.Rows.CountChanged.SubscribeAsync(_ => this.InvokeAsync(this.StateHasChanged)));
         }
 
         /// <summary>

--- a/COMETwebapp/Components/Tabs/OpenTab.razor
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor
@@ -27,8 +27,8 @@
     <DxFormLayoutItem ColSpanLg="12">
         <div style="display:flex; flex-direction: column; align-items: center;">
             <CometIcon Icon="IconName.Smile" Size="42" Color="var(--colors-primary-500)"/>
-            <h5 class="font-weight-bold mt-1" style="color: var(--colors-gray-800);">You have no model selected</h5>
-            <span style="color: var(--colors-gray-600);">Select a model to start working on it</span>
+            <h5 class="font-weight-bold mt-1" style="color: var(--colors-gray-800);">@(this.HeaderText)</h5>
+            <span style="color: var(--colors-gray-600);">@(this.SubtitleText)</span>
         </div>
     </DxFormLayoutItem>
     <DxFormLayoutItem Caption="View" ColSpanLg="12">
@@ -87,17 +87,22 @@
                             @bind-Value="@(this.ViewModel.SelectedIterationSetup)"
                             NullText="Select an Iteration"
                             Enabled="@(this.IterationId == Guid.Empty)">
-                    <ItemTemplate Context="iterationData">
+                <ItemTemplate Context="iterationData">
                         <span data-testid="combo-item">@(iterationData.IterationName)</span>
                     </ItemTemplate>
                 </DxComboBox>
             </DxFormLayoutItem>
         }
 
-        @if (this.ViewModel.IsCurrentIterationOpened)
+        @if (this.ViewModel.HasOpenTab)
         {
             <DxFormLayoutItem ColSpanLg="12">
-                <sub class="my-1">Iteration already opened</sub>
+                <DxButton Id="already-open-tab-button"
+                          CssClass="p-0 my-1 sub text-primary"
+                          Text="Already open - go to that tab"
+                          RenderStyle="@(CometButtonStyle.Link.ToButtonRenderStyle())"
+                          RenderStyleMode="ButtonRenderStyleMode.Text"
+                          Click="this.GoToOpenTab" />
             </DxFormLayoutItem>
         }
     }

--- a/COMETwebapp/Components/Tabs/OpenTab.razor.cs
+++ b/COMETwebapp/Components/Tabs/OpenTab.razor.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="OpenTab.razor.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -29,6 +29,7 @@ namespace COMETwebapp.Components.Tabs
 
     using COMETwebapp.Model;
     using COMETwebapp.ViewModels.Components.Common.OpenTab;
+    using COMETwebapp.ViewModels.Pages;
 
     using Microsoft.AspNetCore.Components;
 
@@ -72,6 +73,16 @@ namespace COMETwebapp.Components.Tabs
         /// Gets the condition to check if the selected application thing type is an <see cref="Iteration" />
         /// </summary>
         private bool IsIterationView => this.ViewModel.SelectedApplication?.ThingTypeOfInterest == typeof(Iteration);
+
+        /// <summary>
+        /// Gets the header text displayed at the top of the form
+        /// </summary>
+        public string HeaderText => this.ViewModel.SelectedEngineeringModel == null ? "You have no model selected" : "Model selected";
+
+        /// <summary>
+        /// Gets the subtitle text displayed at the top of the form
+        /// </summary>
+        public string SubtitleText => this.ViewModel.SelectedEngineeringModel == null ? "Select a model to start working on it" : "Select options to start working on it";
 
         /// <summary>
         /// Asserts that the open-tab form has rendered and its combo boxes are interactive. Exposed to the DOM as the
@@ -131,6 +142,17 @@ namespace COMETwebapp.Components.Tabs
             await this.ViewModel.OpenTab(this.Panel);
             await this.InvokeAsync(this.StateHasChanged);
             this.OnTabOpened?.Invoke();
+        }
+
+        /// <summary>
+        /// Navigates to the already open tab and triggers <see cref="OnTabOpened"/>
+        /// </summary>
+        private void GoToOpenTab()
+        {
+            if (this.ViewModel.NavigateToOpenTab() && this.OnTabOpened != null)
+            {
+                this.OnTabOpened.Invoke();
+            }
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/Common/OpenTab/IOpenTabViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/OpenTab/IOpenTabViewModel.cs
@@ -50,6 +50,11 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
         bool IsCurrentIterationOpened { get; }
 
         /// <summary>
+        /// Gets a value indicating whether a tab for the selected application and model is already open
+        /// </summary>
+        bool HasOpenTab { get; }
+
+        /// <summary>
         /// Gets the <see cref="DomainOfExpertise" /> from the <see cref="OpenModelViewModel.SelectedIterationSetup" />
         /// </summary>
         DomainOfExpertise SelectedIterationDomainOfExpertise { get; }
@@ -60,5 +65,11 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
         /// <param name="panel">The <see cref="TabPanelInformation"/> for which the new tab will be opened</param>
         /// <returns>A <see cref="Task" /></returns>
         Task OpenTab(TabPanelInformation panel);
+
+        /// <summary>
+        /// Navigates to an already open tab for the selected engineering model or iteration if it exists
+        /// </summary>
+        /// <returns>True if a tab was navigated to; otherwise, false.</returns>
+        bool NavigateToOpenTab();
     }
 }

--- a/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
@@ -101,6 +101,11 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
         public DomainOfExpertise SelectedIterationDomainOfExpertise => this.sessionService.GetDomainOfExpertise(this.SelectedEngineeringModelIteration);
 
         /// <summary>
+        /// Gets a value indicating whether a tab for the selected application and model is already open
+        /// </summary>
+        public bool HasOpenTab => this.GetExistingTab() != null;
+
+        /// <summary>
         /// The selected <see cref="TabbedApplication" />
         /// </summary>
         public TabbedApplication SelectedApplication
@@ -161,6 +166,49 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
             {
                 this.tabsViewModel.CreateNewTab(this.SelectedApplication, isIteration ? this.SelectedEngineeringModelIteration.Iid : this.SelectedEngineeringModel.EngineeringModelIid, panel);
             }
+        }
+
+        /// <summary>
+        /// Navigates to an already open tab for the selected engineering model or iteration if it exists
+        /// </summary>
+        /// <returns>True if a tab was navigated to; otherwise, false.</returns>
+        public bool NavigateToOpenTab()
+        {
+            var existingTab = this.GetExistingTab();
+
+            if (existingTab == null)
+            {
+                return false;
+            }
+
+            var targetPanel = this.tabsViewModel.MainPanel.OpenTabs.Items.Contains(existingTab)
+                ? this.tabsViewModel.MainPanel
+                : this.tabsViewModel.SidePanel;
+
+            targetPanel.CurrentTab = existingTab;
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the existing tab for the selected application and engineering model or iteration if it exists
+        /// </summary>
+        /// <returns>The existing tab, or null if no matching tab is found.</returns>
+        private TabbedApplicationInformation GetExistingTab()
+        {
+            if (this.SelectedApplication == null)
+            {
+                return null;
+            }
+
+            IEnumerable<TabbedApplicationInformation> allTabs = 
+            [
+                .. this.tabsViewModel.MainPanel.OpenTabs.Items,
+                .. this.tabsViewModel.SidePanel.OpenTabs.Items
+            ];
+
+            return allTabs.FirstOrDefault(x => 
+                x.ObjectOfInterest == this.SelectedEngineeringModelIteration && 
+                x.ComponentType == this.SelectedApplication.ComponentType);
         }
     }
 }

--- a/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/Common/OpenTab/OpenTabViewModel.cs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 //  <copyright file="OpenTabViewModel.cs" company="Starion Group S.A.">
 //     Copyright (c) 2023-2026 Starion Group S.A.
 //
@@ -22,6 +22,7 @@
 
 namespace COMETwebapp.ViewModels.Components.Common.OpenTab
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -206,8 +207,12 @@ namespace COMETwebapp.ViewModels.Components.Common.OpenTab
                 .. this.tabsViewModel.SidePanel.OpenTabs.Items
             ];
 
+            Thing targetObjectOfInterest = this.SelectedApplication.ThingTypeOfInterest == typeof(Iteration) 
+                ? this.SelectedEngineeringModelIteration
+                : this.sessionService.OpenEngineeringModels.FirstOrDefault(x => x.Iid == this.SelectedEngineeringModel?.EngineeringModelIid);
+
             return allTabs.FirstOrDefault(x => 
-                x.ObjectOfInterest == this.SelectedEngineeringModelIteration && 
+                x.ObjectOfInterest == targetObjectOfInterest && 
                 x.ComponentType == this.SelectedApplication.ComponentType);
         }
     }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/IParameterTableViewModel.cs
@@ -42,6 +42,11 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         SourceList<ParameterBaseRowViewModel> Rows { get; }
 
         /// <summary>
+        /// Gets the total count of parameters available before applying filters
+        /// </summary>
+        int TotalParametersCount { get; }
+
+        /// <summary>
         /// The <see cref="IHaveComponentParameterTypeEditor"/> to show in the popup
         /// </summary>
         IHaveComponentParameterTypeEditor HaveComponentParameterTypeEditorViewModel { get; set; }

--- a/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
+++ b/COMETwebapp/ViewModels/Components/ParameterEditor/ParameterTableViewModel.cs
@@ -141,6 +141,11 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
         public SourceList<ParameterBaseRowViewModel> Rows { get; } = new();
 
         /// <summary>
+        /// Gets the total count of parameters available before applying filters
+        /// </summary>
+        public int TotalParametersCount { get; private set; }
+
+        /// <summary>
         /// Initializes this <see cref="IParameterTableViewModel" />
         /// </summary>
         /// <param name="currentIteration">The current <see cref="Iteration" /></param>
@@ -164,6 +169,7 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
                     .SelectMany(option => this.iteration.QueryParameterAndOverrideBases(option, this.domainOfExpertise))
                     .DistinctBy(x => x.Iid);
 
+                this.TotalParametersCount = this.GetAllParameters().Count;
                 this.Rows.AddRange(this.CreateParameterBaseRowViewModels(ownedNestedParameters, this.currentOptions.Select(x => x.Iid).ToHashSet()));
             }
         }
@@ -215,24 +221,38 @@ namespace COMETwebapp.ViewModels.Components.ParameterEditor
             }
 
             this.currentOptions = this.ResolveSelectedOptions(selectedOptions);
+
             this.currentElementBaseIds = selectedElementBases == null
                 ? new HashSet<Guid>()
                 : new HashSet<Guid>(selectedElementBases.Select(x => x.Iid));
+
             this.currentParameterTypeIds = selectedParameterTypes == null
                 ? new HashSet<Guid>()
                 : new HashSet<Guid>(selectedParameterTypes.Select(x => x.Iid));
+
             this.currentCategoryIds = selectedCategories == null
                 ? new HashSet<Guid>()
                 : new HashSet<Guid>(selectedCategories.Select(x => x.Iid));
+
             this.ownedParameters = isOwnedParameters;
 
-            var parameters = this.currentOptions
-                .SelectMany(option => this.iteration.QueryParameterAndOverrideBases(option))
-                .DistinctBy(x => x.Iid)
-                .ToList();
+            var parameters = this.GetAllParameters();
+            this.TotalParametersCount = parameters.Count;
 
             var rows = this.CreateRowsBasedOnFilters(parameters);
             this.UpdateVisibleRows(rows);
+        }
+
+        /// <summary>
+        /// Queries all <see cref="ParameterOrOverrideBase" /> from the current <see cref="Iteration" /> based on the current <see cref="Option" />s.
+        /// </summary>
+        /// <returns>A list of <see cref="ParameterOrOverrideBase" /> instances.</returns>
+        private List<ParameterOrOverrideBase> GetAllParameters()
+        {
+            return this.currentOptions
+                    .SelectMany(option => this.iteration.QueryParameterAndOverrideBases(option))
+                    .DistinctBy(x => x.Iid)
+                    .ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WEB-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-WEB [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WEB-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Closes #888 [Feature]: The default filter hides most of the model and doesn't say so

Closes #889 [Bug]: "You have no model selected" - while a model is selected

 ### Parameter Editor Filter Count (#888)

  • Parameter Count Indicator: Added a visual count (Showing X of Y parameters) to ParameterEditorBody.razor so users
  can see how many parameters are displayed out of the total model parameters.
  • ViewModel Updates: Added TotalParametersCount property to IParameterTableViewModel / ParameterTableViewModel and
  bound updates on row count changes.
  • Filter Toggle Placement: Maintained the "Only Parameters owned by..." toggle within ViewOptionsMenu in accordance
  with the filter setting harmonization established in #812.

  ### Model Selection Headline & Tab Navigation (#889)

  • Actionable Tab Navigation: Converted the static "Model already opened" indicator into an interactive link button
  (Already open - go to that tab) in OpenTab.razor.
  • Dynamic Header State: Updated OpenTab.razor header and subtitle to dynamically display "Model selected" / "Select
  options to start working on it" when an engineering model is chosen instead of staying on "You have no model
  selected".
  • Tab Lookup Logic: Added GetExistingTab() and NavigateToOpenTab() to OpenTabViewModel to detect and navigate to
  open tabs for both Iteration and EngineeringModel level views.
  • Unit Tests: Added and updated unit tests in OpenTabTestFixture and OpenTabViewModelTestFixture to verify header
  texts and tab navigation logic.
